### PR TITLE
feat(타이머): 이전 정책 회의 기반으로 정책 테이블에 simple-timer 정책그룹 및 정책 추가 

### DIFF
--- a/documents/Undabang Database SQL.sql
+++ b/documents/Undabang Database SQL.sql
@@ -709,7 +709,7 @@ VALUES (3, 'simple-timer');
 -- SIMPLE_TIMER_INIT_VALUES 정책을 생성
 INSERT INTO policies (policy_id, policy_key, policy_value, policy_unit, policy_description)
 VALUES (15, 'SIMPLE_TIMER_INIT_VALUES', '{"init-counts": 6, "step": [{"no": 1, "seconds": 30}, {"no": 2, "seconds": 40}, {"no": 3, "seconds": 50}, {"no": 4, "seconds": 60}, {"no": 5, "seconds": 75}, {"no": 6, "seconds": 90}]}',
-        'SECONDS',  '심플 타이머의 초기 설정 값 (전체 JSON 구조로 저장. 회원 가입시 파싱해서 사용해야 함)');
+        'JSON',  '심플 타이머의 초기 설정 값 (전체 JSON 구조로 저장. 회원 가입시 파싱해서 사용해야 함)');
 
 INSERT INTO policy_group_mappings (policy_id, policy_groups_id)
 VALUES (15, 3);

--- a/documents/Undabang Database SQL.sql
+++ b/documents/Undabang Database SQL.sql
@@ -700,3 +700,16 @@ INSERT INTO scenario_message_mappings (scenario_id, message_id)
 VALUES (2, 2),
        (2, 3),
        (2, 4);
+
+
+-- 'simple-timer' 정책 그룹을 생성
+INSERT INTO policy_groups (policy_groups_id, policy_groups_name)
+VALUES (3, 'simple-timer');
+
+-- SIMPLE_TIMER_INIT_VALUES 정책을 생성
+INSERT INTO policies (policy_id, policy_key, policy_value, policy_unit, policy_description)
+VALUES (15, 'SIMPLE_TIMER_INIT_VALUES', '{"init-counts": 6, "step": [{"no": 1, "seconds": 30}, {"no": 2, "seconds": 40}, {"no": 3, "seconds": 50}, {"no": 4, "seconds": 60}, {"no": 5, "seconds": 75}, {"no": 6, "seconds": 90}]}',
+        'SECONDS',  '심플 타이머의 초기 설정 값 (전체 JSON 구조로 저장. 회원 가입시 파싱해서 사용해야 함)');
+
+INSERT INTO policy_group_mappings (policy_id, policy_groups_id)
+VALUES (15, 3);

--- a/src/main/java/com/project200/undabang/policy/entity/PolicyKey.java
+++ b/src/main/java/com/project200/undabang/policy/entity/PolicyKey.java
@@ -25,6 +25,6 @@ public enum PolicyKey {
     NOTIFICATION_SEND_TIME,                         // 알림을 보내는 시간 (24시간 형식, 예: 18시 = 18)
 
     // 심플 타이머
-    SIMPLE_TIMER_INIT_VALUES // 심플 타이머 초기값
+    SIMPLE_TIMER_INIT_VALUES, // 심플 타이머 초기값. 회원 가입시 추가해야 줘야 함
 
 }

--- a/src/main/java/com/project200/undabang/policy/entity/PolicyKey.java
+++ b/src/main/java/com/project200/undabang/policy/entity/PolicyKey.java
@@ -24,4 +24,7 @@ public enum PolicyKey {
     NOTIFICATION_SCORE_THRESHOLD_MIN,               // 회원 점수가 이 값 이하일 경우 더 이상 알림을 보내지 않음
     NOTIFICATION_SEND_TIME,                         // 알림을 보내는 시간 (24시간 형식, 예: 18시 = 18)
 
+    // 심플 타이머
+    SIMPLE_TIMER_INIT_VALUES // 심플 타이머 초기값
+
 }

--- a/src/main/java/com/project200/undabang/policy/entity/PolicyKey.java
+++ b/src/main/java/com/project200/undabang/policy/entity/PolicyKey.java
@@ -25,6 +25,6 @@ public enum PolicyKey {
     NOTIFICATION_SEND_TIME,                         // 알림을 보내는 시간 (24시간 형식, 예: 18시 = 18)
 
     // 심플 타이머
-    SIMPLE_TIMER_INIT_VALUES, // 심플 타이머 초기값. 회원 가입시 추가해야 줘야 함
+    SIMPLE_TIMER_INIT_VALUES, // 심플 타이머 초기값. 회원 가입시 추가해줘야 함
 
 }


### PR DESCRIPTION
## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

이전 정책 회의를 바탕으로 

정책그룹 : simple-timer
정책명 : simple-timer-init-values
정책값 : json
정책단위 : seconds
정책설명 : "심플 타이머의 초기 설정 값"

해당 내용을 담고있는 SQL문을 추가하였습니다. 
또한 POLICY 정책 추가 후, 로컬에서 정상 동작을 확인하였습니다.

++ 
정확히 기억이 나지 않아서, 정리한 내용 기반으로 정책을 생성하였습니다.
최대, 최소값은 필요하면 정책에 추가하도록 하겠습니다.

## #️⃣연관된 이슈

> (참고) 회의 내용 : #202 
> Closes #202 