### PR TITLE
test(member): 회원 등록 상태 조회 테스트 코드 작성(#90)

### DIFF
--- a/documents/Controller test code 표준.java
+++ b/documents/Controller test code 표준.java
@@ -8,8 +8,8 @@ public class JUnit5ExampleTests extended AbstractRestDocSupport {
     @DisplayName("한국어로 입력")
     public void testExample() extends Exception {
         // given
-        BDDMockito.given(...).willReturn(...);    // 정상 반환 시
-        BDDMockito.given(...).willThrow(...);     // 에러 발생 시
+        BDDMockito.given(mock.mock_method()).willReturn(...);    // 정상 반환 시
+        BDDMockito.given(mock.mock_method()).willThrow(...);     // 에러 발생 시
 
         // when
         HttpHeaders headers = new HttpHeaders();
@@ -63,6 +63,9 @@ public class JUnit5ExampleTests extended AbstractRestDocSupport {
         Assertions.assertThat(response).isEqualTo(expected);
 
         // 2) 에러 발생
-        Mockito.verify(service, never()).method();
+        BDDMockito.then(mock).should().mock_method()
+        BDDMockito.then(mock).should(BDDMockito.times(1)).mock_method()
+        BDDMockito.then(mock).shouldHaveNoMoreInteractions();
+        BDDMockito.then(mock).shouldHaveNoInteractions();
     }
 }

--- a/src/test/java/com/project200/undabang/member/repository/MemberRepositoryTest.java
+++ b/src/test/java/com/project200/undabang/member/repository/MemberRepositoryTest.java
@@ -13,6 +13,7 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.UUID;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -81,4 +82,38 @@ class MemberRepositoryTest {
         boolean check = memberRepository.existsByMemberNickname(name);
         assertFalse(check);
     }
+
+    /**
+     * 회원의 ID가 데이터베이스에 존재하는 경우를 테스트합니다.
+     */
+    @Test
+    @DisplayName("회원 ID가 존재하는 경우")
+    void existsByMemberId_exists() {
+        // given
+        UUID existingMemberId = testUUID;
+
+        // when
+        boolean result = memberRepository.existsByMemberId(existingMemberId);
+
+        // then
+        assertThat(result).isTrue();
+    }
+
+    /**
+     * 회원의 ID가 데이터베이스에 존재하지 않는 경우를 테스트합니다.
+     */
+    @Test
+    @DisplayName("회원 ID가 존재하지 않는 경우")
+    void existsByMemberId_not_exists() {
+        // given
+        UUID nonExistingMemberId = UUID.randomUUID();
+
+        // when
+        boolean result = memberRepository.existsByMemberId(nonExistingMemberId);
+
+        // then
+        assertThat(result).isFalse();
+    }
+
+
 }

--- a/src/test/java/com/project200/undabang/member/service/impl/MemberQueryServiceImplTest.java
+++ b/src/test/java/com/project200/undabang/member/service/impl/MemberQueryServiceImplTest.java
@@ -1,0 +1,72 @@
+package com.project200.undabang.member.service.impl;
+
+import com.project200.undabang.common.context.UserContextHolder;
+import com.project200.undabang.member.dto.response.MemberRegistrationStatusResponseDto;
+import com.project200.undabang.member.repository.MemberRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mockStatic;
+
+@ExtendWith(MockitoExtension.class)
+class MemberQueryServiceImplTest {
+
+    @InjectMocks
+    private MemberQueryServiceImpl memberQueryService;
+
+    @Mock
+    private MemberRepository memberRepository;
+
+    /**
+     * 등록된 회원의 상태를 확인하는 테스트
+     */
+    @Test
+    @DisplayName("회원이 등록되어 있을 경우 회원 상태는 등록됨으로 반환된다")
+    void getRegistrationStatus_RegisteredMember_ReturnsTrue() {
+        UUID testUserId = UUID.randomUUID();
+
+        try (MockedStatic<UserContextHolder> ignored = mockStatic(UserContextHolder.class)) {
+            // given
+            given(UserContextHolder.getUserId()).willReturn(testUserId);
+            given(memberRepository.existsByMemberId(testUserId)).willReturn(true);
+
+            // when
+            MemberRegistrationStatusResponseDto response = memberQueryService.getRegistrationStatus();
+
+            // then
+            assertThat(response.getMemberId()).isEqualTo(testUserId);
+            assertThat(response.isRegistered()).isTrue();
+        }
+    }
+
+    /**
+     * 등록되지 않은 회원의 상태를 확인하는 테스트
+     */
+    @Test
+    @DisplayName("회원이 등록되어 있지 않을 경우 회원 상태는 미등록으로 반환된다")
+    void getRegistrationStatus_UnregisteredMember_ReturnsFalse() {
+        UUID testUserId = UUID.randomUUID();
+
+        try (MockedStatic<UserContextHolder> ignored = mockStatic(UserContextHolder.class)) {
+            // given
+            given(UserContextHolder.getUserId()).willReturn(testUserId);
+            given(memberRepository.existsByMemberId(testUserId)).willReturn(false);
+
+            // when
+            MemberRegistrationStatusResponseDto response = memberQueryService.getRegistrationStatus();
+
+            // then
+            assertThat(response.getMemberId()).isEqualTo(testUserId);
+            assertThat(response.isRegistered()).isFalse();
+        }
+    }
+}


### PR DESCRIPTION
## 📝작업 내용

- 회원 등록 상태 조회 API의 서비스 ,리포지토리 테스트 코드를 작성 하였습니다.
- 조회 성공, 실패 두 상황에 대한 테스트를 작성하였습니다.
- MemberRestController, MemberQueryServiceImpl의 테스트 커버리지 100% 확인하였습니다.
- MemberRepository는 조회 성공, 실패 두 경우 모두 만들었습니다.

## #️⃣연관된 이슈

Closes #90