### PR TITLE
[Feat] 심플 타이머 조회 기능 개발

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ plugins {
 }
 
 group = 'com.project200'
-version = '0.2.2-SNAPSHOT'
+version = '0.2.3-SNAPSHOT'
 
 java {
     toolchain {

--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -132,3 +132,7 @@ include::overview/공통-개발-참고-사항.adoc[]
 === xref:정책-API.html[정책 API]
 
 - 정책 그룹 조회 API #GET# `/open/v1/policy-groups/{groupName}/policies`
+
+=== xref:심플-타이머API.html[심플 타이머 API]
+
+- 심플 타이머 조회 API #GET# `/api/v1/simple-timers`

--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -133,6 +133,6 @@ include::overview/공통-개발-참고-사항.adoc[]
 
 - 정책 그룹 조회 API #GET# `/open/v1/policy-groups/{groupName}/policies`
 
-=== xref:심플-타이머API.html[심플 타이머 API]
+=== xref:심플-타이머-API.html[심플 타이머 API]
 
 - 심플 타이머 조회 API #GET# `/api/v1/simple-timers`

--- a/src/docs/asciidoc/simple-timer/심플-타이머-조회-API.adoc
+++ b/src/docs/asciidoc/simple-timer/심플-타이머-조회-API.adoc
@@ -1,0 +1,31 @@
+== 심플 타이머 조회 API
+
+=== 설명
+
+- #GET# `/api/v1/simple-timers`
+- 심플 타이머 조회 API는 사용자가 자신이 저장한 심플 타이머 정보를 조회하는 기능을 제공합니다.
+
+=== 개발 이력
+
+- Sprint 9 (2025-08-11): 기능 개발이 완료되었습니다.
+
+=== 개발 참고 사항
+
+- <<공통-개발-참고-사항,공통 개발 참고 사항>>을 참고하세요.
+
+=== 코드 샘플
+
+operation::get-simple-timer/get-simple-timers[snippets="curl-request,http-request,http-response"]
+
+=== 매개 변수
+
+operation::get-simple-timer/get-simple-timers[snippets="request-headers,response-fields"]
+
+==== 응답 상태 코드
+
+|===
+|상태 코드|설명
+|200|심플 타이머 정보가 성공적으로 조회되었습니다.
+|404|회원 정보가 올바르지 않습니다.
+|===
+

--- a/src/docs/asciidoc/심플-타이머-API.adoc
+++ b/src/docs/asciidoc/심플-타이머-API.adoc
@@ -1,0 +1,21 @@
+= 심플 타이머 API
+:doctype: book
+:source-highlighter: highlightjs
+:toc: left
+:toclevels: 3
+:seclinks:
+
+:operation-request-headers-title: 요청 헤더
+:operation-path-parameters-title: 경로 매개 변수
+:operation-request-parts-title: 요청 파트(Form Data)
+:operation-request-fields-title: 요청 필드
+:operation-response-fields-title: 응답 필드
+:operation-curl-request-title: Curl 요청 예시
+:operation-http-request-title: HTTP 요청 예시
+:operation-http-response-title: HTTP 응답 예시
+
+[[공통-개발-참고-사항]]
+== 공통 개발 참고 사항
+include::overview/공통-개발-참고-사항.adoc[]
+
+include::simple-timer/심플-타이머-조회-API.adoc[]

--- a/src/main/java/com/project200/undabang/timer/simple/controller/SimpleTimerQueryController.java
+++ b/src/main/java/com/project200/undabang/timer/simple/controller/SimpleTimerQueryController.java
@@ -1,11 +1,23 @@
 package com.project200.undabang.timer.simple.controller;
 
+import com.project200.undabang.common.web.response.CommonResponse;
+import com.project200.undabang.timer.simple.dto.GetSimpleTimerResponseDto;
+import com.project200.undabang.timer.simple.service.SimpleTimerQueryService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/v1")
+@RequestMapping("/api")
 public class SimpleTimerQueryController {
+    private final SimpleTimerQueryService simpleTimerQueryService;
+
+    @GetMapping("/v1/simple-timers")
+    public ResponseEntity<CommonResponse<GetSimpleTimerResponseDto>> getSimpleTimers() {
+        GetSimpleTimerResponseDto responseDto = simpleTimerQueryService.getSimpleTimers();
+        return ResponseEntity.ok(CommonResponse.success(responseDto));
+    }
 }

--- a/src/main/java/com/project200/undabang/timer/simple/controller/SimpleTimerQueryController.java
+++ b/src/main/java/com/project200/undabang/timer/simple/controller/SimpleTimerQueryController.java
@@ -17,7 +17,6 @@ public class SimpleTimerQueryController {
 
     @GetMapping("/v1/simple-timers")
     public ResponseEntity<CommonResponse<GetSimpleTimerResponseDto>> getSimpleTimers() {
-        GetSimpleTimerResponseDto responseDto = simpleTimerQueryService.getSimpleTimers();
-        return ResponseEntity.ok(CommonResponse.success(responseDto));
+        return ResponseEntity.ok(CommonResponse.success(simpleTimerQueryService.getSimpleTimers()));
     }
 }

--- a/src/main/java/com/project200/undabang/timer/simple/controller/SimpleTimerQueryController.java
+++ b/src/main/java/com/project200/undabang/timer/simple/controller/SimpleTimerQueryController.java
@@ -1,0 +1,11 @@
+package com.project200.undabang.timer.simple.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1")
+public class SimpleTimerQueryController {
+}

--- a/src/main/java/com/project200/undabang/timer/simple/dto/GetSimpleTimerResponseDto.java
+++ b/src/main/java/com/project200/undabang/timer/simple/dto/GetSimpleTimerResponseDto.java
@@ -13,7 +13,8 @@ import java.util.List;
 @AllArgsConstructor
 public class GetSimpleTimerResponseDto {
     public int simpleTimerCount;
-    public List<SimpleTimerRecord> simpleTimers;
+    private int simpleTimerCount;
+    private List<SimpleTimerRecord> simpleTimers;
 
     public static GetSimpleTimerResponseDto of(List<SimpleTimerRecord> simpleTimers){
         return GetSimpleTimerResponseDto.builder()

--- a/src/main/java/com/project200/undabang/timer/simple/dto/GetSimpleTimerResponseDto.java
+++ b/src/main/java/com/project200/undabang/timer/simple/dto/GetSimpleTimerResponseDto.java
@@ -12,7 +12,6 @@ import java.util.List;
 @NoArgsConstructor
 @AllArgsConstructor
 public class GetSimpleTimerResponseDto {
-    public int simpleTimerCount;
     private int simpleTimerCount;
     private List<SimpleTimerRecord> simpleTimers;
 

--- a/src/main/java/com/project200/undabang/timer/simple/dto/GetSimpleTimerResponseDto.java
+++ b/src/main/java/com/project200/undabang/timer/simple/dto/GetSimpleTimerResponseDto.java
@@ -1,0 +1,24 @@
+package com.project200.undabang.timer.simple.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class GetSimpleTimerResponseDto {
+    public int simpleTimerCount;
+    public List<SimpleTimerRecord> simpleTimers;
+
+    public static GetSimpleTimerResponseDto of(List<SimpleTimerRecord> simpleTimers){
+        return GetSimpleTimerResponseDto.builder()
+                .simpleTimerCount(simpleTimers.size())
+                .simpleTimers(simpleTimers)
+                .build();
+    }
+}

--- a/src/main/java/com/project200/undabang/timer/simple/dto/SimpleTimerRecord.java
+++ b/src/main/java/com/project200/undabang/timer/simple/dto/SimpleTimerRecord.java
@@ -1,0 +1,11 @@
+package com.project200.undabang.timer.simple.dto;
+
+import com.project200.undabang.timer.simple.entity.SimpleTimer;
+
+public record SimpleTimerRecord(Long simpleTimerId, byte order, int time) {
+    public static SimpleTimerRecord from(SimpleTimer simpleTimer){
+        return new SimpleTimerRecord(
+          simpleTimer.getId(), simpleTimer.getSimpleTimerOrder(), simpleTimer.getSimpleTimerTime()
+        );
+    }
+}

--- a/src/main/java/com/project200/undabang/timer/simple/repository/SimpleTimerRepository.java
+++ b/src/main/java/com/project200/undabang/timer/simple/repository/SimpleTimerRepository.java
@@ -1,0 +1,4 @@
+package com.project200.undabang.timer.simple.repository;
+
+public interface SimpleTimerRepository {
+}

--- a/src/main/java/com/project200/undabang/timer/simple/repository/SimpleTimerRepository.java
+++ b/src/main/java/com/project200/undabang/timer/simple/repository/SimpleTimerRepository.java
@@ -1,4 +1,11 @@
 package com.project200.undabang.timer.simple.repository;
 
-public interface SimpleTimerRepository {
+import com.project200.undabang.member.entity.Member;
+import com.project200.undabang.timer.simple.entity.SimpleTimer;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface SimpleTimerRepository extends JpaRepository<SimpleTimer, Long> {
+    List<SimpleTimer> findByMember(Member member);
 }

--- a/src/main/java/com/project200/undabang/timer/simple/service/SimpleTimerQueryService.java
+++ b/src/main/java/com/project200/undabang/timer/simple/service/SimpleTimerQueryService.java
@@ -1,4 +1,7 @@
 package com.project200.undabang.timer.simple.service;
 
+import com.project200.undabang.timer.simple.dto.GetSimpleTimerResponseDto;
+
 public interface SimpleTimerQueryService {
+    GetSimpleTimerResponseDto getSimpleTimers();
 }

--- a/src/main/java/com/project200/undabang/timer/simple/service/SimpleTimerQueryService.java
+++ b/src/main/java/com/project200/undabang/timer/simple/service/SimpleTimerQueryService.java
@@ -1,0 +1,4 @@
+package com.project200.undabang.timer.simple.service;
+
+public interface SimpleTimerQueryService {
+}

--- a/src/main/java/com/project200/undabang/timer/simple/service/impl/SimpleTimerQueryServiceImpl.java
+++ b/src/main/java/com/project200/undabang/timer/simple/service/impl/SimpleTimerQueryServiceImpl.java
@@ -15,9 +15,9 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 @Slf4j
 @Service
@@ -39,15 +39,10 @@ public class SimpleTimerQueryServiceImpl implements SimpleTimerQueryService {
     }
 
     private GetSimpleTimerResponseDto createSimpleTimerResponse(List<SimpleTimer> simpleTimerList){
-        List<SimpleTimerRecord> simpleTimerRecordList = new ArrayList<>();
-
-        for (SimpleTimer simpleTimer : simpleTimerList) {
-            SimpleTimerRecord record = SimpleTimerRecord.from(simpleTimer);
-            simpleTimerRecordList.add(record);
-        }
         List<SimpleTimerRecord> simpleTimerRecordList = simpleTimerList.stream()
                 .map(SimpleTimerRecord::from)
                 .collect(Collectors.toList());
+
         return GetSimpleTimerResponseDto.of(simpleTimerRecordList);
     }
 }

--- a/src/main/java/com/project200/undabang/timer/simple/service/impl/SimpleTimerQueryServiceImpl.java
+++ b/src/main/java/com/project200/undabang/timer/simple/service/impl/SimpleTimerQueryServiceImpl.java
@@ -45,7 +45,9 @@ public class SimpleTimerQueryServiceImpl implements SimpleTimerQueryService {
             SimpleTimerRecord record = SimpleTimerRecord.from(simpleTimer);
             simpleTimerRecordList.add(record);
         }
-
+        List<SimpleTimerRecord> simpleTimerRecordList = simpleTimerList.stream()
+                .map(SimpleTimerRecord::from)
+                .collect(Collectors.toList());
         return GetSimpleTimerResponseDto.of(simpleTimerRecordList);
     }
 }

--- a/src/main/java/com/project200/undabang/timer/simple/service/impl/SimpleTimerQueryServiceImpl.java
+++ b/src/main/java/com/project200/undabang/timer/simple/service/impl/SimpleTimerQueryServiceImpl.java
@@ -1,0 +1,12 @@
+package com.project200.undabang.timer.simple.service.impl;
+
+import com.project200.undabang.timer.simple.service.SimpleTimerQueryService;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@Transactional(readOnly = true)
+public class SimpleTimerQueryServiceImpl implements SimpleTimerQueryService {
+}

--- a/src/main/java/com/project200/undabang/timer/simple/service/impl/SimpleTimerQueryServiceImpl.java
+++ b/src/main/java/com/project200/undabang/timer/simple/service/impl/SimpleTimerQueryServiceImpl.java
@@ -1,12 +1,51 @@
 package com.project200.undabang.timer.simple.service.impl;
 
+import com.project200.undabang.common.context.UserContextHolder;
+import com.project200.undabang.common.web.exception.CustomException;
+import com.project200.undabang.common.web.exception.ErrorCode;
+import com.project200.undabang.member.entity.Member;
+import com.project200.undabang.member.repository.MemberRepository;
+import com.project200.undabang.timer.simple.dto.GetSimpleTimerResponseDto;
+import com.project200.undabang.timer.simple.dto.SimpleTimerRecord;
+import com.project200.undabang.timer.simple.entity.SimpleTimer;
+import com.project200.undabang.timer.simple.repository.SimpleTimerRepository;
 import com.project200.undabang.timer.simple.service.SimpleTimerQueryService;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
 @Slf4j
 @Service
 @Transactional(readOnly = true)
+@RequiredArgsConstructor
 public class SimpleTimerQueryServiceImpl implements SimpleTimerQueryService {
+    private final SimpleTimerRepository simpleTimerRepository;
+    private final MemberRepository memberRepository;
+
+    @Override
+    public GetSimpleTimerResponseDto getSimpleTimers(){
+        UUID memberId = UserContextHolder.getUserId();
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new CustomException(ErrorCode.MEMBER_NOT_FOUND));
+
+        List<SimpleTimer> simpleTimerList = simpleTimerRepository.findByMember(member);
+
+        return createSimpleTimerResponse(simpleTimerList);
+    }
+
+    private GetSimpleTimerResponseDto createSimpleTimerResponse(List<SimpleTimer> simpleTimerList){
+        List<SimpleTimerRecord> simpleTimerRecordList = new ArrayList<>();
+
+        for (SimpleTimer simpleTimer : simpleTimerList) {
+            SimpleTimerRecord record = SimpleTimerRecord.from(simpleTimer);
+            simpleTimerRecordList.add(record);
+        }
+
+        return GetSimpleTimerResponseDto.of(simpleTimerRecordList);
+    }
 }

--- a/src/test/java/com/project200/undabang/timer/simple/controller/SimpleTimerQueryControllerTest.java
+++ b/src/test/java/com/project200/undabang/timer/simple/controller/SimpleTimerQueryControllerTest.java
@@ -41,7 +41,7 @@ class SimpleTimerQueryControllerTest extends AbstractRestDocSupport {
         public void getSimpleTimers() throws Exception{
             // given
             UUID memberId = UUID.randomUUID();
-            List<SimpleTimerRecord> recordList =createSimpleTimerRecordList(memberId);
+            List<SimpleTimerRecord> recordList =createSimpleTimerRecordList();
             GetSimpleTimerResponseDto expectedResponse = GetSimpleTimerResponseDto.builder()
                     .simpleTimerCount(recordList.size())
                     .simpleTimers(recordList)

--- a/src/test/java/com/project200/undabang/timer/simple/controller/SimpleTimerQueryControllerTest.java
+++ b/src/test/java/com/project200/undabang/timer/simple/controller/SimpleTimerQueryControllerTest.java
@@ -75,9 +75,9 @@ class SimpleTimerQueryControllerTest extends AbstractRestDocSupport {
                                     fieldWithPath("data.simpleTimers[].simpleTimerId").type(NUMBER)
                                             .description("심플 타이머의 식별자 정보 입니다."),
                                     fieldWithPath("data.simpleTimers[].order").type(NUMBER)
-                                            .description("심플 타이머의 순서 정보 입니다"),
+                                            .description("심플 타이머의 순서 정보 입니다."),
                                     fieldWithPath("data.simpleTimers[].time").type(NUMBER)
-                                            .description("심플 타이머의 시간 정보 입니다.")
+                                            .description("심플 타이머의 시간 정보 입니다. 단위는 초 입니다.")
                             ))
                     ));
 

--- a/src/test/java/com/project200/undabang/timer/simple/controller/SimpleTimerQueryControllerTest.java
+++ b/src/test/java/com/project200/undabang/timer/simple/controller/SimpleTimerQueryControllerTest.java
@@ -1,0 +1,126 @@
+package com.project200.undabang.timer.simple.controller;
+
+import com.project200.undabang.common.web.exception.ErrorCode;
+import com.project200.undabang.configuration.AbstractRestDocSupport;
+import com.project200.undabang.timer.simple.dto.GetSimpleTimerResponseDto;
+import com.project200.undabang.timer.simple.dto.SimpleTimerRecord;
+import com.project200.undabang.timer.simple.service.SimpleTimerQueryService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.mockito.BDDMockito;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+
+import java.util.List;
+import java.util.UUID;
+
+import static com.project200.undabang.configuration.HeadersGenerator.getCommonApiHeaders;
+import static com.project200.undabang.configuration.RestDocsUtils.HEADER_ACCESS_TOKEN;
+import static com.project200.undabang.configuration.RestDocsUtils.commonResponseFields;
+import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
+import static org.springframework.restdocs.payload.JsonFieldType.ARRAY;
+import static org.springframework.restdocs.payload.JsonFieldType.NUMBER;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(SimpleTimerQueryController.class)
+class SimpleTimerQueryControllerTest extends AbstractRestDocSupport {
+
+    @MockitoBean
+    private SimpleTimerQueryService simpleTimerQueryService;
+
+    @Nested
+    class GetSimpleTimer{
+        @Test
+        @DisplayName("회원의 심플 타이머 목록을 성공적으로 조회한다")
+        public void getSimpleTimers() throws Exception{
+            // given
+            UUID memberId = UUID.randomUUID();
+            List<SimpleTimerRecord> recordList =createSimpleTimerRecordList(memberId);
+            GetSimpleTimerResponseDto expectedResponse = GetSimpleTimerResponseDto.builder()
+                    .simpleTimerCount(recordList.size())
+                    .simpleTimers(recordList)
+                    .build();
+
+            BDDMockito.given(simpleTimerQueryService.getSimpleTimers()).willReturn(expectedResponse);
+
+            // when
+            mockMvc.perform(get("/api/v1/simple-timers")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .accept(MediaType.APPLICATION_JSON)
+                    .headers(getCommonApiHeaders(memberId)))
+                    .andExpectAll(
+                            status().isOk(),
+                            jsonPath("$.succeed").value(true),
+                            jsonPath("$.code").value("SUCCESS"),
+                            jsonPath("$.message").value("요청이 성공적으로 처리되었습니다."),
+                            jsonPath("$.data.simpleTimerCount").value(expectedResponse.getSimpleTimerCount()),
+                            jsonPath("$.data.simpleTimers").isArray(),
+                            jsonPath("$.data.simpleTimers[0].simpleTimerId").value(recordList.get(0).simpleTimerId()),
+                            jsonPath("$.data.simpleTimers[0].order").value((int) recordList.get(0).order()),
+                            jsonPath("$.data.simpleTimers[0].time").value(recordList.get(0).time())
+                    )
+                    .andDo(document.document(
+                            requestHeaders(HEADER_ACCESS_TOKEN),
+                            responseFields(commonResponseFields(
+                                    fieldWithPath("data.simpleTimerCount").type(NUMBER)
+                                            .description("심플 타이머 리스트의 크기를 담고있는 데이터 입니다."),
+                                    fieldWithPath("data.simpleTimers").type(ARRAY)
+                                            .description("심플 타이머 리스트 입니다. 내용에는 식별자, 순서, 시간이 포함됩니다."),
+                                    fieldWithPath("data.simpleTimers[].simpleTimerId").type(NUMBER)
+                                            .description("심플 타이머의 식별자 정보 입니다."),
+                                    fieldWithPath("data.simpleTimers[].order").type(NUMBER)
+                                            .description("심플 타이머의 순서 정보 입니다"),
+                                    fieldWithPath("data.simpleTimers[].time").type(NUMBER)
+                                            .description("심플 타이머의 시간 정보 입니다.")
+                            ))
+                    ));
+
+            // then
+            BDDMockito.then(simpleTimerQueryService).should(BDDMockito.times(1)).getSimpleTimers();
+        }
+
+        @Test
+        @DisplayName("회원의 심플 타이머 조회에 실패했다")
+        public void getSimpleTimers_Fail() throws Exception{
+            // given
+            UUID memberId = UUID.randomUUID();
+            BDDMockito.given(simpleTimerQueryService.getSimpleTimers())
+                    .willThrow(new com.project200.undabang.common.web.exception.CustomException(com.project200.undabang.common.web.exception.ErrorCode.MEMBER_NOT_FOUND));
+
+            // when & then
+            mockMvc.perform(get("/api/v1/simple-timers")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .accept(MediaType.APPLICATION_JSON)
+                            .headers(getCommonApiHeaders(memberId)))
+                    .andExpectAll(
+                            status().isNotFound(),
+                            jsonPath("$.succeed").value(false),
+                            jsonPath("$.code").value(ErrorCode.MEMBER_NOT_FOUND.getCode()),
+                            jsonPath("$.message").value(ErrorCode.MEMBER_NOT_FOUND.getMessage())
+                    );
+
+            // then
+            BDDMockito.then(simpleTimerQueryService).should(BDDMockito.times(1)).getSimpleTimers();
+        }
+
+        private List<SimpleTimerRecord> createSimpleTimerRecordList(UUID memberId){
+            return List.of(
+                    new SimpleTimerRecord(1L, (byte) 1, 30),
+                    new SimpleTimerRecord(2L, (byte) 2, 40),
+                    new SimpleTimerRecord(3L, (byte) 3, 50),
+                    new SimpleTimerRecord(4L, (byte) 4, 60),
+                    new SimpleTimerRecord(5L, (byte) 5, 75),
+                    new SimpleTimerRecord(6L, (byte) 6, 90)
+            );
+        }
+    }
+
+
+
+}

--- a/src/test/java/com/project200/undabang/timer/simple/controller/SimpleTimerQueryControllerTest.java
+++ b/src/test/java/com/project200/undabang/timer/simple/controller/SimpleTimerQueryControllerTest.java
@@ -109,7 +109,7 @@ class SimpleTimerQueryControllerTest extends AbstractRestDocSupport {
             BDDMockito.then(simpleTimerQueryService).should(BDDMockito.times(1)).getSimpleTimers();
         }
 
-        private List<SimpleTimerRecord> createSimpleTimerRecordList(UUID memberId){
+        private List<SimpleTimerRecord> createSimpleTimerRecordList(){
             return List.of(
                     new SimpleTimerRecord(1L, (byte) 1, 30),
                     new SimpleTimerRecord(2L, (byte) 2, 40),

--- a/src/test/java/com/project200/undabang/timer/simple/repository/SimpleTimerRepositoryTest.java
+++ b/src/test/java/com/project200/undabang/timer/simple/repository/SimpleTimerRepositoryTest.java
@@ -1,0 +1,115 @@
+package com.project200.undabang.timer.simple.repository;
+
+import com.project200.undabang.configuration.TestQuerydslConfig;
+import com.project200.undabang.member.entity.Member;
+import com.project200.undabang.member.enums.MemberGender;
+import com.project200.undabang.member.repository.MemberRepository;
+import com.project200.undabang.timer.simple.entity.SimpleTimer;
+import jakarta.persistence.EntityManager;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DataJpaTest
+@Import(TestQuerydslConfig.class)
+class SimpleTimerRepositoryTest {
+
+    @Autowired
+    private EntityManager em;
+
+    @Autowired
+    private SimpleTimerRepository simpleTimerRepository;
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+
+    @Nested
+    @DisplayName("findByMember 메소드는")
+    class Describe_findByMember {
+
+        @Test
+        @DisplayName("특정 회원이 가지고 있는 심플 타이머 목록을 조회한다")
+        void it_returns_timers_for_the_given_member() {
+            // given
+            Member member1 = createAndSaveMember("testMember1");
+            Member member2 = createAndSaveMember("testMember2");
+
+            SimpleTimer timer1 = createAndSaveSimpleTimer(member1, (byte) 1, 30);
+            SimpleTimer timer2 = createAndSaveSimpleTimer(member1, (byte) 2, 40);
+            SimpleTimer timer3 = createAndSaveSimpleTimer(member1, (byte) 3, 50);
+            SimpleTimer timer4 = createAndSaveSimpleTimer(member1, (byte) 4, 60);
+            SimpleTimer timer5 = createAndSaveSimpleTimer(member1, (byte) 5, 75);
+            SimpleTimer timer6 = createAndSaveSimpleTimer(member1, (byte) 6, 90);
+
+            createAndSaveSimpleTimer(member2, (byte) 1, 300); // 다른 회원의 타이머
+
+            flushAndClear();
+
+            // when
+            List<SimpleTimer> foundTimers = simpleTimerRepository.findByMember(member1);
+
+            // then
+            Assertions.assertThat(foundTimers).hasSize(6);
+            Assertions.assertThat(foundTimers).extracting(SimpleTimer::getId)
+                    .containsExactlyInAnyOrder(timer1.getId(),
+                            timer2.getId(),
+                            timer3.getId(),
+                            timer4.getId(),
+                            timer5.getId(),
+                            timer6.getId());
+        }
+
+        @Test
+        @DisplayName("심플 타이머가 없는 회원을 조회하면 빈 리스트를 반환한다")
+        void it_returns_an_empty_list_when_no_timers_exist() {
+            // given
+            Member member = createAndSaveMember("testMember");
+            flushAndClear();
+
+            // when
+            List<SimpleTimer> foundTimers = simpleTimerRepository.findByMember(member);
+
+            // then
+            assertThat(foundTimers).isNotNull();
+            assertThat(foundTimers).isEmpty();
+        }
+    }
+
+    private Member createAndSaveMember(String nickname){
+        Member member = Member.builder()
+                .memberId(UUID.randomUUID())
+                .memberEmail(nickname + "@email.com")
+                .memberNickname(nickname)
+                .memberGender(MemberGender.UNKNOWN)
+                .memberBday(LocalDate.of(2000,1,1))
+                .build();
+        em.persist(member);
+        return member;
+    }
+
+    private SimpleTimer createAndSaveSimpleTimer(Member member, byte order, int time){
+        SimpleTimer timer = SimpleTimer.builder()
+                .member(member)
+                .simpleTimerOrder(order)
+                .simpleTimerTime(time)
+                .build();
+        em.persist(timer);
+        return timer;
+    }
+
+    private void flushAndClear(){
+        em.flush();
+        em.clear();
+    }
+}

--- a/src/test/java/com/project200/undabang/timer/simple/service/impl/SimpleTimerQueryServiceImplTest.java
+++ b/src/test/java/com/project200/undabang/timer/simple/service/impl/SimpleTimerQueryServiceImplTest.java
@@ -1,0 +1,95 @@
+package com.project200.undabang.timer.simple.service.impl;
+
+import com.project200.undabang.common.context.UserContextHolder;
+import com.project200.undabang.common.web.exception.CustomException;
+import com.project200.undabang.common.web.exception.ErrorCode;
+import com.project200.undabang.member.entity.Member;
+import com.project200.undabang.member.repository.MemberRepository;
+import com.project200.undabang.timer.simple.dto.GetSimpleTimerResponseDto;
+import com.project200.undabang.timer.simple.entity.SimpleTimer;
+import com.project200.undabang.timer.simple.repository.SimpleTimerRepository;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mockStatic;
+
+@ExtendWith(MockitoExtension.class)
+class SimpleTimerQueryServiceImplTest {
+
+    @Mock
+    private SimpleTimerRepository simpleTimerRepository;
+
+    @Mock
+    private MemberRepository memberRepository;
+
+    @InjectMocks
+    private SimpleTimerQueryServiceImpl simpleTimerQueryService;
+
+    @Nested
+    @DisplayName("getSimpleTimers() 메소드는")
+    class Describe_getSimpleTimers{
+        @Test
+        @DisplayName("유효한 사용자로 호출될 때, 회원의 심플 타이머 정보를 조합하여 반환한다")
+        void getSimpleTimers() {
+            // given
+            UUID testUserId = UUID.randomUUID();
+            Member testUser = Member.builder().memberId(testUserId).build();
+            List<SimpleTimer> simpleTimerList = createSimpleTimerList(testUser);
+
+            try(MockedStatic<UserContextHolder> ignored = mockStatic(UserContextHolder.class)){
+                given(UserContextHolder.getUserId()).willReturn(testUserId);
+                given(memberRepository.findById(testUserId)).willReturn(Optional.of(testUser));
+                given(simpleTimerRepository.findByMember(testUser)).willReturn(simpleTimerList);
+
+                // when
+                GetSimpleTimerResponseDto responseDto = simpleTimerQueryService.getSimpleTimers();
+
+                // then
+                Assertions.assertThat(responseDto).isNotNull();
+                Assertions.assertThat(responseDto.getSimpleTimerCount()).isEqualTo(simpleTimerList.size());
+                Assertions.assertThat(responseDto.getSimpleTimers()).hasSize(simpleTimerList.size());
+                Assertions.assertThat(responseDto.getSimpleTimers().get(0).simpleTimerId()).isEqualTo(simpleTimerList.get(0).getId());
+                Assertions.assertThat(responseDto.getSimpleTimers().get(0).order()).isEqualTo(simpleTimerList.get(0).getSimpleTimerOrder());
+                Assertions.assertThat(responseDto.getSimpleTimers().get(0).time()).isEqualTo(simpleTimerList.get(0).getSimpleTimerTime());
+            }
+        }
+
+        @Test
+        @DisplayName("사용자가 없을시 CustomException(MemberNotFound) 예외를 반환한다")
+        void getSimpleTimers_MemberNotFound() {
+            // given
+            UUID testUserId = UUID.randomUUID();
+            try(MockedStatic<UserContextHolder> ignored = mockStatic(UserContextHolder.class)){
+                given(UserContextHolder.getUserId()).willReturn(testUserId);
+                given(memberRepository.findById(testUserId)).willReturn(Optional.empty());
+
+                // when then
+                Assertions.assertThatThrownBy(() -> simpleTimerQueryService.getSimpleTimers())
+                        .isInstanceOf(CustomException.class)
+                        .hasFieldOrPropertyWithValue("errorCode", ErrorCode.MEMBER_NOT_FOUND);
+            }
+        }
+
+        private List<SimpleTimer> createSimpleTimerList(Member testUser){
+            return List.of(
+                    SimpleTimer.builder().id(1L).member(testUser).simpleTimerOrder((byte) 1).simpleTimerTime(30).build(),
+                    SimpleTimer.builder().id(2L).member(testUser).simpleTimerOrder((byte) 2).simpleTimerTime(60).build()
+            );
+        }
+    }
+
+
+
+}


### PR DESCRIPTION
## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

심플 타이머 조회 기능을 개발하였습니다.

응답값은 다음과 같습니다. // (조회값이 없는경우 빈 리스트를 반환합니다)
<img width="488" height="398" alt="image" src="https://github.com/user-attachments/assets/c4fb479f-f1dd-4a99-aac0-c32144a5b518" />

GetSimpleTimerResponseDto를 활용해 회원의 심플 타이머 갯수, 심플 타이머 내용을 반환하도록 하였습니다.
SimpleTimerRecord DTO를 사용해서 repository에서 가져오는 List<SimpleTimer> 값을 가공하였습니다. 

### 스크린샷 (선택)
자코코를 통해 테스트 커버리지가 100%임을 확인하였습니다.
<img width="1170" height="95" alt="image" src="https://github.com/user-attachments/assets/c6824f76-9ffd-4131-a3b8-d6ae81b57983" />

### 커밋 정보 
_(후 수정에 따라 살짝 변동사항이 있을 수 있습니다.)_

**f8c5fb4** 커밋을 통해 기능 개발을 완료하였습니다.
**3b0000d** 커밋을 통해 테스트 코드 작성을 완료하였습니다.
**eb6c768** 커밋을 통해 명세서 작성을 완료하였습니다.
**e5f286c** 커밋을 통해 코드 수정을 추가하였습니다.

> ex) #207 , Closes #216 