### PR TITLE
[fix] 날짜별 조회 시 데이터 중복 반환 문제 해결

### DIFF
--- a/src/main/java/com/project200/undabang/exercise/controller/ExerciseQueryController.java
+++ b/src/main/java/com/project200/undabang/exercise/controller/ExerciseQueryController.java
@@ -39,8 +39,8 @@ public class ExerciseQueryController {
      */
     @GetMapping("/v1/exercises")
     public ResponseEntity<CommonResponse<List<FindExerciseRecordDateResponseDto>>> findExerciseRecordByDate(@RequestParam(value = "date") LocalDate inputDate) {
-        List<FindExerciseRecordDateResponseDto> responseDto = exerciseQueryService.findExerciseRecordByDate(inputDate).orElse(null);
-        return responseDto != null ? ResponseEntity.ok(CommonResponse.success(responseDto)) : ResponseEntity.ok(CommonResponse.success());
+        List<FindExerciseRecordDateResponseDto> responseDto = exerciseQueryService.findExerciseRecordByDate(inputDate);
+        return !responseDto.isEmpty() ? ResponseEntity.ok(CommonResponse.success(responseDto)) : ResponseEntity.ok(CommonResponse.success());
     }
 
     /**

--- a/src/main/java/com/project200/undabang/exercise/dto/response/FindExerciseRecordDateResponseDto.java
+++ b/src/main/java/com/project200/undabang/exercise/dto/response/FindExerciseRecordDateResponseDto.java
@@ -5,6 +5,7 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 @Data
 @NoArgsConstructor
@@ -15,5 +16,5 @@ public class FindExerciseRecordDateResponseDto {
     private String exercisePersonalType;
     private LocalDateTime exerciseStartedAt;
     private LocalDateTime exerciseEndedAt;
-    private String pictureUrl;
+    private List<String> pictureUrl;
 }

--- a/src/main/java/com/project200/undabang/exercise/repository/ExerciseRepositoryCustom.java
+++ b/src/main/java/com/project200/undabang/exercise/repository/ExerciseRepositoryCustom.java
@@ -6,12 +6,11 @@ import com.project200.undabang.exercise.dto.response.FindExerciseRecordResponseD
 
 import java.time.LocalDate;
 import java.util.List;
-import java.util.Optional;
 import java.util.UUID;
 
 public interface ExerciseRepositoryCustom {
     boolean existsByRecordIdAndMemberId(UUID memberId, Long recordId);
     FindExerciseRecordResponseDto findExerciseByExerciseId(UUID memberId, Long recordId);
-    Optional<List<FindExerciseRecordDateResponseDto>> findExerciseRecordByDate(UUID memberId, LocalDate date);
+    List<FindExerciseRecordDateResponseDto> findExerciseRecordByDate(UUID memberId, LocalDate date);
     List<FindExerciseRecordByPeriodResponseDto> findExercisesByPeriod(UUID memberId, LocalDate startDate, LocalDate endDate);
 }

--- a/src/main/java/com/project200/undabang/exercise/repository/impl/ExerciseRepositoryImpl.java
+++ b/src/main/java/com/project200/undabang/exercise/repository/impl/ExerciseRepositoryImpl.java
@@ -102,8 +102,22 @@ public class ExerciseRepositoryImpl extends QuerydslRepositorySupport implements
 
     /**
      * 특정 회원의 특정 날짜에 해당하는 운동 기록을 조회합니다.
-     * 해당 날짜의 자정(00:00:00)부터 다음 날 자정 직전까지의 운동 기록을 검색합니다.
-     * 썸네일이 없을수도 있으니 LeftJoin을 사용하였습니다.
+     *
+     * <p>이 메서드는 다음과 같은 단계로 동작합니다:</p>
+     * <ol>
+     *   <li>주어진 날짜의 00:00:00부터 다음 날 00:00:00 직전까지의 시간 범위를 설정</li>
+     *   <li>해당 시간 범위 내에 시작된 운동 기록 데이터를 조회</li>
+     *   <li>조회된 운동 ID에 해당하는 사진 URL 정보를 별도 쿼리로 조회</li>
+     *   <li>두 결과를 결합하여 최종 응답 DTO 생성</li>
+     * </ol>
+     *
+     * <p>사진이 없는 운동 기록의 경우 빈 리스트가 포함됩니다.</p>
+     * <p>조회 결과는 운동 시작 시간 기준으로 오름차순 정렬됩니다.</p>
+     *
+     * @param memberId 조회할 회원의 고유 식별자 UUID
+     * @param date 조회할 날짜 (해당 날짜의 모든 운동 기록이 반환됨)
+     * @return 해당 날짜의 운동 기록과 관련 사진 URL을 포함한 응답 DTO 리스트.
+     *         조회 결과가 없을 경우 빈 리스트 반환.
      */
     @Override
     public List<FindExerciseRecordDateResponseDto> findExerciseRecordByDate(UUID memberId, LocalDate date) {

--- a/src/main/java/com/project200/undabang/exercise/service/ExerciseQueryService.java
+++ b/src/main/java/com/project200/undabang/exercise/service/ExerciseQueryService.java
@@ -6,12 +6,11 @@ import com.project200.undabang.exercise.dto.response.FindExerciseRecordResponseD
 
 import java.time.LocalDate;
 import java.util.List;
-import java.util.Optional;
 import java.util.UUID;
 
 public interface ExerciseQueryService {
     FindExerciseRecordResponseDto findExerciseRecordByRecordId(Long recordId);
-    Optional<List<FindExerciseRecordDateResponseDto>> findExerciseRecordByDate(LocalDate inputDate);
+    List<FindExerciseRecordDateResponseDto> findExerciseRecordByDate(LocalDate inputDate);
     List<FindExerciseRecordByPeriodResponseDto> findExerciseRecordsByPeriod(LocalDate startDate, LocalDate endDate);
     boolean checkMemberId(UUID memberId);
     boolean checkExerciseRecordId(Long recordId);

--- a/src/main/java/com/project200/undabang/exercise/service/impl/ExerciseQueryServiceImpl.java
+++ b/src/main/java/com/project200/undabang/exercise/service/impl/ExerciseQueryServiceImpl.java
@@ -17,7 +17,6 @@ import org.springframework.transaction.annotation.Transactional;
 import java.time.LocalDate;
 import java.util.List;
 import java.util.Objects;
-import java.util.Optional;
 import java.util.UUID;
 
 /**
@@ -58,7 +57,6 @@ public class ExerciseQueryServiceImpl implements ExerciseQueryService {
      * 특정 운동 기록의 상세 정보를 조회합니다.
      * 현재 인증된 사용자가 해당 운동 기록에 접근 권한이 있는지 검증합니다.
      */
-
     @Override
     public FindExerciseRecordResponseDto findExerciseRecordByRecordId(Long recordId) {
         UUID memberId = UserContextHolder.getUserId();
@@ -87,9 +85,8 @@ public class ExerciseQueryServiceImpl implements ExerciseQueryService {
     /**
      * 특정 날짜에 해당하는 운동 기록 목록을 조회합니다.
      */
-
     @Override
-    public Optional<List<FindExerciseRecordDateResponseDto>>  findExerciseRecordByDate(LocalDate inputDate) {
+    public List<FindExerciseRecordDateResponseDto>  findExerciseRecordByDate(LocalDate inputDate) {
         if(inputDate.isBefore(LocalDate.of(1945, 8, 15)) || inputDate.isAfter(LocalDate.now())){
             throw new CustomException(ErrorCode.INVALID_INPUT_VALUE);
         }
@@ -97,16 +94,12 @@ public class ExerciseQueryServiceImpl implements ExerciseQueryService {
         UUID memberId = UserContextHolder.getUserId();
 
         log.debug("날짜별 운동 기록 조회 요청: date={}", inputDate);
-        Optional<List<FindExerciseRecordDateResponseDto>> responseDtoList = exerciseRepository.findExerciseRecordByDate(memberId, inputDate);
-        log.debug("날짜별 운동 기록 조회 결과: date={}, count={}", inputDate, responseDtoList.map(List::size).orElse(0));
-
-        return responseDtoList;
+        return exerciseRepository.findExerciseRecordByDate(memberId, inputDate);
     }
 
     /**
      * 특정 기간 동안의 날짜별 운동 기록 개수를 조회합니다.
      */
-
     @Override
     public List<FindExerciseRecordByPeriodResponseDto> findExerciseRecordsByPeriod(LocalDate startDate, LocalDate endDate) {
         if(startDate.isBefore(LocalDate.of(1945,8,15)) || endDate.isAfter(LocalDate.now())){
@@ -117,9 +110,7 @@ public class ExerciseQueryServiceImpl implements ExerciseQueryService {
         }
 
         UUID memberId = UserContextHolder.getUserId();
-        List<FindExerciseRecordByPeriodResponseDto> responseDto = exerciseRepository.findExercisesByPeriod(memberId, startDate, endDate);
-
-        return responseDto;
+        return exerciseRepository.findExercisesByPeriod(memberId, startDate, endDate);
     }
 }
 

--- a/src/test/java/com/project200/undabang/exercise/controller/ExerciseQueryControllerTest.java
+++ b/src/test/java/com/project200/undabang/exercise/controller/ExerciseQueryControllerTest.java
@@ -24,10 +24,7 @@ import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Optional;
-import java.util.UUID;
+import java.util.*;
 
 import static com.project200.undabang.configuration.RestDocsUtils.HEADER_X_USER_ID;
 import static com.project200.undabang.configuration.RestDocsUtils.commonResponseFields;
@@ -265,7 +262,7 @@ class ExerciseQueryControllerTest extends AbstractRestDocSupport {
         //given
         UUID memberId = UUID.randomUUID();
         LocalDateTime testDateTime = LocalDateTime.of(2021, 1, 1, 00, 00, 00);
-        String picureUrl = "https://s3.urlpage/test/pic1.jpg";
+        List<String> picureUrl = List.of("https://s3.urlpage/test/pic1.jpg");
         Long exerciseId = 1L;
 
         List<FindExerciseRecordDateResponseDto> responseDtoList = new ArrayList<>();
@@ -280,7 +277,7 @@ class ExerciseQueryControllerTest extends AbstractRestDocSupport {
         responseDtoList.add(dto);
 
         //given
-        given(exerciseQueryService.findExerciseRecordByDate(testDateTime.toLocalDate())).willReturn(Optional.of(responseDtoList));
+        given(exerciseQueryService.findExerciseRecordByDate(testDateTime.toLocalDate())).willReturn(responseDtoList);
 
         //when
         HttpHeaders headers = new HttpHeaders();
@@ -304,7 +301,7 @@ class ExerciseQueryControllerTest extends AbstractRestDocSupport {
                                 fieldWithPath("data[].exercisePersonalType").type(JsonFieldType.STRING).description("운동 종류"),
                                 fieldWithPath("data[].exerciseStartedAt").type(JsonFieldType.STRING).description("운동 시작시간"),
                                 fieldWithPath("data[].exerciseEndedAt").type(JsonFieldType.STRING).description("운동 종료시간"),
-                                fieldWithPath("data[].pictureUrl").type(JsonFieldType.STRING).description("운동 사진 URL")
+                                fieldWithPath("data[].pictureUrl").type(JsonFieldType.ARRAY).description("운동 사진 URL 목록")
                         )
                 ))
                 .andReturn().getResponse().getContentAsString();
@@ -323,7 +320,7 @@ class ExerciseQueryControllerTest extends AbstractRestDocSupport {
         LocalDateTime testDateTime = LocalDateTime.of(2021, 1, 1, 00, 00, 00);
 
         //given
-        given(exerciseQueryService.findExerciseRecordByDate(testDateTime.toLocalDate())).willReturn(Optional.empty());
+        given(exerciseQueryService.findExerciseRecordByDate(testDateTime.toLocalDate())).willReturn(Collections.emptyList());
 
         //when
         HttpHeaders headers = new HttpHeaders();

--- a/src/test/java/com/project200/undabang/exercise/service/impl/ExerciseQueryServiceImplTest.java
+++ b/src/test/java/com/project200/undabang/exercise/service/impl/ExerciseQueryServiceImplTest.java
@@ -20,7 +20,6 @@ import java.time.LocalDate;
 import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Optional;
 import java.util.UUID;
 
 import static org.junit.Assert.*;
@@ -160,19 +159,19 @@ class ExerciseQueryServiceImplTest {
         LocalDate testDate = LocalDate.of(2020,1,1);
         List<FindExerciseRecordDateResponseDto> mockedListDto = new ArrayList<>();
         mockedListDto.add(new FindExerciseRecordDateResponseDto());
-        Optional<List<FindExerciseRecordDateResponseDto>> optionalList = Optional.of(mockedListDto);
 
         try(MockedStatic<UserContextHolder> mockedStatic = mockStatic(UserContextHolder.class)){
             mockedStatic.when(UserContextHolder::getUserId).thenReturn(testUserId);
 
-            given(exerciseRepository.findExerciseRecordByDate(testUserId, testDate)).willReturn(optionalList);
+            given(exerciseRepository.findExerciseRecordByDate(testUserId, testDate)).willReturn(mockedListDto);
 
             //when
-            Optional<List<FindExerciseRecordDateResponseDto>> result = service.findExerciseRecordByDate(testDate);
+            List<FindExerciseRecordDateResponseDto> result = service.findExerciseRecordByDate(testDate);
 
             //then
-            assertTrue(result.isPresent());
-            assertEquals(1, result.get().size());
+            assertNotNull(result);
+            assertTrue(!result.isEmpty());
+            assertEquals(1, result.size());
             then(exerciseRepository).should().findExerciseRecordByDate(testUserId, testDate);
         }
     }
@@ -184,17 +183,15 @@ class ExerciseQueryServiceImplTest {
         LocalDate testDate = LocalDate.of(1900,1,1);
         List<FindExerciseRecordDateResponseDto> mockedListDto = new ArrayList<>();
         mockedListDto.add(new FindExerciseRecordDateResponseDto());
-        Optional<List<FindExerciseRecordDateResponseDto>> optionalList = Optional.of(mockedListDto);
 
         try(MockedStatic<UserContextHolder> mockedStatic = mockStatic(UserContextHolder.class)){
             mockedStatic.when(UserContextHolder::getUserId).thenReturn(testUserId);
 
-
             CustomException exception = assertThrows(CustomException.class,
                     () -> service.findExerciseRecordByDate(testDate));
+
             assertEquals(ErrorCode.INVALID_INPUT_VALUE, exception.getErrorCode());
         }
-
     }
 
     @Test
@@ -204,17 +201,14 @@ class ExerciseQueryServiceImplTest {
         LocalDate testDate = LocalDate.now().plusDays(1);
         List<FindExerciseRecordDateResponseDto> mockedListDto = new ArrayList<>();
         mockedListDto.add(new FindExerciseRecordDateResponseDto());
-        Optional<List<FindExerciseRecordDateResponseDto>> optionalList = Optional.of(mockedListDto);
 
         try(MockedStatic<UserContextHolder> mockedStatic = mockStatic(UserContextHolder.class)){
             mockedStatic.when(UserContextHolder::getUserId).thenReturn(testUserId);
-
 
             CustomException exception = assertThrows(CustomException.class,
                     () -> service.findExerciseRecordByDate(testDate));
             assertEquals(ErrorCode.INVALID_INPUT_VALUE, exception.getErrorCode());
         }
-
     }
 
     @Test


### PR DESCRIPTION
## 📝작업 내용

> 날짜별 조회시 발생하는 문제 해결

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> transform()을 사용하지 못해서 (hibernate-querydsl 버전 충돌) query를 두번 날리는 방법을 사용했습니다.

## #️⃣연관된 이슈

> #123