### PR TITLE
[Feat] 운동 독려 알림 기능 개발 - 5. dev, prod 환경 CI/CD 구성

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -261,3 +261,4 @@ $RECYCLE.BIN/
 *.lnk
 
 # End of https://www.toptal.com/developers/gitignore/api/git,windows,macos,java,intellij
+/src/main/resources/firebase/undabang-firebase-adminsdk.json

--- a/build.gradle
+++ b/build.gradle
@@ -69,10 +69,15 @@ dependencies {
     // Lombok
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'
+
+    // Spring Boot Configuration Processor
     annotationProcessor 'org.springframework.boot:spring-boot-configuration-processor'
 
     // AWS 관련
     implementation "io.awspring.cloud:spring-cloud-aws-starter-s3"    // Spring Cloud AWS S3 Starter
+
+    // firebase
+    implementation 'com.google.firebase:firebase-admin:9.5.0'
 
     // 테스트 의존성
     testImplementation 'org.springframework.boot:spring-boot-starter-test'

--- a/src/main/java/com/project200/undabang/UndabangApplication.java
+++ b/src/main/java/com/project200/undabang/UndabangApplication.java
@@ -2,8 +2,10 @@ package com.project200.undabang;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
 
 @SpringBootApplication
+@ConfigurationPropertiesScan("com.project200.undabang.common.properties")
 public class UndabangApplication {
 
     public static void main(String[] args) {

--- a/src/main/java/com/project200/undabang/common/config/FirebaseConfig.java
+++ b/src/main/java/com/project200/undabang/common/config/FirebaseConfig.java
@@ -1,0 +1,61 @@
+package com.project200.undabang.common.config;
+
+import com.google.auth.oauth2.GoogleCredentials;
+import com.google.firebase.FirebaseApp;
+import com.google.firebase.FirebaseOptions;
+import com.google.firebase.messaging.FirebaseMessaging;
+import com.project200.undabang.common.properties.FirebaseProperties;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.io.ClassPathResource;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+@Slf4j
+@Configuration
+@ConditionalOnProperty(name = "firebase.enabled", havingValue = "true")
+public class FirebaseConfig {
+
+    private final FirebaseProperties firebaseProperties;
+
+    public FirebaseConfig(FirebaseProperties firebaseProperties) {
+        this.firebaseProperties = firebaseProperties;
+    }
+
+    /**
+     * 'firebase.enabled=true'일 때만 FirebaseApp을 초기화하고 FirebaseMessaging 인스턴스를 Bean으로 등록합니다.
+     *
+     * @return FirebaseMessaging 인스턴스
+     */
+    @Bean
+    public FirebaseMessaging firebaseMessaging() throws IOException {
+        log.info("FCM 설정을 초기화합니다. (firebase.enabled=true)");
+
+        String path = firebaseProperties.credentials().path();
+        if (path == null || path.isBlank()) {
+            throw new IOException("FCM 초기화 오류: 'firebase.credentials.path' 속성이 설정되지 않았습니다.");
+        }
+
+        ClassPathResource resource = new ClassPathResource(path.replace("classpath:", ""));
+
+        try (InputStream credentials = resource.getInputStream()) {
+            FirebaseOptions options = FirebaseOptions.builder()
+                    .setCredentials(GoogleCredentials.fromStream(credentials))
+                    .build();
+
+            // 중복 초기화 방지
+            if (FirebaseApp.getApps().isEmpty()) {
+                FirebaseApp.initializeApp(options);
+                log.info("FirebaseApp이 성공적으로 초기화되었습니다.");
+            }
+
+            return FirebaseMessaging.getInstance();
+        } catch (IOException e) {
+            log.error("FCM 설정 초기화에 실패했습니다. 키 파일 경로: {}", path, e);
+            throw new IOException("FCM 초기화 오류: 서비스 계정 키 파일을 찾거나 읽을 수 없습니다.", e);
+        }
+    }
+}

--- a/src/main/java/com/project200/undabang/common/properties/FirebaseProperties.java
+++ b/src/main/java/com/project200/undabang/common/properties/FirebaseProperties.java
@@ -1,0 +1,19 @@
+package com.project200.undabang.common.properties;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+/**
+ * Firebase 관련 설정 값을 application.yml에서 바인딩하는 record 클래스입니다.
+ *
+ * @Param enabled Firebase 기능 활성화 여부
+ * @Param credentials Firebase 인증 정보
+ * @Param credentials.path Firebase 인증 파일 경로
+ */
+@ConfigurationProperties(prefix = "firebase")
+public record FirebaseProperties(
+        boolean enabled,
+        Credentials credentials
+) {
+    public record Credentials(String path) {
+    }
+}

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -45,3 +45,8 @@ app:
 
 cors:
   allowed-origins: http://localhost:3000
+
+firebase:
+  enabled: true
+  credentials:
+    path: "classpath:firebase/undabang-firebase-adminsdk.json"


### PR DESCRIPTION
- 프로덕션 및 개발 환경용 Firebase Admin SDK 설정 추가
- 애플리케이션 속성 파일 및 Gradle 빌드 설정 변경

## 📝작업 내용

1. ~~정책 설계~~
2. ~~개발 설계~~
3. ~~파이어베이스 프로젝트 구성~~
4. ~~비공개 키 저장 및 FCM 설정 구성~~
5. dev, prod 환경 CI/CD 구성

## 💬리뷰 요구사항

로컬 환경에서 파이어베이스 연결하는 법 공유드립니다.
1. 구글 드라이브 개발 > firebase admin sdk > dev 나 prod admin sdk json 파일이 있습니다.
  <img width="393" height="113" alt="image" src="https://github.com/user-attachments/assets/8403f69f-8674-4e4b-9077-07fa065ad1e1" />

2. 원하는 환경의 json 파일을 받은 후 로컬의 resources > firebase > undabang-firebase-adminsdk.json 으로 위치시킵니다.
  참고로  undabang-firebase-adminsdk.jso는 git ignore에 추가되어있으므로 유지하셔도 됩니다.
  <img width="288" height="170" alt="image" src="https://github.com/user-attachments/assets/64354557-891b-406f-a01e-0691a5034eaf" />

3. application-local.yml의 firebase.enabled 를 true로 설정합니다.

4. 서버 실행 후 로그에 firebase 정상 로딩 메시지가 출력될 경우 연결된 겁니다.
  <img width="654" height="48" alt="image" src="https://github.com/user-attachments/assets/3e10568b-7b17-4eaf-b70c-30563aa1c42b" />


현재 application.yml 파일이 통째로 secrets으로 관리되다보니 기밀성이 요구되지 않는 단순 설정 변경도 secrets를 수정하는 번거로움과 실수의 가능성이 존재합니다. 따라서 다음 이슈 기술부채로 남겼습니다. https://github.com/projects200/api-server/issues/184


## #️⃣연관된 이슈

> Closes #182 