### PR TITLE
test: 테스트용 헤더 처리 공통화

### DIFF
--- a/src/test/java/com/project200/undabang/configuration/HeadersGenerator.java
+++ b/src/test/java/com/project200/undabang/configuration/HeadersGenerator.java
@@ -2,15 +2,20 @@ package com.project200.undabang.configuration;
 
 import org.springframework.http.HttpHeaders;
 
-public interface DocumentTokenGenerator {
-    static HttpHeaders getAccessToken(){
+import java.util.UUID;
+
+public interface HeadersGenerator {
+    static HttpHeaders getCommonApiHeaders(UUID xUserId) {
         HttpHeaders httpHeaders = new HttpHeaders();
         httpHeaders.add("Authorization", "Bearer {{AccessToken}}");
+        httpHeaders.add("X-USER-ID", xUserId.toString());
         return httpHeaders;
     }
-    static HttpHeaders getIdToken(){
+    static HttpHeaders getCommonAuthHeaders(UUID xUserId, String xUserEmail) {
         HttpHeaders httpHeaders = new HttpHeaders();
         httpHeaders.add("Authorization", "Bearer {{IdToken}}");
+        httpHeaders.add("X-USER-ID", xUserId.toString());
+        httpHeaders.add("X-USER-EMAIL", xUserEmail);
         return httpHeaders;
     }
 }


### PR DESCRIPTION
## 📝작업 내용

getCommonApiHeaders를 추가했습니다.
/api로 시작할 때 들어가는 공통 헤더와
/auth로 시작할 때 들어가는 공통 헤더
를 생성해주는 정적 메소드입니다.


## 💬리뷰 요구사항(선택)

getCommonApiHeaders 사용법을 확인해주세요.