### PR TITLE
feat(타이머): 타이머 엔티티 개발 및 관련 DB 스키마 추가

### DIFF
--- a/documents/Undabang Database SQL.sql
+++ b/documents/Undabang Database SQL.sql
@@ -479,8 +479,8 @@ create table if not exists custom_timers
     `member_id`               char(36)   not null comment 'UUID_SELF',
     `custom_timer_name`       varchar(100) null,
     `custom_timer_created_at` datetime     not null default current_timestamp,
-    `custom_timer_updated_at` datetime     null     default current_timestamp,
-    `custom_timer_deleted_at` datetime     null     default current_timestamp,
+    `custom_timer_updated_at` datetime     null,
+    `custom_timer_deleted_at` datetime     null,
     foreign key (`member_id`) references `members` (`member_id`)
 );
 
@@ -489,8 +489,8 @@ create table if not exists simple_timers
     `simple_timer_id`            bigint     not null auto_increment primary key ,
     `member_id`                  char(36) not null comment 'UUID_SELF',
     `simple_timer_created_at`    datetime   not null default current_timestamp,
-    `simple_timer_updated_at`    datetime   null     default current_timestamp,
-    `simple_timer_deleted_at`    datetime   null     default current_timestamp,
+    `simple_timer_updated_at`    datetime   null,
+    `simple_timer_deleted_at`    datetime   null,
     `simple_timer_order` tinyint    null,
     `simple_timer_time`  integer    null,
     foreign key (`member_id`) references `members` (`member_id`)
@@ -504,8 +504,8 @@ create table if not exists custom_timer_steps
     `custom_timer_steps_order`      tinyint     not null,
     `custom_timer_steps_time`       integer     not null,
     `custom_timer_steps_created_at` datetime    not null default current_timestamp,
-    `custom_timer_steps_updated_at` datetime    null     default current_timestamp,
-    `custom_timer_steps_deleted_at` datetime    null     default current_timestamp,
+    `custom_timer_steps_updated_at` datetime    null,
+    `custom_timer_steps_deleted_at` datetime    null,
     foreign key (`custom_timer_id`) references `custom_timers` (`custom_timer_id`)
 );
 

--- a/documents/Undabang Database SQL.sql
+++ b/documents/Undabang Database SQL.sql
@@ -33,8 +33,12 @@ drop table if exists posts;
 drop table if exists post_type;
 drop table if exists preferred_exercises;
 drop table if exists exercise_types;
+drop table if exists custom_timer_steps;
+drop table if exists simple_timers;
+drop table if exists custom_timers;
 drop table if exists members;
 drop table if exists reports;
+
 
 DROP TRIGGER IF EXISTS before_insert_members;
 
@@ -48,16 +52,16 @@ create table if not exists BATCH_JOB_EXECUTION_SEQ
 
 create table if not exists BATCH_JOB_INSTANCE
 (
-    JOB_INSTANCE_ID bigint       not null   primary key,
+    JOB_INSTANCE_ID bigint       not null primary key,
     VERSION         bigint       null,
     JOB_NAME        varchar(100) not null,
     JOB_KEY         varchar(32)  not null,
-    constraint JOB_INST_UN  unique (JOB_NAME, JOB_KEY)
+    constraint JOB_INST_UN unique (JOB_NAME, JOB_KEY)
 );
 
 create table if not exists BATCH_JOB_EXECUTION
 (
-    JOB_EXECUTION_ID           bigint        not null        primary key,
+    JOB_EXECUTION_ID           bigint        not null primary key,
     VERSION                    bigint        null,
     JOB_INSTANCE_ID            bigint        not null,
     CREATE_TIME                datetime(6)   not null,
@@ -123,9 +127,9 @@ create table if not exists BATCH_STEP_EXECUTION
 
 create table if not exists BATCH_STEP_EXECUTION_CONTEXT
 (
-    STEP_EXECUTION_ID  bigint not null primary key,
+    STEP_EXECUTION_ID  bigint        not null primary key,
     SHORT_CONTEXT      varchar(2500) not null,
-    SERIALIZED_CONTEXT text   null,
+    SERIALIZED_CONTEXT text          null,
     constraint STEP_EXEC_CTX_FK foreign key (STEP_EXECUTION_ID) references BATCH_STEP_EXECUTION (STEP_EXECUTION_ID)
 );
 
@@ -169,7 +173,7 @@ create table if not exists members
     member_bday         date                               null,
     member_nickname     varchar(50)                        not null,
     member_desc         varchar(500)                       null,
-    member_score tinyint not null comment '0~100',
+    member_score        tinyint                            not null comment '0~100',
     member_warned_count tinyint  default 0                 not null comment '관리자 처리 신고 누적',
     member_created_at   datetime default CURRENT_TIMESTAMP not null,
     member_deleted_at   datetime                           null comment '탈퇴 시 삭제 일시 기록',
@@ -178,7 +182,7 @@ create table if not exists members
     constraint member_nickname
         unique (member_nickname),
     constraint check_member_gender
-        check (`member_gender` in ('M','F','U'))
+        check (`member_gender` in ('M', 'F', 'U'))
 );
 
 create table if not exists chatrooms
@@ -296,29 +300,32 @@ create table if not exists member_pictures
         foreign key (picture_id) references pictures (picture_id)
 );
 
-create table if not exists policies (
-    policy_id             int             not null    auto_increment primary key,
-    policy_key            varchar(100)    not null    unique comment '정책을 식별하는 키 (ex:SCORE_INITIAL)',
-    policy_value          varchar(255)    null comment '정책 값',
-    policy_unit           varchar(20)     null comment '정책 값의 단위',
-    policy_description    varchar(500)    null comment '관리자 페이지에 표시될 정책 설명',
-    policy_updated_at     datetime        not null default current_timestamp comment '마지막 수정 일시',
-    policy_created_at     datetime        not null default current_timestamp comment '생성일시'
+create table if not exists policies
+(
+    policy_id          int          not null auto_increment primary key,
+    policy_key         varchar(100) not null unique comment '정책을 식별하는 키 (ex:SCORE_INITIAL)',
+    policy_value       varchar(255) null comment '정책 값',
+    policy_unit        varchar(20)  null comment '정책 값의 단위',
+    policy_description varchar(500) null comment '관리자 페이지에 표시될 정책 설명',
+    policy_updated_at  datetime     not null default current_timestamp comment '마지막 수정 일시',
+    policy_created_at  datetime     not null default current_timestamp comment '생성일시'
 );
 
-create table if not exists policy_groups (
-    policy_groups_id            int             not null    auto_increment primary key,
-    policy_groups_name          varchar(100)    not null    unique comment '정책 타입 이름',
-    policy_groups_created_at    datetime        not null    default current_timestamp comment '생성일시',
-    policy_groups_updated_at    datetime        not null    default current_timestamp comment '수정일시'
+create table if not exists policy_groups
+(
+    policy_groups_id         int          not null auto_increment primary key,
+    policy_groups_name       varchar(100) not null unique comment '정책 타입 이름',
+    policy_groups_created_at datetime     not null default current_timestamp comment '생성일시',
+    policy_groups_updated_at datetime     not null default current_timestamp comment '수정일시'
 );
 
-create table if not exists policy_group_mappings (
-    mapping_id                  int             not null    auto_increment primary key comment '정책 타입 매핑 id',
-    policy_id                 int             not null    comment '정책번호',
-    policy_groups_id             int             not null    comment '정책 그룹 번호',
-    foreign key (policy_id) references policies(policy_id),
-    foreign key (policy_groups_id) references policy_groups(policy_groups_id)
+create table if not exists policy_group_mappings
+(
+    mapping_id       int not null auto_increment primary key comment '정책 타입 매핑 id',
+    policy_id        int not null comment '정책번호',
+    policy_groups_id int not null comment '정책 그룹 번호',
+    foreign key (policy_id) references policies (policy_id),
+    foreign key (policy_groups_id) references policy_groups (policy_groups_id)
 );
 
 create table if not exists post_report_subjects
@@ -408,7 +415,7 @@ create table if not exists preferred_exercises
     constraint FK_pe_type
         foreign key (exercise_id) references exercise_types (exercise_id),
     constraint check_preferred_exercise_skill_level
-        check (`preferred_exercise_skill_level` in ('BEGINNER','NOVICE','INTERMEDIATE','EXPERT'))
+        check (`preferred_exercise_skill_level` in ('BEGINNER', 'NOVICE', 'INTERMEDIATE', 'EXPERT'))
 );
 
 create table if not exists reports
@@ -421,7 +428,7 @@ create table if not exists reports
     report_processed_at       datetime                              null,
     report_processing_content varchar(500)                          null,
     constraint check_report_processing_status
-        check (`report_processing_status` in ('PENDING','PROCESSING','COMPLETED','REJECTED','POSTPONED'))
+        check (`report_processing_status` in ('PENDING', 'PROCESSING', 'COMPLETED', 'REJECTED', 'POSTPONED'))
 );
 
 create table if not exists comment_reports
@@ -464,6 +471,42 @@ create table if not exists post_reports
         foreign key (post_id) references posts (post_id),
     constraint FK_reports_TO_post_reports_1
         foreign key (report_id) references reports (report_id)
+);
+
+create table if not exists custom_timers
+(
+    `custom_timer_id`         bigint       not null auto_increment primary key,
+    `member_id`               char(36)   not null comment 'UUID_SELF',
+    `custom_timer_name`       varchar(100) null,
+    `custom_timer_created_at` datetime     not null default current_timestamp,
+    `custom_timer_updated_at` datetime     null     default current_timestamp,
+    `custom_timer_deleted_at` datetime     null     default current_timestamp,
+    foreign key (`member_id`) references `members` (`member_id`)
+);
+
+create table if not exists simple_timers
+(
+    `simple_timer_id`            bigint     not null auto_increment primary key ,
+    `member_id`                  char(36) not null comment 'UUID_SELF',
+    `simple_timer_created_at`    datetime   not null default current_timestamp,
+    `simple_timer_updated_at`    datetime   null     default current_timestamp,
+    `simple_timer_deleted_at`    datetime   null     default current_timestamp,
+    `simple_timer_order` tinyint    null,
+    `simple_timer_time`  integer    null,
+    foreign key (`member_id`) references `members` (`member_id`)
+);
+
+create table if not exists custom_timer_steps
+(
+    `custom_timer_steps_id`         bigint      not null auto_increment primary key,
+    `custom_timer_id`               bigint      not null comment 'AUTO_INCREMENT',
+    `custom_timer_steps_name`       varchar(50) null,
+    `custom_timer_steps_order`      tinyint     not null,
+    `custom_timer_steps_time`       integer     not null,
+    `custom_timer_steps_created_at` datetime    not null default current_timestamp,
+    `custom_timer_steps_updated_at` datetime    null     default current_timestamp,
+    `custom_timer_steps_deleted_at` datetime    null     default current_timestamp,
+    foreign key (`custom_timer_id`) references `custom_timers` (`custom_timer_id`)
 );
 
 CREATE TRIGGER before_insert_members
@@ -537,16 +580,16 @@ VALUES
     ('PENALTY_INACTIVITY_THRESHOLD_DAYS', '7', 'DAYS', '페널티가 시작되는 비활성 기준일 (이 기간 이상 운동 기록이 없을 경우)'),
     ('PENALTY_SCORE_DECREMENT_POINTS', '1', 'POINTS', '비활성 상태일 때 매일 차감되는 점수');
 
-INSERT INTO policy_groups (policy_groups_name) VALUES ('exercise-score');
+INSERT INTO policy_groups (policy_groups_name)
+VALUES ('exercise-score');
 
 INSERT INTO policy_group_mappings (policy_id, policy_groups_id)
-SELECT
-    p.policy_id, -- (A) 조회된 각 정책의 ID
-    (SELECT pg.policy_groups_id FROM policy_groups pg WHERE pg.policy_groups_name = 'exercise-score') -- (B) 'exercise-score' 그룹의 ID
-FROM
-    policies p
-WHERE
-    p.policy_key IN (
+SELECT p.policy_id,                                     -- (A) 조회된 각 정책의 ID
+       (SELECT pg.policy_groups_id
+        FROM policy_groups pg
+        WHERE pg.policy_groups_name = 'exercise-score') -- (B) 'exercise-score' 그룹의 ID
+FROM policies p
+WHERE p.policy_key IN (
                        'EXERCISE_SCORE_MAX_POINTS',
                        'EXERCISE_SCORE_MIN_POINTS',
                        'SIGNUP_INITIAL_POINTS',
@@ -555,15 +598,19 @@ WHERE
                        'EXERCISE_RECORD_MAX_PER_DAY',
                        'PENALTY_INACTIVITY_THRESHOLD_DAYS',
                        'PENALTY_SCORE_DECREMENT_POINTS'
-        )
+    )
   -- 이미 매핑된 데이터는 중복 삽입하지 않도록 방지하는 로직
-  AND NOT EXISTS (
-    SELECT 1 FROM policy_group_mappings pgm
-    WHERE pgm.policy_id = p.policy_id
-      AND pgm.policy_groups_id = (SELECT pg.policy_groups_id FROM policy_groups pg WHERE pg.policy_groups_name = 'exercise-score')
-);
+  AND NOT EXISTS (SELECT 1
+                  FROM policy_group_mappings pgm
+                  WHERE pgm.policy_id = p.policy_id
+                    AND pgm.policy_groups_id = (SELECT pg.policy_groups_id
+                                                FROM policy_groups pg
+                                                WHERE pg.policy_groups_name = 'exercise-score'));
 
 -- 시퀀스 초기값 설정
-insert into BATCH_JOB_EXECUTION_SEQ (ID, UNIQUE_KEY) values (0, '0');
-insert into BATCH_JOB_SEQ (ID, UNIQUE_KEY) values (0, '0');
-insert into BATCH_STEP_EXECUTION_SEQ (ID, UNIQUE_KEY) values (0, '0');
+insert into BATCH_JOB_EXECUTION_SEQ (ID, UNIQUE_KEY)
+values (0, '0');
+insert into BATCH_JOB_SEQ (ID, UNIQUE_KEY)
+values (0, '0');
+insert into BATCH_STEP_EXECUTION_SEQ (ID, UNIQUE_KEY)
+values (0, '0');

--- a/src/main/java/com/project200/undabang/timer/custom/entity/CustomTimer.java
+++ b/src/main/java/com/project200/undabang/timer/custom/entity/CustomTimer.java
@@ -1,0 +1,43 @@
+package com.project200.undabang.timer.custom.entity;
+
+import com.project200.undabang.member.entity.Member;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Table(name = "custom_timers")
+public class CustomTimer {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "custom_timer_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id", nullable = false)
+    private Member member;
+
+    @Column(name = "custom_timer_name", length = 100)
+    private String customTimerName;
+
+    @Builder.Default
+    @Column(name = "custom_timer_created_at", nullable = false, updatable = false)
+    private LocalDateTime customTimerCreatedAt = LocalDateTime.now();
+
+    @Column(name = "custom_timer_updated_at")
+    private LocalDateTime customTimerUpdatedAt;
+
+    @Column(name = "custom_timer_deleted_at")
+    private LocalDateTime customTimerDeletedAt;
+
+    @Builder.Default
+    @OneToMany(mappedBy = "customTimer")
+    private List<CustomTimerStep> customTimerSteps = new ArrayList<>();
+}

--- a/src/main/java/com/project200/undabang/timer/custom/entity/CustomTimerStep.java
+++ b/src/main/java/com/project200/undabang/timer/custom/entity/CustomTimerStep.java
@@ -1,0 +1,43 @@
+package com.project200.undabang.timer.custom.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Table(name = "custom_timer_steps")
+public class CustomTimerStep {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "custom_timer_steps_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "custom_timer_id", nullable = false)
+    private CustomTimer customTimer;
+
+    @Column(name = "custom_timer_steps_name", length = 50)
+    private String name;
+
+    @Column(name = "custom_timer_steps_order", nullable = false)
+    private Integer order;
+
+    @Column(name = "custom_timer_steps_time", nullable = false)
+    private Integer time;
+
+    @Builder.Default
+    @Column(name = "custom_timer_steps_created_at", nullable = false, updatable = false)
+    private LocalDateTime customTimerStepCreatedAt = LocalDateTime.now();
+
+    @Column(name = "custom_timer_steps_updated_at")
+    private LocalDateTime customTimerStepUpdatedAt;
+
+    @Column(name = "custom_timer_steps_deleted_at")
+    private LocalDateTime customTimerStepDeletedAt;
+}

--- a/src/main/java/com/project200/undabang/timer/simple/entity/SimpleTimer.java
+++ b/src/main/java/com/project200/undabang/timer/simple/entity/SimpleTimer.java
@@ -1,0 +1,41 @@
+package com.project200.undabang.timer.simple.entity;
+
+import com.project200.undabang.member.entity.Member;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Table(name = "simple_timers")
+public class SimpleTimer {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "simple_timer_id")
+    private Long id;
+
+    @Column(name = "simple_timer_order")
+    private Integer simpleTimerOrder;
+
+    @Column(name = "simple_timer_time")
+    private Integer simpleTimerTime;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id", nullable = false)
+    private Member member;
+
+    @Builder.Default
+    @Column(name = "simple_timer_created_at", nullable = false, updatable = false)
+    private LocalDateTime simpleTimerCreatedAt = LocalDateTime.now();
+
+    @Column(name = "simple_timer_updated_at")
+    private LocalDateTime simpleTimerUpdatedAt;
+
+    @Column(name = "simple_timer_deleted_at")
+    private LocalDateTime simpleTimerDeletedAt;
+}


### PR DESCRIPTION
## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

이전에 설계한 ERD 바탕으로 SQL문을 추가하였고, 
패키지에 엔티티를 생성하였습니다.

## 💬리뷰 요구사항(선택)

> SQL 문서에서 IDE 정렬을 했더니, 전체 파일 수정이 되어버렸습니다. 실제 생성된 부분은
simple_timers, custom_timers, custom_timer_steps 부분입니다.
Drop_table 부분도 전체 삭제가 되는지 확인하였습니다.

해당 sql로 로컬 db 재생성시 문제가 발생하지 않았습니다.

엔티티를 만드는데 사용한 ERD는 연관된 이슈 198번으로 추가하였습니다.

패키지 설계는 다음과 같이 하였습니다. 
<img width="249" height="336" alt="image" src="https://github.com/user-attachments/assets/81fb0e23-c95e-4ab3-ad70-91508b959945" />

++ 
ERD 에는 update, delete 컬럼에 current_timestamp 를 디폴트로 놓고, 실제 SQL 도 그렇게 만들긴 하였으나...
코파일럿이 null 을 가지고 있다면, 해당 디폴트를 삭제하는것을 추천하여 일단 삭제하였습니다.

## #️⃣연관된 이슈

> ex) #198, Closes #206 