### PR TITLE
fix(운동기록 삭제) : 운동기록 이미지 삭제 로직 재구현 #130

### DIFF
--- a/src/main/java/com/project200/undabang/common/service/S3Service.java
+++ b/src/main/java/com/project200/undabang/common/service/S3Service.java
@@ -59,13 +59,25 @@ public class S3Service {
             return null;
         }
 
-        // (bucketName + '/') 포함
-        int bucketEndIndex = url.indexOf(bucketName) + bucketName.length() + 1;
+        // "uploads/"로 시작하는 부분을 찾아서 그 부분부터 끝까지를 객체 키로 반환
+        int uploadsIndex = url.indexOf("uploads/");
+        if (uploadsIndex >= 0) {
+            return url.substring(uploadsIndex);
+        }
 
-        if(bucketEndIndex > 0 && bucketEndIndex < url.length()){
+        // "uploads/"를 찾을 수 없는 경우 기존 방식 시도
+        int bucketEndIndex = url.indexOf(bucketName);
+        if (bucketEndIndex >= 0) {
+            bucketEndIndex += bucketName.length();
+            // URL에 버킷 이름 다음에 / 문자가 있는지 확인
+            if (bucketEndIndex < url.length() && url.charAt(bucketEndIndex) == '/') {
+                bucketEndIndex += 1;
+            }
             return url.substring(bucketEndIndex);
         }
 
+        log.warn("객체 키를 추출할 수 없습니다: {}", url);
+        // 추출 실패시 원래 url 반환
         return url;
     }
 


### PR DESCRIPTION
## 📝작업 내용

> dev/prod s3 bucket에서 삭제 안되는 오류 개선 시도

## 💬리뷰 요구사항(선택)

> object key를 생성하는 로직을 전에 말해주셨던 "uploads/' 기준으로 찾도록 수정했습니다. 그 후 로컬스택에서는 지워지는것을 확인했는데, 배포 후 동작하는지 확인해봐야 할 것 같습니다.

## #️⃣연관된 이슈

> #130 