### PR TITLE
[Feat] 비공개 키 저장 및 FCM 설정 구성(#181)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -261,3 +261,4 @@ $RECYCLE.BIN/
 *.lnk
 
 # End of https://www.toptal.com/developers/gitignore/api/git,windows,macos,java,intellij
+/src/main/resources/firebase/undabang-firebase-adminsdk.json

--- a/build.gradle
+++ b/build.gradle
@@ -69,10 +69,15 @@ dependencies {
     // Lombok
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'
+
+    // Spring Boot Configuration Processor
     annotationProcessor 'org.springframework.boot:spring-boot-configuration-processor'
 
     // AWS 관련
     implementation "io.awspring.cloud:spring-cloud-aws-starter-s3"    // Spring Cloud AWS S3 Starter
+
+    // firebase
+    implementation 'com.google.firebase:firebase-admin:9.5.0'
 
     // 테스트 의존성
     testImplementation 'org.springframework.boot:spring-boot-starter-test'

--- a/src/main/java/com/project200/undabang/UndabangApplication.java
+++ b/src/main/java/com/project200/undabang/UndabangApplication.java
@@ -2,8 +2,10 @@ package com.project200.undabang;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
 
 @SpringBootApplication
+@ConfigurationPropertiesScan("com.project200.undabang.common.properties")
 public class UndabangApplication {
 
     public static void main(String[] args) {

--- a/src/main/java/com/project200/undabang/common/config/FirebaseConfig.java
+++ b/src/main/java/com/project200/undabang/common/config/FirebaseConfig.java
@@ -1,0 +1,61 @@
+package com.project200.undabang.common.config;
+
+import com.google.auth.oauth2.GoogleCredentials;
+import com.google.firebase.FirebaseApp;
+import com.google.firebase.FirebaseOptions;
+import com.google.firebase.messaging.FirebaseMessaging;
+import com.project200.undabang.common.properties.FirebaseProperties;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.io.ClassPathResource;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+@Slf4j
+@Configuration
+@ConditionalOnProperty(name = "firebase.enabled", havingValue = "true")
+public class FirebaseConfig {
+
+    private final FirebaseProperties firebaseProperties;
+
+    public FirebaseConfig(FirebaseProperties firebaseProperties) {
+        this.firebaseProperties = firebaseProperties;
+    }
+
+    /**
+     * 'firebase.enabled=true'일 때만 FirebaseApp을 초기화하고 FirebaseMessaging 인스턴스를 Bean으로 등록합니다.
+     *
+     * @return FirebaseMessaging 인스턴스
+     */
+    @Bean
+    public FirebaseMessaging firebaseMessaging() throws IOException {
+        log.info("FCM 설정을 초기화합니다. (firebase.enabled=true)");
+
+        String path = firebaseProperties.credentials().path();
+        if (path == null || path.isBlank()) {
+            throw new IOException("FCM 초기화 오류: 'firebase.credentials.path' 속성이 설정되지 않았습니다.");
+        }
+
+        ClassPathResource resource = new ClassPathResource(path.replace("classpath:", ""));
+
+        try (InputStream credentials = resource.getInputStream()) {
+            FirebaseOptions options = FirebaseOptions.builder()
+                    .setCredentials(GoogleCredentials.fromStream(credentials))
+                    .build();
+
+            // 중복 초기화 방지
+            if (FirebaseApp.getApps().isEmpty()) {
+                FirebaseApp.initializeApp(options);
+                log.info("FirebaseApp이 성공적으로 초기화되었습니다.");
+            }
+
+            return FirebaseMessaging.getInstance();
+        } catch (IOException e) {
+            log.error("FCM 설정 초기화에 실패했습니다. 키 파일 경로: {}", path, e);
+            throw new IOException("FCM 초기화 오류: 서비스 계정 키 파일을 찾거나 읽을 수 없습니다.", e);
+        }
+    }
+}

--- a/src/main/java/com/project200/undabang/common/properties/FirebaseProperties.java
+++ b/src/main/java/com/project200/undabang/common/properties/FirebaseProperties.java
@@ -5,9 +5,9 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 /**
  * Firebase 관련 설정 값을 application.yml에서 바인딩하는 record 클래스입니다.
  *
- * @Param enabled Firebase 기능 활성화 여부
- * @Param credentials Firebase 인증 정보
- * @Param credentials.path Firebase 인증 파일 경로
+ * @param enabled Firebase 기능 활성화 여부
+ * @param credentials Firebase 인증 정보
+ * @param credentials.path Firebase 인증 파일 경로
  */
 @ConfigurationProperties(prefix = "firebase")
 public record FirebaseProperties(

--- a/src/main/java/com/project200/undabang/common/properties/FirebaseProperties.java
+++ b/src/main/java/com/project200/undabang/common/properties/FirebaseProperties.java
@@ -1,0 +1,19 @@
+package com.project200.undabang.common.properties;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+/**
+ * Firebase 관련 설정 값을 application.yml에서 바인딩하는 record 클래스입니다.
+ *
+ * @Param enabled Firebase 기능 활성화 여부
+ * @Param credentials Firebase 인증 정보
+ * @Param credentials.path Firebase 인증 파일 경로
+ */
+@ConfigurationProperties(prefix = "firebase")
+public record FirebaseProperties(
+        boolean enabled,
+        Credentials credentials
+) {
+    public record Credentials(String path) {
+    }
+}

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -45,3 +45,8 @@ app:
 
 cors:
   allowed-origins: http://localhost:3000
+
+firebase:
+  enabled: false
+  credentials:
+    path: "classpath:firebase/undabang-firebase-adminsdk.json"


### PR DESCRIPTION
- FirebaseAdmin SDK 의존성 및 설정 추가
- `FirebaseConfig` 클래스 추가로 FCM 초기화 및 `FirebaseMessaging` Bean 등록
- `FirebaseProperties` 클래스 추가로 application.yml 설정값 바인딩 지원
- 로컬 환경 지원을 위한 Firebase 관련 설정(application-local.yml) 추가
- Firebase 인증 파일 경로 및 사용 가능 여부 조건 처리 (`@ConditionalOnProperty`)

## 📝작업 내용

1. ~~정책 설계~~
2. ~~개발 설계~~
3. ~~파이어베이스 프로젝트 구성~~
4. 비공개 키 저장 및 FCM 설정 구성

- FCM 설정과 관련된 내용입니다.
- local에선 FCM이 연결되지 않도록 설정하였습니다.
- dev, prod도 false가 들어가도록 yml 파일을 수정하였습니다. 비공개 키가 주입되도록 ci/cd 수정하는 다음 PR 이후에 true로 변경하겠습니다.

## 💬리뷰 요구사항

- rebase, squash, amend, reset 등을 이용해서 커밋을 정리해서 올려봅시다.

## #️⃣연관된 이슈

Closes #181 