### PR TITLE
fix(심플타이머): simple-timers 테이블의 'order' 컬럼 제거로 인한 sql 및 엔티티 변경

### DIFF
--- a/documents/Undabang Database SQL.sql
+++ b/documents/Undabang Database SQL.sql
@@ -705,10 +705,18 @@ VALUES (2, 2),
 INSERT INTO policy_groups (policy_groups_id, policy_groups_name)
 VALUES (3, 'simple-timer');
 
--- SIMPLE_TIMER_INIT_VALUES 정책을 생성
+-- SIMPLE_TIMER_INIT_COUNT 정책을 생성
 INSERT INTO policies (policy_id, policy_key, policy_value, policy_unit, policy_description)
-VALUES (15, 'SIMPLE_TIMER_INIT_VALUES', '{"init-counts" : 6, "seconds" : [30,40,50,60,75,90]}',
-        'JSON',  '심플 타이머의 초기 설정 값 (전체 JSON 구조로 저장. 회원 가입시 파싱해서 사용해야 함)');
+VALUES (15, 'SIMPLE_TIMER_INIT_COUNT', '6',
+        'COUNT',  '심플 타이머의 초기 설정 갯수');
 
 INSERT INTO policy_group_mappings (policy_id, policy_groups_id)
 VALUES (15, 3);
+
+-- SIMPLE_TIMER_INIT_VALUES 정책을 생성
+INSERT INTO policies (policy_id, policy_key, policy_value, policy_unit, policy_description)
+VALUES (16, 'SIMPLE_TIMER_INIT_VALUES', '30,40,50,60,75,90',
+        'SECONDS',  '심플 타이머의 초기 설정 값. 회원 가입시 추가해서 사용해야 함');
+
+INSERT INTO policy_group_mappings (policy_id, policy_groups_id)
+VALUES (16, 3);

--- a/documents/Undabang Database SQL.sql
+++ b/documents/Undabang Database SQL.sql
@@ -490,7 +490,6 @@ create table if not exists simple_timers
 (
     simple_timer_id             bigint       not null auto_increment primary key ,
     member_id                   char(36)     not null comment 'UUID_SELF',
-    simple_timer_order          tinyint      null comment '심플 타이머 순서',
     simple_timer_time           int          null comment '심플 타이머 시간',
     simple_timer_created_at     datetime     not null default current_timestamp,
     simple_timer_updated_at     datetime     not null default current_timestamp ON UPDATE CURRENT_TIMESTAMP,
@@ -708,7 +707,7 @@ VALUES (3, 'simple-timer');
 
 -- SIMPLE_TIMER_INIT_VALUES 정책을 생성
 INSERT INTO policies (policy_id, policy_key, policy_value, policy_unit, policy_description)
-VALUES (15, 'SIMPLE_TIMER_INIT_VALUES', '{"init-counts": 6, "step": [{"no": 1, "seconds": 30}, {"no": 2, "seconds": 40}, {"no": 3, "seconds": 50}, {"no": 4, "seconds": 60}, {"no": 5, "seconds": 75}, {"no": 6, "seconds": 90}]}',
+VALUES (15, 'SIMPLE_TIMER_INIT_VALUES', '{"init-counts" : 6, "seconds" : [30,40,50,60,75,90]}',
         'JSON',  '심플 타이머의 초기 설정 값 (전체 JSON 구조로 저장. 회원 가입시 파싱해서 사용해야 함)');
 
 INSERT INTO policy_group_mappings (policy_id, policy_groups_id)

--- a/src/main/java/com/project200/undabang/policy/entity/PolicyKey.java
+++ b/src/main/java/com/project200/undabang/policy/entity/PolicyKey.java
@@ -25,6 +25,7 @@ public enum PolicyKey {
     NOTIFICATION_SEND_TIME,                         // 알림을 보내는 시간 (24시간 형식, 예: 18시 = 18)
 
     // 심플 타이머
-    SIMPLE_TIMER_INIT_VALUES, // 심플 타이머 초기값. 회원 가입시 추가해줘야 함
+    SIMPLE_TIMER_INIT_COUNT, // 심플 타이머 초기 생성 갯수
+    SIMPLE_TIMER_INIT_VALUES, // 심플 타이머 초기 값. 회원 가입시 추가해줘야 함
 
 }

--- a/src/main/java/com/project200/undabang/timer/simple/entity/SimpleTimer.java
+++ b/src/main/java/com/project200/undabang/timer/simple/entity/SimpleTimer.java
@@ -26,10 +26,6 @@ public class SimpleTimer {
     @JoinColumn(name = "member_id", nullable = false)
     private Member member;
 
-    @Comment("심플 타이머 순서")
-    @Column(name = "simple_timer_order")
-    private Byte simpleTimerOrder;
-
     @Comment("심플 타이머 시간")
     @Column(name = "simple_timer_time")
     private Integer simpleTimerTime;


### PR DESCRIPTION
## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

심플 타이머 테이블의 order 컬럼 삭제로 인한

1) sql 변경
2) 엔티티 변경
3) 정책 테이블에 들어갈 value 변경 을 진행하였습니다.

value값은 기존 json 형태에서 새로 제안하였습니다.

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> 
order 컬럼이 제거되면서, init-counts의 역할이 줄어든것 같다고 생각하였습니다.
하지만 그렇다고 init-counts를 제거하기보단, 명시적으로 갯수를 나타내기 위해 역할을 제거하지 않고 남겨두었습니다. 
혹시 제거하는게 더 좋을까요?

```json
{
    "init-counts" : 6,
    "seconds" : [30,40,50,60,75,90]
}
```


## #️⃣연관된 이슈

> ex) Closes #202