### PR TITLE
이미지 수정시 삭제된 사진도 참조하는 오류 해결

### DIFF
--- a/documents/Java 단위 테스트 프롬프트.md
+++ b/documents/Java 단위 테스트 프롬프트.md
@@ -14,54 +14,50 @@ public class JUnit5ExampleTests extended AbstractRestDocSupport {
     // 한국어로 주석 입력
     @Test
     @DisplayName("한국어로 입력")
-    public void testExample() extends Exception {
+    public void testExample() extends
+
+    Exception {
         // given
+        UUID testMemberId = UUID.randomUUID();
+
         BDDMockito.given(mock.mock_method()).willReturn(...)// 정상 반환 시
         BDDMockito.given(mock.mock_method()).willThrow(...);     // 에러 발생 시
 
         // when
-        HttpHeaders headers = new HttpHeaders();
-        headers.add("X-USER-ID", memberId.toString());
-        headers.add("Authorization", "Bearer dummy-access-token-for-docs");
-
         String response = this.mockMvc.perform(MockMvcRequestBuilders.get("/api/items/{id}", 1L)
                         .contentType(MediaType.APPLICATION_JSON)
                         .accept(MediaType.APPLICATION_JSON)
-                        .headers(headers))
+                        .headers(HeadersGenerator.getCommonApiHeaders(testMemberId)))
                 .andExpectAll(
                         MockMvcResultMatchers.status().isOk(),
-				...
-			)
+            ...
+         )
         // rest docs 문서화
-			.andDo(this.document.document(
+         .andDo(this.document.document(
                 pathParameters(
-                    parameterWithName("id").description("아이디"),
+                        parameterWithName("id").description("아이디"),
                     ...
                 ),
-                requestHeaders(
-                    RestDocsUtils.HEADER_ACCESS_TOKEN,
-                    headerWithName("email").description("사용자 이메일"),
-                            ...
-                ),
+        requestHeaders(RestDocsUtils.HEADER_ACCESS_TOKEN),
                 requestFields(
-                    fieldWithPath("data.id").type(JsonFieldType.NUMBER).description("리소스의 ID"),
+                        fieldWithPath("data.id").type(JsonFieldType.NUMBER).description("리소스의 ID"),
                             ...
                 ),
 
-                // 1) data가 단일 객체
-                responseFields(RestDocsUtils.commonResponseFields(
-                    fieldWithPath("data.id").type(JsonFieldType.NUMBER).description("리소스의 ID"),
-                    fieldWithPath("data.name").type(JsonFieldType.STRING).description("리소스 이름")
-                ))
+        // 1) data가 단일 객체
+        responseFields(RestDocsUtils.commonResponseFields(
+                fieldWithPath("data.id").type(JsonFieldType.NUMBER).description("리소스의 ID"),
+                fieldWithPath("data.name").type(JsonFieldType.STRING).description("리소스 이름")
+        ))
 
-                // 2) data가 리스트
-                responseFields(RestDocsUtils.commonResponseFieldsForList( // 공통 응답 + data 리스트 내부 필드
-                    fieldWithPath("data[].id").type(JsonFieldType.NUMBER).description("리소스 ID"),
-                    fieldWithPath("data[].name").type(JsonFieldType.STRING).description("리소스 이름")
-                ))
+        // 2) data가 리스트
+        responseFields(RestDocsUtils.commonResponseFieldsForList( // 공통 응답 + data 리스트 내부 필드
+                fieldWithPath("data[].id").type(JsonFieldType.NUMBER).description("리소스 ID"),
+                fieldWithPath("data[].name").type(JsonFieldType.STRING).description("리소스 이름")
+        ))
 
-                // 3) data가 없음
-                responseFields(RestDocsUtils.commonResponseFieldsOnly()) // 공통 응답 필드만 (data는 null)
+        // 3) data가 없음
+        responseFields(RestDocsUtils.commonResponseFieldsOnly()) // 공통 응답 필드만 (data는 null)
             ))
             .andReturn().getResponse().getContentAsString();
 
@@ -72,8 +68,10 @@ public class JUnit5ExampleTests extended AbstractRestDocSupport {
         Assertions.assertThat(response).isEqualTo(expected);
 
         // 2) 에러 발생
-        BDDMockito.then(mock).should().mock_method()
-        BDDMockito.then(mock).should(BDDMockito.times(1)).mock_method()
+        BDDMockito.then(mock).should().mock_method();
+        BDDMockito.then(mock).should(BDDMockito.times(1)).mock_method();
         BDDMockito.then(mock).shouldHaveNoMoreInteractions();
-        BDDMockito.then(mock).shouldHaveNoInteractions
+        BDDMockito.then(mock).shouldHaveNoInteractions();
+    }
+}
 ```

--- a/src/main/java/com/project200/undabang/exercise/repository/ExercisePictureRepository.java
+++ b/src/main/java/com/project200/undabang/exercise/repository/ExercisePictureRepository.java
@@ -5,9 +5,8 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
 
-public interface ExercisePictureRepository extends JpaRepository<ExercisePicture, Long> {
+public interface ExercisePictureRepository extends JpaRepository<ExercisePicture, Long>, ExercisePictureRepositoryCustom {
 
     List<ExercisePicture> findAllByExercise_Id(Long exerciseId);
-
     long countByExercise_Id(Long id);
 }

--- a/src/main/java/com/project200/undabang/exercise/repository/ExercisePictureRepository.java
+++ b/src/main/java/com/project200/undabang/exercise/repository/ExercisePictureRepository.java
@@ -8,4 +8,5 @@ import java.util.List;
 public interface ExercisePictureRepository extends JpaRepository<ExercisePicture, Long>, ExercisePictureRepositoryCustom {
 
     List<ExercisePicture> findAllByExercise_Id(Long exerciseId);
+    long countByExercise_Id(Long id);
 }

--- a/src/main/java/com/project200/undabang/exercise/repository/ExercisePictureRepository.java
+++ b/src/main/java/com/project200/undabang/exercise/repository/ExercisePictureRepository.java
@@ -8,5 +8,4 @@ import java.util.List;
 public interface ExercisePictureRepository extends JpaRepository<ExercisePicture, Long>, ExercisePictureRepositoryCustom {
 
     List<ExercisePicture> findAllByExercise_Id(Long exerciseId);
-    long countByExercise_Id(Long id);
 }

--- a/src/main/java/com/project200/undabang/exercise/repository/ExercisePictureRepositoryCustom.java
+++ b/src/main/java/com/project200/undabang/exercise/repository/ExercisePictureRepositoryCustom.java
@@ -1,0 +1,5 @@
+package com.project200.undabang.exercise.repository;
+
+public interface ExercisePictureRepositoryCustom {
+    long countNotDeletedPicturesByExerciseId(Long exerciseId);
+}

--- a/src/main/java/com/project200/undabang/exercise/repository/impl/ExercisePictureRepositoryImpl.java
+++ b/src/main/java/com/project200/undabang/exercise/repository/impl/ExercisePictureRepositoryImpl.java
@@ -1,0 +1,27 @@
+package com.project200.undabang.exercise.repository.impl;
+
+import com.project200.undabang.common.entity.QPicture;
+import com.project200.undabang.exercise.entity.QExercisePicture;
+import com.project200.undabang.exercise.repository.ExercisePictureRepositoryCustom;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class ExercisePictureRepositoryImpl implements ExercisePictureRepositoryCustom {
+    private final JPAQueryFactory jpaQueryFactory;
+
+    @Override
+    public long countNotDeletedPicturesByExerciseId(Long exerciseId) {
+        QExercisePicture exercisePicture = QExercisePicture.exercisePicture;
+        QPicture picture = QPicture.picture;
+
+        return jpaQueryFactory.select(exercisePicture.count())
+                .from(exercisePicture)
+                .join(exercisePicture.picture, picture)
+                .where(
+                        exercisePicture.exercise.id.eq(exerciseId),
+                        picture.pictureDeletedAt.isNull()
+                )
+                .fetchOne();
+    }
+}

--- a/src/main/java/com/project200/undabang/exercise/repository/impl/ExerciseRepositoryImpl.java
+++ b/src/main/java/com/project200/undabang/exercise/repository/impl/ExerciseRepositoryImpl.java
@@ -13,6 +13,7 @@ import com.querydsl.core.types.Projections;
 import com.querydsl.core.types.dsl.Expressions;
 import com.querydsl.core.types.dsl.NumberPath;
 import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -24,15 +25,9 @@ import java.util.stream.Collectors;
  * Exercise 엔티티에 대한 QueryDSL 기반 커스텀 레포지토리 구현체입니다.
  * 운동 기록 조회와 관련된 복잡한 쿼리를 처리합니다.
  */
+@RequiredArgsConstructor
 public class ExerciseRepositoryImpl implements ExerciseRepositoryCustom {
     private final JPAQueryFactory queryFactory;
-
-    /**
-     * QueryDSL 쿼리 팩토리를 주입받는 생성자입니다.
-     */
-    public ExerciseRepositoryImpl(JPAQueryFactory queryFactory) {
-        this.queryFactory = queryFactory;
-    }
 
     /**
      * 특정 회원이 소유한 운동 기록이 존재하는지 확인합니다.

--- a/src/main/java/com/project200/undabang/exercise/service/impl/ExercisePictureServiceImpl.java
+++ b/src/main/java/com/project200/undabang/exercise/service/impl/ExercisePictureServiceImpl.java
@@ -54,7 +54,7 @@ public class ExercisePictureServiceImpl implements ExercisePictureService {
         }
 
         // 이미 있는 운동 사진 개수 + 새로 올라온 사진 개수 < 5 검증
-        long pictureCountOfExercise = exercisePictureRepository.countByExercise_Id(exerciseId);
+        long pictureCountOfExercise = exercisePictureRepository.countNotDeletedPicturesByExerciseId(exerciseId);
         if (pictureCountOfExercise + exercisePictureList.size() > 5) {
             throw new CustomException(ErrorCode.EXERCISE_PICTURE_COUNT_EXCEEDED);
         }

--- a/src/test/java/com/project200/undabang/exercise/repository/ExercisePictureRepositoryTest.java
+++ b/src/test/java/com/project200/undabang/exercise/repository/ExercisePictureRepositoryTest.java
@@ -1,6 +1,7 @@
 package com.project200.undabang.exercise.repository;
 
 import com.project200.undabang.common.entity.Picture;
+import com.project200.undabang.common.repository.PictureRepository;
 import com.project200.undabang.configuration.TestQuerydslConfig;
 import com.project200.undabang.exercise.entity.Exercise;
 import com.project200.undabang.exercise.entity.ExercisePicture;
@@ -28,14 +29,21 @@ class ExercisePictureRepositoryTest {
     private ExercisePictureRepository exercisePictureRepository;
 
     @Autowired
+    private PictureRepository pictureRepository;
+
+    @Autowired
     private EntityManager em;
 
     private UUID memberId = UUID.randomUUID();
     private Exercise exercise;
+    private List<Picture> savedPictures;
 
     @BeforeEach
     void setUp(){
         makeEntities();
+
+        em.flush();
+        em.clear();
     }
 
     @Test
@@ -102,10 +110,7 @@ class ExercisePictureRepositoryTest {
                 .pictureUrl("pictureUrl3.jpg")
                 .pictureExtension(".jpg")
                 .build();
-
-        em.persist(picture);
-        em.persist(picture2);
-        em.persist(picture3);
+        savedPictures = pictureRepository.saveAll(List.of(picture, picture2, picture3));
 
         ExercisePicture exercisePicture = ExercisePicture.builder()
                 .exercise(exercise)
@@ -122,8 +127,68 @@ class ExercisePictureRepositoryTest {
                 .picture(picture3)
                 .build();
 
-        exercisePictureRepository.save(exercisePicture);
-        exercisePictureRepository.save(exercisePicture2);
-        exercisePictureRepository.save(exercisePicture3);
+        exercisePictureRepository.saveAll(List.of(exercisePicture, exercisePicture2, exercisePicture3));
+    }
+
+    @DisplayName("countByExercise_Id 가 SoftDelete된 데이터를 포함하여 갯수를 세는 경우 (버그 재현)")
+    // 에러 확인
+    public void countByExercise_Id_SoftDelete(){
+        // === Given: setUp에서 3개의 사진이 정상적으로 추가된 상태 ===
+        // 이 시점에서 총 개수는 3개입니다.
+        Assertions.assertThat(exercisePictureRepository.countByExercise_Id(exercise.getId())).isEqualTo(3L);
+
+
+        // === When: 연결된 Picture 중 2개를 soft-delete 처리 ===
+        // 1. 삭제할 Picture 엔티티 2개를 가져옵니다.
+        Picture pictureToDelete1 = savedPictures.get(0);
+        Picture pictureToDelete2 = savedPictures.get(1);
+
+        // 2. Picture 엔티티의 softDelete 메소드를 호출하여 pictureDeletedAt 필드를 업데이트합니다.
+        pictureToDelete1.softDelete();
+        pictureToDelete2.softDelete();
+
+        // 3. 변경된 Picture 엔티티를 저장합니다.
+        pictureRepository.save(pictureToDelete1);
+        pictureRepository.save(pictureToDelete2);
+
+        // 4. DB에 변경사항을 반영하고 캐시를 비웁니다.
+        em.flush();
+        em.clear();
+
+        // 5. 문제가 되는 메소드를 다시 호출합니다.
+        long countAfterSoftDelete = exercisePictureRepository.countByExercise_Id(exercise.getId());
+
+        // === Then: 활성 사진 개수는 1개여야 한다 ===
+        // 올바른 동작이라면 soft-delete된 Picture와 연결된 ExercisePicture를 제외하고 '1'을 반환해야 합니다.
+        // 하지만 현재 countByExercise_Id 쿼리는 Picture 테이블을 보지 않으므로, 여전히 '3'을 반환할 것입니다.
+        // 따라서 이 테스트는 `Expected: 1, but was: 3` 오류를 내며 실패합니다. (RED 단계 성공)
+        Assertions.assertThat(countAfterSoftDelete).isEqualTo(1L);
+    }
+
+    @Test
+    @DisplayName("countNotDeletedPicturesByExerciseId을 사용해서 서비스 정상 작동되는지 확인")
+    public void countNotDeletedPicturesByExerciseId_success(){
+        // given
+        Assertions.assertThat(exercisePictureRepository.countNotDeletedPicturesByExerciseId(exercise.getId())).isEqualTo(3L);
+
+
+        // when
+        Picture pictureToDelete1 = savedPictures.get(0);
+        Picture pictureToDelete2 = savedPictures.get(1);
+
+        pictureToDelete1.softDelete();
+        pictureToDelete2.softDelete();
+
+        pictureRepository.save(pictureToDelete1);
+        pictureRepository.save(pictureToDelete2);
+
+        em.flush();
+        em.clear();
+
+        // 문제가 되는 메소드를 호출
+        long countAfterSoftDelete = exercisePictureRepository.countNotDeletedPicturesByExerciseId(exercise.getId());
+
+        // then
+        Assertions.assertThat(countAfterSoftDelete).isEqualTo(1L);
     }
 }

--- a/src/test/java/com/project200/undabang/exercise/service/impl/ExerciseCommandServiceImplTest.java
+++ b/src/test/java/com/project200/undabang/exercise/service/impl/ExerciseCommandServiceImplTest.java
@@ -139,8 +139,8 @@ class ExerciseCommandServiceImplTest {
                 .exerciseDetail("내용")
                 .exerciseLocation("장소")
                 .exercisePersonalType("헬스")
-                .exerciseStartedAt(LocalDateTime.of(2025,5,27,00,00,00))
-                .exerciseEndedAt(LocalDateTime.of(2025,5,27,01,00,00))
+                .exerciseStartedAt(LocalDateTime.of(2025, 5, 27, 00, 00, 00))
+                .exerciseEndedAt(LocalDateTime.of(2025, 5, 27, 01, 00, 00))
                 .build();
 
         UpdateExerciseRequestDto dto = UpdateExerciseRequestDto.builder()
@@ -149,13 +149,13 @@ class ExerciseCommandServiceImplTest {
                 .exerciseEndedAt(LocalDateTime.now())
                 .build();
 
-        try(MockedStatic<UserContextHolder> mockedUserContextHolder = Mockito.mockStatic(UserContextHolder.class)){
+        try (MockedStatic<UserContextHolder> mockedUserContextHolder = Mockito.mockStatic(UserContextHolder.class)) {
             mockedUserContextHolder.when(UserContextHolder::getUserId).thenReturn(memberId);
 
             BDDMockito.given(memberRepository.findById(memberId)).willReturn(Optional.of(member));
             BDDMockito.given(exerciseRepository.findById(exerciseId)).willReturn(Optional.of(exercise));
             // 예외처리 통과설정
-            BDDMockito.given(exerciseRepository.existsByRecordIdAndMemberId(memberId,exerciseId)).willReturn(true);
+            BDDMockito.given(exerciseRepository.existsByRecordIdAndMemberId(memberId, exerciseId)).willReturn(true);
 
             //when
             ExerciseIdResponseDto responseDto = exerciseCommandService.updateExercise(exerciseId, dto);
@@ -182,7 +182,7 @@ class ExerciseCommandServiceImplTest {
                 .exerciseEndedAt(LocalDateTime.now())
                 .build();
 
-        try(MockedStatic<UserContextHolder> mockedUserContextHolder = Mockito.mockStatic(UserContextHolder.class)){
+        try (MockedStatic<UserContextHolder> mockedUserContextHolder = Mockito.mockStatic(UserContextHolder.class)) {
             mockedUserContextHolder.when(UserContextHolder::getUserId).thenReturn(memberId);
 
             BDDMockito.given(memberRepository.findById(memberId)).willThrow(new CustomException(ErrorCode.MEMBER_NOT_FOUND));
@@ -196,7 +196,7 @@ class ExerciseCommandServiceImplTest {
 
     @Test
     @DisplayName("운동기록 수정 _ 날짜 입력 실패")
-    void updateExercise_dateInputFailed(){
+    void updateExercise_dateInputFailed() {
         //given
         UUID memberId = UUID.randomUUID();
         Long exerciseId = 1L;
@@ -207,12 +207,12 @@ class ExerciseCommandServiceImplTest {
                 .exerciseEndedAt(LocalDateTime.now().plusDays(1))
                 .build();
 
-        try(MockedStatic<UserContextHolder> mockedUserContextHolder = Mockito.mockStatic(UserContextHolder.class)){
+        try (MockedStatic<UserContextHolder> mockedUserContextHolder = Mockito.mockStatic(UserContextHolder.class)) {
             mockedUserContextHolder.when(UserContextHolder::getUserId).thenReturn(memberId);
 
             BDDMockito.given(memberRepository.findById(memberId)).willReturn(Optional.of(mockedMember));
 
-            Assertions.assertThatThrownBy(() -> exerciseCommandService.updateExercise(exerciseId,dto))
+            Assertions.assertThatThrownBy(() -> exerciseCommandService.updateExercise(exerciseId, dto))
                     .isInstanceOf(CustomException.class)
                     .hasFieldOrPropertyWithValue("errorCode", ErrorCode.INVALID_INPUT_VALUE);
         }
@@ -220,7 +220,7 @@ class ExerciseCommandServiceImplTest {
 
     @Test
     @DisplayName("운동기록 수정 _ 타인의 운동기록 접근")
-    void updateExercise_wrongExerciseIdInput(){
+    void updateExercise_wrongExerciseIdInput() {
         UUID memberId = UUID.randomUUID();
         Long exerciseId = 1L;
         Member mockedMember = Member.builder().memberId(memberId).build();
@@ -230,13 +230,13 @@ class ExerciseCommandServiceImplTest {
                 .exerciseEndedAt(LocalDateTime.now())
                 .build();
 
-        try(MockedStatic<UserContextHolder> mockedUserContextHolder = Mockito.mockStatic(UserContextHolder.class)){
+        try (MockedStatic<UserContextHolder> mockedUserContextHolder = Mockito.mockStatic(UserContextHolder.class)) {
             mockedUserContextHolder.when(UserContextHolder::getUserId).thenReturn(memberId);
 
             BDDMockito.given(memberRepository.findById(memberId)).willReturn(Optional.of(mockedMember));
-            BDDMockito.given(exerciseRepository.existsByRecordIdAndMemberId(memberId,exerciseId)).willReturn(false);
+            BDDMockito.given(exerciseRepository.existsByRecordIdAndMemberId(memberId, exerciseId)).willReturn(false);
 
-            Assertions.assertThatThrownBy(() -> exerciseCommandService.updateExercise(exerciseId,dto))
+            Assertions.assertThatThrownBy(() -> exerciseCommandService.updateExercise(exerciseId, dto))
                     .isInstanceOf(CustomException.class)
                     .hasFieldOrPropertyWithValue("errorCode", ErrorCode.AUTHORIZATION_DENIED);
         }
@@ -244,7 +244,7 @@ class ExerciseCommandServiceImplTest {
 
     @Test
     @DisplayName("운동기록 수정 _ 운동기록 불러오기 실패")
-    void updateExercise_recordNotFound(){
+    void updateExercise_recordNotFound() {
         UUID memberId = UUID.randomUUID();
         Long exerciseId = 1L;
         Member mockedMember = Member.builder().memberId(memberId).build();
@@ -254,14 +254,14 @@ class ExerciseCommandServiceImplTest {
                 .exerciseEndedAt(LocalDateTime.now())
                 .build();
 
-        try(MockedStatic<UserContextHolder> mockedUserContextHolder = Mockito.mockStatic(UserContextHolder.class)){
+        try (MockedStatic<UserContextHolder> mockedUserContextHolder = Mockito.mockStatic(UserContextHolder.class)) {
             mockedUserContextHolder.when(UserContextHolder::getUserId).thenReturn(memberId);
 
             BDDMockito.given(memberRepository.findById(memberId)).willReturn(Optional.of(mockedMember));
-            BDDMockito.given(exerciseRepository.existsByRecordIdAndMemberId(memberId,exerciseId)).willReturn(true);
+            BDDMockito.given(exerciseRepository.existsByRecordIdAndMemberId(memberId, exerciseId)).willReturn(true);
             BDDMockito.given(exerciseRepository.findById(exerciseId)).willThrow(new CustomException(ErrorCode.EXERCISE_RECORD_NOT_FOUND));
 
-            Assertions.assertThatThrownBy(() -> exerciseCommandService.updateExercise(exerciseId,dto))
+            Assertions.assertThatThrownBy(() -> exerciseCommandService.updateExercise(exerciseId, dto))
                     .isInstanceOf(CustomException.class)
                     .hasFieldOrPropertyWithValue("errorCode", ErrorCode.EXERCISE_RECORD_NOT_FOUND);
         }
@@ -269,37 +269,37 @@ class ExerciseCommandServiceImplTest {
 
     @Test
     @DisplayName("운동기록 이미지 삭제 _ 성공")
-    void deleteExerciseImages(){
+    void deleteExerciseImages() {
         // given
         Long testExerciseId = 1L;
         UUID testMemberId = UUID.randomUUID();
-        List<Long> deletePictureIdList = List.of(1L,2L,3L);
+        List<Long> deletePictureIdList = List.of(1L, 2L, 3L);
         Member testMember = Member.builder().memberId(testMemberId).build();
 
-        try(MockedStatic<UserContextHolder> mockedUserContextHolder = Mockito.mockStatic(UserContextHolder.class)){
+        try (MockedStatic<UserContextHolder> mockedUserContextHolder = Mockito.mockStatic(UserContextHolder.class)) {
             mockedUserContextHolder.when(UserContextHolder::getUserId).thenReturn(testMemberId);
             BDDMockito.given(memberRepository.findById(testMemberId)).willReturn(Optional.of(testMember));
-            BDDMockito.given(exerciseRepository.existsByRecordIdAndMemberId(testMemberId,testExerciseId)).willReturn(true);
+            BDDMockito.given(exerciseRepository.existsByRecordIdAndMemberId(testMemberId, testExerciseId)).willReturn(true);
             // 반환타입이 void라 willDoNothing() 사용
-            BDDMockito.willDoNothing().given(exercisePictureService).deleteExercisePictures(testMemberId,testExerciseId,deletePictureIdList);
+            BDDMockito.willDoNothing().given(exercisePictureService).deleteExercisePictures(testMemberId, testExerciseId, deletePictureIdList);
 
             // when
-            exerciseCommandService.deleteImages(testExerciseId,deletePictureIdList);
+            exerciseCommandService.deleteImages(testExerciseId, deletePictureIdList);
 
             // then
-            BDDMockito.then(exercisePictureService).should(BDDMockito.times(1)).deleteExercisePictures(testMemberId,testExerciseId,deletePictureIdList);
+            BDDMockito.then(exercisePictureService).should(BDDMockito.times(1)).deleteExercisePictures(testMemberId, testExerciseId, deletePictureIdList);
         }
     }
 
     @Test
     @DisplayName("운동기록 이미지 삭제 _ 회원 인증 실패")
-    void deleteExerciseImages_MemberNotFound(){
+    void deleteExerciseImages_MemberNotFound() {
         // given
         UUID testMemberId = UUID.randomUUID();
         Long testExerciseId = 1L;
         List<Long> deletePictureIdList = List.of(1L, 2L, 3L);
 
-        try(MockedStatic<UserContextHolder> mockedStatic = Mockito.mockStatic(UserContextHolder.class)){
+        try (MockedStatic<UserContextHolder> mockedStatic = Mockito.mockStatic(UserContextHolder.class)) {
             mockedStatic.when(UserContextHolder::getUserId).thenReturn(testMemberId);
             BDDMockito.given(memberRepository.findById(testMemberId)).willReturn(Optional.empty());
 
@@ -308,48 +308,48 @@ class ExerciseCommandServiceImplTest {
                     .isInstanceOf(CustomException.class)
                     .hasFieldOrPropertyWithValue("errorCode", ErrorCode.MEMBER_NOT_FOUND);
 
-            BDDMockito.then(exercisePictureService).should(BDDMockito.never()).deleteExercisePictures(testMemberId,testExerciseId,deletePictureIdList);
+            BDDMockito.then(exercisePictureService).should(BDDMockito.never()).deleteExercisePictures(testMemberId, testExerciseId, deletePictureIdList);
         }
     }
 
     @Test
     @DisplayName("운동기록 이미지 삭제 _ 타인의 운동기록, 사진 접근 확인")
-    void deleteExerciseImages_AuthorizationDenied(){
+    void deleteExerciseImages_AuthorizationDenied() {
         UUID testMemberId = UUID.randomUUID();
         Long testExerciseId = 1L;
         List<Long> deletePictureIdList = List.of(1L, 2L, 3L);
         Member testMember = Member.builder().memberId(testMemberId).build();
 
-        try(MockedStatic<UserContextHolder> mockedStatic = Mockito.mockStatic(UserContextHolder.class)){
+        try (MockedStatic<UserContextHolder> mockedStatic = Mockito.mockStatic(UserContextHolder.class)) {
             mockedStatic.when(UserContextHolder::getUserId).thenReturn(testMemberId);
             BDDMockito.given(memberRepository.findById(testMemberId)).willReturn(Optional.of(testMember));
-            BDDMockito.given(exerciseRepository.existsByRecordIdAndMemberId(testMemberId,testExerciseId)).willReturn(false);
+            BDDMockito.given(exerciseRepository.existsByRecordIdAndMemberId(testMemberId, testExerciseId)).willReturn(false);
 
             //when, then
             Assertions.assertThatThrownBy(() -> exerciseCommandService.deleteImages(testExerciseId, deletePictureIdList))
                     .isInstanceOf(CustomException.class)
                     .hasFieldOrPropertyWithValue("errorCode", ErrorCode.AUTHORIZATION_DENIED);
 
-            BDDMockito.then(exercisePictureService).should(BDDMockito.never()).deleteExercisePictures(testMemberId,testExerciseId,deletePictureIdList);
+            BDDMockito.then(exercisePictureService).should(BDDMockito.never()).deleteExercisePictures(testMemberId, testExerciseId, deletePictureIdList);
         }
     }
 
     @Test
     @DisplayName("운동기록 삭제")
-    void deleteExercise(){
+    void deleteExercise() {
         UUID testMemberId = UUID.randomUUID();
         Long testExerciseId = 1L;
 
         Member testMember = Member.builder().memberId(testMemberId).build();
         Exercise testExercise = Exercise.builder().id(testExerciseId).member(testMember).build();
 
-        List<Long> testPictureIdList = List.of(1L,2L,3L);
+        List<Long> testPictureIdList = List.of(1L, 2L, 3L);
 
-        try(MockedStatic<UserContextHolder> mockedStatic = Mockito.mockStatic(UserContextHolder.class)){
+        try (MockedStatic<UserContextHolder> mockedStatic = Mockito.mockStatic(UserContextHolder.class)) {
             mockedStatic.when(UserContextHolder::getUserId).thenReturn(testMemberId);
 
             BDDMockito.given(memberRepository.findById(testMemberId)).willReturn(Optional.of(testMember));
-            BDDMockito.given(exerciseRepository.existsByRecordIdAndMemberId(testMemberId,testExerciseId)).willReturn(true);
+            BDDMockito.given(exerciseRepository.existsByRecordIdAndMemberId(testMemberId, testExerciseId)).willReturn(true);
             BDDMockito.given(exercisePictureService.getAllImagesFromExercise(testMemberId, testExerciseId)).willReturn(testPictureIdList);
 
             BDDMockito.given(exerciseRepository.findById(testExerciseId)).willReturn(Optional.of(testExercise));
@@ -366,11 +366,11 @@ class ExerciseCommandServiceImplTest {
 
     @Test
     @DisplayName("운동기록 삭제 _ 회원 ID 불일치")
-    void deleteExercise_FailedMemberIdAuthorization(){
+    void deleteExercise_FailedMemberIdAuthorization() {
         UUID testMemberId = UUID.randomUUID();
         Long testExerciseId = 1L;
 
-        try(MockedStatic<UserContextHolder> mockedStatic = Mockito.mockStatic(UserContextHolder.class)){
+        try (MockedStatic<UserContextHolder> mockedStatic = Mockito.mockStatic(UserContextHolder.class)) {
             mockedStatic.when(UserContextHolder::getUserId).thenReturn(testMemberId);
 
             BDDMockito.given(memberRepository.findById(testMemberId)).willThrow(new CustomException(ErrorCode.MEMBER_NOT_FOUND));
@@ -388,18 +388,18 @@ class ExerciseCommandServiceImplTest {
 
     @Test
     @DisplayName("운동기록 삭제 _ 타인의 운동기록 접근 시도")
-    void deleteExercise_FailedToAccessExercise(){
+    void deleteExercise_FailedToAccessExercise() {
         UUID testMemberId = UUID.randomUUID();
         Long testExerciseId = 1L;
 
         Member member = Member.builder().memberId(testMemberId).build();
         Exercise exercise = Exercise.builder().id(testExerciseId).member(member).build();
 
-        try(MockedStatic<UserContextHolder> mockedStatic = Mockito.mockStatic(UserContextHolder.class)){
+        try (MockedStatic<UserContextHolder> mockedStatic = Mockito.mockStatic(UserContextHolder.class)) {
             mockedStatic.when(UserContextHolder::getUserId).thenReturn(testMemberId);
 
             BDDMockito.given(memberRepository.findById(testMemberId)).willReturn(Optional.of(member));
-            BDDMockito.given(exerciseRepository.existsByRecordIdAndMemberId(testMemberId,testExerciseId)).willThrow(new CustomException(ErrorCode.AUTHORIZATION_DENIED));
+            BDDMockito.given(exerciseRepository.existsByRecordIdAndMemberId(testMemberId, testExerciseId)).willThrow(new CustomException(ErrorCode.AUTHORIZATION_DENIED));
 
             Assertions.assertThatThrownBy(() ->
                             exerciseCommandService.deleteExercise(testExerciseId))
@@ -416,14 +416,14 @@ class ExerciseCommandServiceImplTest {
 
     @Test
     @DisplayName("운동기록 삭제 _ 삭제 대상 운동기록 없음")
-    void deleteExercise_TargetExerciseNotFound(){
+    void deleteExercise_TargetExerciseNotFound() {
         UUID testMemberId = UUID.randomUUID();
         Long testExerciseId = 1L;
 
         Member member = Member.builder().memberId(testMemberId).build();
         List<Long> pictureIds = List.of(1L, 2L);
 
-        try(MockedStatic<UserContextHolder> mockedStatic = Mockito.mockStatic(UserContextHolder.class)){
+        try (MockedStatic<UserContextHolder> mockedStatic = Mockito.mockStatic(UserContextHolder.class)) {
             mockedStatic.when(UserContextHolder::getUserId).thenReturn(testMemberId);
 
             BDDMockito.given(memberRepository.findById(testMemberId)).willReturn(Optional.of(member));
@@ -533,5 +533,4 @@ class ExerciseCommandServiceImplTest {
             BDDMockito.then(exerciseRepository).should(BDDMockito.never()).findById(testExerciseId);
         }
     }
-
 }

--- a/src/test/java/com/project200/undabang/exercise/service/impl/ExercisePictureServiceImplTest.java
+++ b/src/test/java/com/project200/undabang/exercise/service/impl/ExercisePictureServiceImplTest.java
@@ -71,7 +71,7 @@ public class ExercisePictureServiceImplTest {
         try (var ignored = BDDMockito.mockStatic(UserContextHolder.class)) {
             BDDMockito.given(UserContextHolder.getUserId()).willReturn(testUserId);
             BDDMockito.given(exerciseRepository.findById(testExerciseId)).willReturn(Optional.of(testExercise));
-            BDDMockito.given(exercisePictureRepository.countByExercise_Id(testExerciseId)).willReturn(0L);
+            BDDMockito.given(exercisePictureRepository.countNotDeletedPicturesByExerciseId(testExerciseId)).willReturn(0L);
             BDDMockito.given(s3Service.generateObjectKey(BDDMockito.anyString(), BDDMockito.any())).willReturn("key");
             BDDMockito.given(s3Service.uploadImage(BDDMockito.any(), BDDMockito.anyString())).willReturn("url");
 
@@ -146,7 +146,7 @@ public class ExercisePictureServiceImplTest {
         try (var ignored = BDDMockito.mockStatic(UserContextHolder.class)) {
             BDDMockito.given(UserContextHolder.getUserId()).willReturn(testUserId);
             BDDMockito.given(exerciseRepository.findById(testExerciseId)).willReturn(Optional.of(testExercise));
-            BDDMockito.given(exercisePictureRepository.countByExercise_Id(testExerciseId)).willReturn(3L);
+            BDDMockito.given(exercisePictureRepository.countNotDeletedPicturesByExerciseId(testExerciseId)).willReturn(3L);
 
             // when and then
             assertThatThrownBy(() -> exercisePictureService.uploadExercisePictures(testExerciseId, testFiles))
@@ -174,7 +174,7 @@ public class ExercisePictureServiceImplTest {
         try (var ignored = BDDMockito.mockStatic(UserContextHolder.class)) {
             BDDMockito.given(UserContextHolder.getUserId()).willReturn(testUserId);
             BDDMockito.given(exerciseRepository.findById(testExerciseId)).willReturn(Optional.of(testExercise));
-            BDDMockito.given(exercisePictureRepository.countByExercise_Id(testExerciseId)).willReturn(0L);
+            BDDMockito.given(exercisePictureRepository.countNotDeletedPicturesByExerciseId(testExerciseId)).willReturn(0L);
             BDDMockito.given(s3Service.generateObjectKey(BDDMockito.anyString(), BDDMockito.any())).willReturn("key");
             BDDMockito.given(s3Service.uploadImage(BDDMockito.any(), BDDMockito.anyString())).willReturn("url");
             BDDMockito.doThrow(new RuntimeException("Database error")).when(pictureRepository).saveAll(BDDMockito.any());
@@ -207,7 +207,7 @@ public class ExercisePictureServiceImplTest {
         try (var ignored = BDDMockito.mockStatic(UserContextHolder.class)) {
             BDDMockito.given(UserContextHolder.getUserId()).willReturn(testUserId);
             BDDMockito.given(exerciseRepository.findById(testExerciseId)).willReturn(Optional.of(testExercise));
-            BDDMockito.given(exercisePictureRepository.countByExercise_Id(testExerciseId)).willReturn(2L);
+            BDDMockito.given(exercisePictureRepository.countNotDeletedPicturesByExerciseId(testExerciseId)).willReturn(2L);
             BDDMockito.given(s3Service.generateObjectKey(BDDMockito.anyString(), BDDMockito.any())).willReturn("key");
 
             // s3Service.uploadImage 모의 설정 시작

--- a/src/test/java/com/project200/undabang/exercise/service/impl/ExercisePictureServiceImplTest.java
+++ b/src/test/java/com/project200/undabang/exercise/service/impl/ExercisePictureServiceImplTest.java
@@ -13,14 +13,14 @@ import com.project200.undabang.exercise.entity.ExercisePicture;
 import com.project200.undabang.exercise.repository.ExercisePictureRepository;
 import com.project200.undabang.exercise.repository.ExerciseRepository;
 import com.project200.undabang.member.entity.Member;
+import com.project200.undabang.member.repository.MemberRepository;
 import org.assertj.core.api.Assertions;
 import org.assertj.core.api.SoftAssertions;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.BDDMockito;
-import org.mockito.InjectMocks;
-import org.mockito.Mock;
+import org.mockito.*;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.MediaType;
 import org.springframework.mock.web.MockMultipartFile;
@@ -47,6 +47,9 @@ public class ExercisePictureServiceImplTest {
 
     @Mock
     private S3Service s3Service;
+
+    @Mock
+    private MemberRepository memberRepository;
 
     @InjectMocks
     private ExercisePictureServiceImpl exercisePictureService;
@@ -233,7 +236,7 @@ public class ExercisePictureServiceImplTest {
 
     @Test
     @DisplayName("운동기록 이미지 삭제 _ 성공")
-    void deleteExerciseImages(){
+    void deleteExerciseImages() {
         // given
         UUID testMemberId = UUID.randomUUID();
         Long testExerciseId = 1L;
@@ -249,7 +252,7 @@ public class ExercisePictureServiceImplTest {
         ExercisePicture exercisePicture2 = ExercisePicture.builder().id(picture2.getId()).picture(picture2).exercise(testExercise).build();
         ExercisePicture exercisePicture3 = ExercisePicture.builder().id(picture3.getId()).picture(picture3).exercise(testExercise).build();
 
-        List<Long> testDeleteIdList = List.of(1L,2L,3L);
+        List<Long> testDeleteIdList = List.of(1L, 2L, 3L);
         List<ExercisePicture> exercisePicturesForAuthCheck = List.of(exercisePicture1, exercisePicture2, exercisePicture3);
         List<ExercisePicture> exercisePicturesToDelete = List.of(exercisePicture1, exercisePicture2, exercisePicture3);
 
@@ -283,17 +286,17 @@ public class ExercisePictureServiceImplTest {
 
     @Test
     @DisplayName("운동기록 이미지 삭제 _ 자신의 운동기록이 아닌경우")
-    void deleteExerciseImage_FailedNotOwner(){
+    void deleteExerciseImage_FailedNotOwner() {
         // given
         UUID testMemberId = UUID.randomUUID();
         Long testExerciseId = 1L;
-        List<Long> pictureIdDeleteList = List.of(1L,2L,3L);
+        List<Long> pictureIdDeleteList = List.of(1L, 2L, 3L);
 
-        BDDMockito.given(exerciseRepository.existsByRecordIdAndMemberId(testMemberId,testExerciseId)).willReturn(false);
+        BDDMockito.given(exerciseRepository.existsByRecordIdAndMemberId(testMemberId, testExerciseId)).willReturn(false);
 
         // when, then
         Assertions.assertThatThrownBy(() ->
-                exercisePictureService.deleteExercisePictures(testMemberId,testExerciseId,pictureIdDeleteList))
+                        exercisePictureService.deleteExercisePictures(testMemberId, testExerciseId, pictureIdDeleteList))
                 .isInstanceOf(CustomException.class)
                 .hasFieldOrPropertyWithValue("errorCode", ErrorCode.AUTHORIZATION_DENIED);
 
@@ -305,7 +308,7 @@ public class ExercisePictureServiceImplTest {
 
     @Test
     @DisplayName("운동기록 이미지 삭제 _ 사진이 해당 운동 기록에 속하지 않는 경우")
-    void deleteExerciseImage_FailedPictureNotBelongsToExercise(){
+    void deleteExerciseImage_FailedPictureNotBelongsToExercise() {
         // given
         UUID testMemberId = UUID.randomUUID();
         Long testExerciseId = 1L;
@@ -322,13 +325,13 @@ public class ExercisePictureServiceImplTest {
                 .picture(picture)
                 .build();
 
-        BDDMockito.given(exerciseRepository.existsByRecordIdAndMemberId(testMemberId,testExerciseId)).willReturn(true);
+        BDDMockito.given(exerciseRepository.existsByRecordIdAndMemberId(testMemberId, testExerciseId)).willReturn(true);
         // 입력받은 pictureId가 아니라 실제 Id반환. 따라서 에러가 발생해야 함
         BDDMockito.given(exercisePictureRepository.findAllByExercise_Id(testExerciseId)).willReturn(List.of(exercisePicture));
 
         //when then
         Assertions.assertThatThrownBy(() ->
-                exercisePictureService.deleteExercisePictures(testMemberId,testExerciseId,testDeletePictureIdList))
+                        exercisePictureService.deleteExercisePictures(testMemberId, testExerciseId, testDeletePictureIdList))
                 .isInstanceOf(CustomException.class)
                 .hasFieldOrPropertyWithValue("errorCode", ErrorCode.AUTHORIZATION_DENIED);
 
@@ -338,7 +341,7 @@ public class ExercisePictureServiceImplTest {
 
     @Test
     @DisplayName("운동기록 이미지 삭제 _ S3에 있는 이미지 삭제 실패")
-    void deleteExerciseImage_FailedToDeletePicturesInS3(){
+    void deleteExerciseImage_FailedToDeletePicturesInS3() {
         // given
         UUID testMemberId = UUID.randomUUID();
         Long testExerciseId = 1L;
@@ -350,7 +353,7 @@ public class ExercisePictureServiceImplTest {
         ExercisePicture exercisePicture = ExercisePicture.builder().id(picture.getId()).picture(picture).exercise(exercise).build();
         List<Long> testDeletePictureList = List.of(exercisePicture.getId());
 
-        BDDMockito.given(exerciseRepository.existsByRecordIdAndMemberId(testMemberId,testExerciseId)).willReturn(true);
+        BDDMockito.given(exerciseRepository.existsByRecordIdAndMemberId(testMemberId, testExerciseId)).willReturn(true);
         BDDMockito.given(exercisePictureRepository.findAllByExercise_Id(testExerciseId)).willReturn(List.of(exercisePicture));
         BDDMockito.given(exercisePictureRepository.findAllById(testDeletePictureList)).willReturn(List.of(exercisePicture));
         BDDMockito.given(s3Service.extractObjectKeyFromUrl(picture.getPictureUrl())).willReturn("key1.png");
@@ -358,8 +361,8 @@ public class ExercisePictureServiceImplTest {
         // S3 삭제시 S3UploadFailedException 발생
         BDDMockito.willThrow(new S3UploadFailedException("S3 Exception")).given(s3Service).deleteImage("key1.png");
 
-        Assertions.assertThatThrownBy(()->
-                exercisePictureService.deleteExercisePictures(testMemberId,testExerciseId,testDeletePictureList))
+        Assertions.assertThatThrownBy(() ->
+                        exercisePictureService.deleteExercisePictures(testMemberId, testExerciseId, testDeletePictureList))
                 .isInstanceOf(CustomException.class)
                 .hasFieldOrPropertyWithValue("errorCode", ErrorCode.EXERCISE_PICTURE_DELETE_FAILED);
 
@@ -370,7 +373,7 @@ public class ExercisePictureServiceImplTest {
 
     @Test
     @DisplayName("운동기록과 연계된 이미지 조회 성공케이스")
-    void getAllImagesFromExercise(){
+    void getAllImagesFromExercise() {
         UUID testMemberId = UUID.randomUUID();
         Long testExerciseId = 1L;
 
@@ -399,7 +402,7 @@ public class ExercisePictureServiceImplTest {
         BDDMockito.given(exercisePictureRepository.findAllByExercise_Id(testExerciseId)).willReturn(testExercisePictures);
 
         // when
-        List<Long> pictureIds = exercisePictureService.getAllImagesFromExercise(testMemberId,testExerciseId);
+        List<Long> pictureIds = exercisePictureService.getAllImagesFromExercise(testMemberId, testExerciseId);
 
         // then
         Assertions.assertThat(pictureIds.size()).isEqualTo(testPictureIds.size());
@@ -411,14 +414,14 @@ public class ExercisePictureServiceImplTest {
 
     @Test
     @DisplayName("운동기록과 연계된 이미지 조회 실패 _ 운동기록 없음")
-    void getAllImagesFromExercise_NoExerciseExist(){
+    void getAllImagesFromExercise_NoExerciseExist() {
         UUID testMemberId = UUID.randomUUID();
         Long testExerciseId = 1L;
 
         BDDMockito.given(exerciseRepository.findById(testExerciseId)).willThrow(new CustomException(ErrorCode.EXERCISE_NOT_FOUND));
 
         Assertions.assertThatThrownBy(() ->
-                exercisePictureService.getAllImagesFromExercise(testMemberId,testExerciseId))
+                        exercisePictureService.getAllImagesFromExercise(testMemberId, testExerciseId))
                 .isInstanceOf(CustomException.class)
                 .hasFieldOrPropertyWithValue("errorCode", ErrorCode.EXERCISE_NOT_FOUND);
 
@@ -427,7 +430,7 @@ public class ExercisePictureServiceImplTest {
 
     @Test
     @DisplayName("운동기록과 연계된 이미지 조회 실패 _  운동 기록이 회원의 것이 아닌 경우")
-    void getAllImagesFromExercise_NotRelatedMemberExercise(){
+    void getAllImagesFromExercise_NotRelatedMemberExercise() {
         // given
         UUID testMemberId = UUID.randomUUID();
         Long testExerciseId = 1L;
@@ -439,7 +442,7 @@ public class ExercisePictureServiceImplTest {
 
         // 운동기록과 연관되지 않은
         Assertions.assertThatThrownBy(() ->
-                exercisePictureService.getAllImagesFromExercise(UUID.randomUUID(), testExerciseId))
+                        exercisePictureService.getAllImagesFromExercise(UUID.randomUUID(), testExerciseId))
                 .isInstanceOf(CustomException.class)
                 .hasFieldOrPropertyWithValue("errorCode", ErrorCode.AUTHORIZATION_DENIED);
 
@@ -449,7 +452,7 @@ public class ExercisePictureServiceImplTest {
 
     @Test
     @DisplayName("운동기록과 연계된 이미지 조회 실패 _ 운동 기록이 없는 경우 빈 리스트 발생")
-    void getAllImagesFromExercise_SucceedNoExercisePicture(){
+    void getAllImagesFromExercise_SucceedNoExercisePicture() {
         // given
         UUID testMemberId = UUID.randomUUID();
         Long testExerciseId = 1L;
@@ -462,7 +465,7 @@ public class ExercisePictureServiceImplTest {
         BDDMockito.given(exercisePictureRepository.findAllByExercise_Id(testExerciseId)).willReturn(Collections.emptyList());
 
         // when
-        List<Long> testPictureIds = exercisePictureService.getAllImagesFromExercise(testMemberId,testExerciseId);
+        List<Long> testPictureIds = exercisePictureService.getAllImagesFromExercise(testMemberId, testExerciseId);
 
         // then
         Assertions.assertThat(testPictureIds).isNotNull();
@@ -471,5 +474,84 @@ public class ExercisePictureServiceImplTest {
         BDDMockito.then(exerciseRepository).should(BDDMockito.times(1)).findById(testExerciseId);
         BDDMockito.then(exercisePictureRepository).should(BDDMockito.times(1)).findAllByExercise_Id(testExerciseId);
 
+    }
+
+    @Nested
+    class test_for_image_upload_error {
+        @Test
+        @DisplayName("운동 사진 관리 - 사진 3개 추가, 2개 삭제, 3개 추가 시나리오")
+            // 처음 작성시에는 디비를 모킹으로 넣어주었으므로 에러가 안남(확인됨)
+            // 함수 수정으로 인한 정상 동작 확인
+        void manageExerciseImages_AddDeleteAddScenario() {
+            // given
+            UUID testMemberId = UUID.randomUUID();
+            Long testExerciseId = 1L;
+            Member member = Member.builder().memberId(testMemberId).build();
+            Exercise exercise = Exercise.builder().id(testExerciseId).member(member).build();
+
+            // 처음 업로드할 사진 3개
+            List<MultipartFile> initialFiles = List.of(
+                    new MockMultipartFile("file1", "file1.jpg", MediaType.IMAGE_JPEG_VALUE, "test1".getBytes()),
+                    new MockMultipartFile("file2", "file2.jpg", MediaType.IMAGE_JPEG_VALUE, "test2".getBytes()),
+                    new MockMultipartFile("file3", "file3.jpg", MediaType.IMAGE_JPEG_VALUE, "test3".getBytes())
+            );
+
+            // 삭제할 사진 ID 목록
+            List<Long> pictureIdsToDelete = List.of(1L, 2L);
+
+            // 나중에 추가할 사진 3개
+            List<MultipartFile> additionalFiles = List.of(
+                    new MockMultipartFile("file4", "file4.jpg", MediaType.IMAGE_JPEG_VALUE, "test4".getBytes()),
+                    new MockMultipartFile("file5", "file5.jpg", MediaType.IMAGE_JPEG_VALUE, "test5".getBytes()),
+                    new MockMultipartFile("file6", "file6.jpg", MediaType.IMAGE_JPEG_VALUE, "test6".getBytes())
+            );
+
+            try (MockedStatic<UserContextHolder> mockedStatic = Mockito.mockStatic(UserContextHolder.class)) {
+                mockedStatic.when(UserContextHolder::getUserId).thenReturn(testMemberId);
+                BDDMockito.given(exerciseRepository.findById(testExerciseId)).willReturn(Optional.of(exercise));
+
+                BDDMockito.given(exercisePictureRepository.countNotDeletedPicturesByExerciseId(testExerciseId))
+                        .willReturn(0L) // 맨 처음 조회시 디비엔 아무것도 없으므로 0 반환
+                        .willReturn(1L);// 사진 3개 삽입 후 2개 삭제했으므로 1 반환
+
+                // S3 업로드 설정
+                BDDMockito.given(s3Service.generateObjectKey(BDDMockito.anyString(), BDDMockito.any())).willReturn("key");
+                BDDMockito.given(s3Service.uploadImage(BDDMockito.any(), BDDMockito.anyString())).willReturn("url");
+
+                // 2단계: 사진 2개 삭제 준비
+                BDDMockito.given(exerciseRepository.existsByRecordIdAndMemberId(testMemberId, testExerciseId)).willReturn(true);
+
+                Picture picture1 = Picture.builder().id(1L).pictureUrl("url1").build();
+                Picture picture2 = Picture.builder().id(2L).pictureUrl("url2").build();
+                ExercisePicture exercisePicture1 = ExercisePicture.builder().id(1L).exercise(exercise).picture(picture1).build();
+                ExercisePicture exercisePicture2 = ExercisePicture.builder().id(2L).exercise(exercise).picture(picture2).build();
+
+                List<ExercisePicture> exercisePictureList = List.of(exercisePicture1, exercisePicture2);
+
+                BDDMockito.given(exercisePictureRepository.findAllByExercise_Id(testExerciseId)).willReturn(exercisePictureList);
+                BDDMockito.given(exercisePictureRepository.findAllById(pictureIdsToDelete)).willReturn(exercisePictureList);
+
+                BDDMockito.given(s3Service.extractObjectKeyFromUrl(BDDMockito.anyString())).willReturn("key");
+                BDDMockito.willDoNothing().given(s3Service).deleteImage(BDDMockito.anyString());
+
+                // when
+                // 사진 3개 추가
+                exercisePictureService.uploadExercisePictures(testExerciseId, initialFiles);
+
+                // 사진 2개 삭제
+                exercisePictureService.deleteExercisePictures(testMemberId, testExerciseId, pictureIdsToDelete);
+
+                // 사진 3개 추가
+                ExerciseIdResponseDto uploadResult = exercisePictureService.uploadExercisePictures(testExerciseId, additionalFiles);
+
+                // then
+                Assertions.assertThat(uploadResult.exerciseId()).isEqualTo(testExerciseId);
+                // 내가 작성한 함수가 두번 호출되었는지 확인
+                BDDMockito.then(exercisePictureRepository).should(BDDMockito.times(2)).countNotDeletedPicturesByExerciseId(testExerciseId);
+
+                // 논리 오류가 있던 메소드는 호출되지 않았는지 확인
+                BDDMockito.then(exercisePictureRepository).should(BDDMockito.never()).countByExercise_Id(BDDMockito.anyLong());
+            }
+        }
     }
 }


### PR DESCRIPTION
## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

countByExercise_Id 함수는 관계테이블에서 갯수만 조회하므로 Picture 테이블의 isDeletedAt을 조회하지 못함
따라서 QueryDSL을 사용하여 ExercisePicture 테이블과 Picture 테이블을 조인하여 picture의 isDeletedAt() 이 null 인 컬럼의 갯수를 찾아서 Long으로 반환

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> TDD를 적용해서 개발해보았습니다. 원형은 repository test에 @Test 어노테이션을 제거하고 구현하였습니다.

## #️⃣연관된 이슈

Closes #146 