### PR TITLE
[Feat] 운동 독려 알림 기능 개발 - 7. 로그인/로그아웃 API 개발(0.2.3 -> 0.2.4)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ plugins {
 }
 
 group = 'com.project200'
-version = '0.2.3-SNAPSHOT'
+version = '0.2.4-SNAPSHOT'
 
 java {
     toolchain {

--- a/documents/Undabang Database SQL.sql
+++ b/documents/Undabang Database SQL.sql
@@ -57,16 +57,16 @@ create table if not exists BATCH_JOB_EXECUTION_SEQ
 
 create table if not exists BATCH_JOB_INSTANCE
 (
-    JOB_INSTANCE_ID bigint       not null   primary key,
+    JOB_INSTANCE_ID bigint not null primary key,
     VERSION         bigint       null,
     JOB_NAME        varchar(100) not null,
     JOB_KEY         varchar(32)  not null,
-    constraint JOB_INST_UN  unique (JOB_NAME, JOB_KEY)
+    constraint JOB_INST_UN unique (JOB_NAME, JOB_KEY)
 );
 
 create table if not exists BATCH_JOB_EXECUTION
 (
-    JOB_EXECUTION_ID           bigint        not null        primary key,
+    JOB_EXECUTION_ID bigint not null primary key,
     VERSION                    bigint        null,
     JOB_INSTANCE_ID            bigint        not null,
     CREATE_TIME                datetime(6)   not null,
@@ -224,15 +224,15 @@ create table if not exists exercises
 (
     exercise_id            bigint auto_increment
         primary key,
-    member_id              char(36)                                                     not null,
-    exercise_started_at    datetime default CURRENT_TIMESTAMP                           not null,
-    exercise_ended_at datetime default ((exercise_started_at + interval 1 hour)) not null,
-    exercise_detail        text                                                         null,
-    exercise_title         varchar(255)                                                 not null,
-    exercise_personal_type varchar(255)                                                 null comment '시스템이 아닌 개인 등록',
-    exercise_created_at    datetime default CURRENT_TIMESTAMP                           not null,
-    exercise_deleted_at    datetime                                                     null,
-    exercise_location      varchar(255)                                                 null,
+    member_id              char(36)                                                   not null,
+    exercise_started_at    datetime default CURRENT_TIMESTAMP                         not null,
+    exercise_ended_at      datetime default ((exercise_started_at + interval 1 hour)) not null,
+    exercise_detail        text                                                       null,
+    exercise_title         varchar(255)                                               not null,
+    exercise_personal_type varchar(255)                                               null comment '시스템이 아닌 개인 등록',
+    exercise_created_at    datetime default CURRENT_TIMESTAMP                         not null,
+    exercise_deleted_at    datetime                                                   null,
+    exercise_location      varchar(255)                                               null,
     constraint FK_ex_member
         foreign key (member_id) references members (member_id)
 );
@@ -305,29 +305,32 @@ create table if not exists member_pictures
         foreign key (picture_id) references pictures (picture_id)
 );
 
-create table if not exists policies (
-                                        policy_id          int          not null auto_increment primary key,
-                                        policy_key         varchar(100) not null unique comment '정책을 식별하는 키 (ex:SCORE_INITIAL)',
-                                        policy_value       varchar(255) null comment '정책 값',
-                                        policy_unit        varchar(20)  null comment '정책 값의 단위',
-                                        policy_description varchar(500) null comment '관리자 페이지에 표시될 정책 설명',
-                                        policy_updated_at  datetime     not null default current_timestamp comment '마지막 수정 일시',
-                                        policy_created_at  datetime     not null default current_timestamp comment '생성일시'
+create table if not exists policies
+(
+    policy_id          int          not null auto_increment primary key,
+    policy_key         varchar(100) not null unique comment '정책을 식별하는 키 (ex:SCORE_INITIAL)',
+    policy_value       varchar(255) null comment '정책 값',
+    policy_unit        varchar(20)  null comment '정책 값의 단위',
+    policy_description varchar(500) null comment '관리자 페이지에 표시될 정책 설명',
+    policy_updated_at  datetime     not null default current_timestamp comment '마지막 수정 일시',
+    policy_created_at  datetime     not null default current_timestamp comment '생성일시'
 );
 
-create table if not exists policy_groups (
-                                             policy_groups_id         int          not null auto_increment primary key,
-                                             policy_groups_name       varchar(100) not null unique comment '정책 타입 이름',
-                                             policy_groups_created_at datetime     not null default current_timestamp comment '생성일시',
-                                             policy_groups_updated_at datetime     not null default current_timestamp comment '수정일시'
+create table if not exists policy_groups
+(
+    policy_groups_id         int          not null auto_increment primary key,
+    policy_groups_name       varchar(100) not null unique comment '정책 타입 이름',
+    policy_groups_created_at datetime     not null default current_timestamp comment '생성일시',
+    policy_groups_updated_at datetime     not null default current_timestamp comment '수정일시'
 );
 
-create table if not exists policy_group_mappings (
-                                                     mapping_id       int not null auto_increment primary key comment '정책 타입 매핑 id',
-                                                     policy_id        int not null comment '정책번호',
-                                                     policy_groups_id int not null comment '정책 그룹 번호',
-                                                     foreign key (policy_id) references policies (policy_id),
-                                                     foreign key (policy_groups_id) references policy_groups (policy_groups_id)
+create table if not exists policy_group_mappings
+(
+    mapping_id       int not null auto_increment primary key comment '정책 타입 매핑 id',
+    policy_id        int not null comment '정책번호',
+    policy_groups_id int not null comment '정책 그룹 번호',
+    foreign key (policy_id) references policies (policy_id),
+    foreign key (policy_groups_id) references policy_groups (policy_groups_id)
 );
 
 create table if not exists post_report_subjects
@@ -477,23 +480,23 @@ create table if not exists post_reports
 
 create table if not exists custom_timers
 (
-    custom_timer_id         bigint          not null   auto_increment  primary key,
-    member_id               char(36)        not null comment 'UUID_SELF',
-    custom_timer_name       varchar(100)    null comment '커스텀 타이머 이름',
-    custom_timer_created_at datetime        not null default current_timestamp,
-    custom_timer_updated_at datetime        not null default current_timestamp ON UPDATE CURRENT_TIMESTAMP,
-    custom_timer_deleted_at datetime        null,
+    custom_timer_id         bigint       not null auto_increment primary key,
+    member_id               char(36)     not null comment 'UUID_SELF',
+    custom_timer_name       varchar(100) null comment '커스텀 타이머 이름',
+    custom_timer_created_at datetime     not null default current_timestamp,
+    custom_timer_updated_at datetime     not null default current_timestamp ON UPDATE CURRENT_TIMESTAMP,
+    custom_timer_deleted_at datetime     null,
     foreign key (member_id) references members (member_id)
 );
 
 create table if not exists simple_timers
 (
-    simple_timer_id             bigint       not null auto_increment primary key ,
-    member_id                   char(36)     not null comment 'UUID_SELF',
-    simple_timer_time           int          null comment '심플 타이머 시간',
-    simple_timer_created_at     datetime     not null default current_timestamp,
-    simple_timer_updated_at     datetime     not null default current_timestamp ON UPDATE CURRENT_TIMESTAMP,
-    simple_timer_deleted_at     datetime     null,
+    simple_timer_id         bigint   not null auto_increment primary key,
+    member_id               char(36) not null comment 'UUID_SELF',
+    simple_timer_time       int      null comment '심플 타이머 시간',
+    simple_timer_created_at datetime not null default current_timestamp,
+    simple_timer_updated_at datetime not null default current_timestamp ON UPDATE CURRENT_TIMESTAMP,
+    simple_timer_deleted_at datetime null,
     foreign key (member_id) references members (member_id)
 );
 
@@ -501,7 +504,7 @@ create table if not exists custom_timer_steps
 (
     custom_timer_steps_id         bigint      not null auto_increment primary key,
     custom_timer_id               bigint      not null comment 'AUTO_INCREMENT',
-    custom_timer_steps_name       varchar(50) null     comment '스텝 이름',
+    custom_timer_steps_name varchar(50) null comment '스텝 이름',
     custom_timer_steps_order      tinyint     not null comment '스텝 순서',
     custom_timer_steps_time       int         not null comment '스텝 시간',
     custom_timer_steps_created_at datetime    not null default current_timestamp,
@@ -595,9 +598,12 @@ VALUES (1, 1),
        (8, 1);
 
 -- 시퀀스 초기값 설정
-insert into BATCH_JOB_EXECUTION_SEQ (ID, UNIQUE_KEY) values (0, '0');
-insert into BATCH_JOB_SEQ (ID, UNIQUE_KEY) values (0, '0');
-insert into BATCH_STEP_EXECUTION_SEQ (ID, UNIQUE_KEY) values (0, '0');
+insert into BATCH_JOB_EXECUTION_SEQ (ID, UNIQUE_KEY)
+values (0, '0');
+insert into BATCH_JOB_SEQ (ID, UNIQUE_KEY)
+values (0, '0');
+insert into BATCH_STEP_EXECUTION_SEQ (ID, UNIQUE_KEY)
+values (0, '0');
 
 CREATE TABLE IF NOT EXISTS fcm_tokens
 (
@@ -605,6 +611,7 @@ CREATE TABLE IF NOT EXISTS fcm_tokens
     member_id              CHAR(36)     NOT NULL COMMENT 'UUID_SELF',
     fcm_token_value        VARCHAR(255) NOT NULL COMMENT 'FCM 토큰 값, unique',
     fcm_token_user_agent   VARCHAR(255) NULL COMMENT '디바이스 정보 (User Agent)',
+    fcm_token_is_active BOOLEAN NOT NULL DEFAULT TRUE COMMENT '토큰 활성화 여부',
     fcm_token_activated_at DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT '마지막 활성 일시',
     fcm_token_created_at   DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT '생성일시',
     fcm_token_deleted_at   DATETIME     NULL COMMENT '삭제일시',
@@ -708,7 +715,7 @@ VALUES (3, 'simple-timer');
 -- SIMPLE_TIMER_INIT_COUNT 정책을 생성
 INSERT INTO policies (policy_id, policy_key, policy_value, policy_unit, policy_description)
 VALUES (15, 'SIMPLE_TIMER_INIT_COUNT', '6',
-        'COUNT',  '심플 타이머의 초기 설정 갯수');
+        'COUNT', '심플 타이머의 초기 설정 갯수');
 
 INSERT INTO policy_group_mappings (policy_id, policy_groups_id)
 VALUES (15, 3);
@@ -716,7 +723,7 @@ VALUES (15, 3);
 -- SIMPLE_TIMER_INIT_VALUES 정책을 생성
 INSERT INTO policies (policy_id, policy_key, policy_value, policy_unit, policy_description)
 VALUES (16, 'SIMPLE_TIMER_INIT_VALUES', '30,40,50,60,75,90',
-        'SECONDS',  '심플 타이머의 초기 설정 값. 회원 가입시 추가해서 사용해야 함');
+        'SECONDS', '심플 타이머의 초기 설정 값. 회원 가입시 추가해서 사용해야 함');
 
 INSERT INTO policy_group_mappings (policy_id, policy_groups_id)
 VALUES (16, 3);

--- a/src/docs/asciidoc/auth/로그아웃-API.adoc
+++ b/src/docs/asciidoc/auth/로그아웃-API.adoc
@@ -1,0 +1,35 @@
+== 로그아웃 API
+
+=== 설명
+
+- #POST# `/api/v1/logout`
+- 사용자의 로그아웃을 처리하는 API입니다.
+요청 시 헤더에 포함된 FCM 토큰을 비활성화하여 더 이상 해당 기기로 푸시 알림이 전송되지 않도록 합니다.
+
+=== 개발 이력
+
+- Sprint 9 (2025-08-13): 기능 개발이 완료되었습니다.
+
+=== 개발 참고 사항
+
+- <<공통-개발-참고-사항,공통 개발 참고 사항>>을 참고하세요.
+
+=== 코드 샘플
+
+operation::logout/logout-member_-success_-with-fcm-token[snippets="curl-request,http-request,http-response"]
+
+=== 매개 변수
+
+operation::logout/logout-member_-success_-with-fcm-token[snippets="request-headers,response-fields"]
+
+==== 응답 상태 코드
+
+|===
+|상태 코드|설명
+|200|로그아웃에 성공했습니다.
+|401|로그아웃에 실패했습니다. 일치하는 회원을 찾을 수 없습니다.
+|===
+
+==== 실패 시 코드 샘플
+
+operation::logout/logout-member_-fail_-member-not-found[snippets="http-response"]

--- a/src/docs/asciidoc/auth/로그인-API.adoc
+++ b/src/docs/asciidoc/auth/로그인-API.adoc
@@ -1,0 +1,35 @@
+== 로그인 API
+
+=== 설명
+
+- #POST# `/api/v1/login`
+- 사용자의 로그인을 처리하는 API입니다.
+요청 시 FCM 토큰과 User-Agent 정보를 헤더에 담아 전송하면, 서버는 해당 토큰을 저장하여 푸시 알림에 사용합니다.
+
+=== 개발 이력
+
+- Sprint 9 (2025-08-13): 기능 개발이 완료되었습니다.
+
+=== 개발 참고 사항
+
+- <<공통-개발-참고-사항,공통 개발 참고 사항>>을 참고하세요.
+
+=== 코드 샘플
+
+operation::login/login-member_-success_-with-fcm-token[snippets="curl-request,http-request,http-response"]
+
+=== 매개 변수
+
+operation::login/login-member_-success_-with-fcm-token[snippets="request-headers,response-fields"]
+
+==== 응답 상태 코드
+
+|===
+|상태 코드|설명
+|200|로그인에 성공했습니다.
+|401|로그인에 실패했습니다. 일치하는 회원을 찾을 수 없습니다.
+|===
+
+==== 실패 시 코드 샘플
+
+operation::login/login-member_-fail_-member-not-found[snippets="http-response"]

--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -97,6 +97,10 @@ include::overview/공통-개발-참고-사항.adoc[]
 
 - 회원 등록 상태 조회 API #GET# `/auth/v1/registration-status`
 
+- 로그인 API #POST# `/api/v1/login`
+
+- 로그아웃 API #POST# `/api/v1/logout`
+
 === xref:회원-API.html[회원 API]
 
 - 회원 운동 점수 조회 API #GET# `/api/v1/members/score`

--- a/src/docs/asciidoc/인증-API.adoc
+++ b/src/docs/asciidoc/인증-API.adoc
@@ -21,3 +21,7 @@ include::overview/공통-개발-참고-사항.adoc[]
 include::auth/회원-가입-API.adoc[]
 
 include::auth/회원-등록-상태-조회-API.adoc[]
+
+include::auth/로그인-API.adoc[]
+
+include::auth/로그아웃-API.adoc[]

--- a/src/main/java/com/project200/undabang/auth/controller/AuthController.java
+++ b/src/main/java/com/project200/undabang/auth/controller/AuthController.java
@@ -1,0 +1,49 @@
+package com.project200.undabang.auth.controller;
+
+import com.project200.undabang.auth.service.AuthService;
+import com.project200.undabang.common.web.response.CommonResponse;
+import com.project200.undabang.common.web.response.SuccessDetails;
+import com.project200.undabang.member.entity.Member;
+import com.project200.undabang.push_message.service.FcmTokenCommandService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.Objects;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1")
+public class AuthController {
+
+    private final AuthService authService;
+
+    private final FcmTokenCommandService fcmTokenCommandService;
+
+    @ResponseStatus(HttpStatus.OK)
+    @PostMapping("/login")
+    public CommonResponse<Void> loginMember(@RequestHeader(value = "User-Agent", required = false) String userAgent,
+                                            @RequestHeader(value = "X-Fcm-Token", required = false) String fcmToken) {
+
+        Member member = authService.login();
+
+        if (Objects.nonNull(fcmToken) && !fcmToken.isBlank()) {
+            fcmTokenCommandService.saveFcmToken(member, fcmToken, userAgent);
+        }
+
+        return CommonResponse.success(new SuccessDetails("LOGIN_SUCCESS", "로그인 성공"));
+    }
+
+    @ResponseStatus(HttpStatus.OK)
+    @PostMapping("/logout")
+    public CommonResponse<Void> logoutMember(@RequestHeader(value = "X-Fcm-Token", required = false) String fcmToken) {
+
+        Member member = authService.logout();
+
+        if (Objects.nonNull(fcmToken) && !fcmToken.isBlank()) {
+            fcmTokenCommandService.deactivateFcmToken(member, fcmToken);
+        }
+
+        return CommonResponse.success(new SuccessDetails("LOGOUT_SUCCESS", "로그아웃 성공"));
+    }
+}

--- a/src/main/java/com/project200/undabang/auth/dto/request/LoginRequestDto.java
+++ b/src/main/java/com/project200/undabang/auth/dto/request/LoginRequestDto.java
@@ -1,0 +1,4 @@
+package com.project200.undabang.auth.dto.request;
+
+public record LoginRequestDto(String fcmToken) {
+}

--- a/src/main/java/com/project200/undabang/auth/service/AuthService.java
+++ b/src/main/java/com/project200/undabang/auth/service/AuthService.java
@@ -1,0 +1,10 @@
+package com.project200.undabang.auth.service;
+
+import com.project200.undabang.member.entity.Member;
+
+public interface AuthService {
+
+    Member login();
+
+    Member logout();
+}

--- a/src/main/java/com/project200/undabang/auth/service/impl/AuthServiceImpl.java
+++ b/src/main/java/com/project200/undabang/auth/service/impl/AuthServiceImpl.java
@@ -1,0 +1,33 @@
+package com.project200.undabang.auth.service.impl;
+
+import com.project200.undabang.auth.service.AuthService;
+import com.project200.undabang.common.context.UserContextHolder;
+import com.project200.undabang.common.web.exception.CustomException;
+import com.project200.undabang.common.web.exception.ErrorCode;
+import com.project200.undabang.member.entity.Member;
+import com.project200.undabang.member.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class AuthServiceImpl implements AuthService {
+
+    private final MemberRepository memberRepository;
+
+    @Override
+    public Member login() {
+        return memberRepository.findByMemberIdAndMemberDeletedAtNull(UserContextHolder.getUserId())
+                .orElseThrow(() -> new CustomException(ErrorCode.LOGIN_FAILED));
+    }
+
+    @Override
+    public Member logout() {
+        return memberRepository.findByMemberIdAndMemberDeletedAtNull(UserContextHolder.getUserId())
+                .orElseThrow(() -> new CustomException(ErrorCode.LOGOUT_FAILED));
+    }
+}

--- a/src/main/java/com/project200/undabang/common/web/exception/ErrorCode.java
+++ b/src/main/java/com/project200/undabang/common/web/exception/ErrorCode.java
@@ -18,6 +18,8 @@ public enum ErrorCode {
     USER_ID_HEADER_MISSING(401, "USER_ID_HEADER_MISSING", "X-USER-ID 헤더가 누락되었습니다."),
     USER_EMAIL_HEADER_MISSING(401, "USER_EMAIL_HEADER_MISSING", "X-USER-EMAIL 헤더가 누락되었습니다."),
     INVALID_USER_ID_FORMAT(400, "INVALID_USER_ID_FORMAT", "X-USER-ID 헤더는 유효한 UUID 형식이어야 합니다."),
+    LOGIN_FAILED(401, "LOGIN_FAILED", "로그인에 실패했습니다. 일치하는 회원을 찾을 수 없습니다."),
+    LOGOUT_FAILED(401, "LOGOUT_FAILED", "로그아웃에 실패했습니다. 일치하는 회원을 찾을 수 없습니다."),
 
     // 사용자 관련 에러
     MEMBER_NOT_FOUND(404, "USER_NOT_FOUND", "해당 사용자를 찾을 수 없습니다."),

--- a/src/main/java/com/project200/undabang/push_message/entity/FcmToken.java
+++ b/src/main/java/com/project200/undabang/push_message/entity/FcmToken.java
@@ -52,13 +52,15 @@ public class FcmToken {
     @Builder.Default
     @NotNull
     @Comment("마지막 활성 일시")
-    @Column(name = "fcm_token_activated_at", nullable = false, columnDefinition = "DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP")
+    @ColumnDefault("CURRENT_TIMESTAMP")
+    @Column(name = "fcm_token_activated_at", nullable = false)
     private LocalDateTime fcmTokenActivatedAt = LocalDateTime.now();
 
     @Builder.Default
     @NotNull
     @Comment("생성일시")
-    @Column(name = "fcm_token_created_at", nullable = false, columnDefinition = "DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP")
+    @ColumnDefault("CURRENT_TIMESTAMP")
+    @Column(name = "fcm_token_created_at", nullable = false)
     private LocalDateTime fcmTokenCreatedAt = LocalDateTime.now();
 
     @Comment("삭제일시")

--- a/src/main/java/com/project200/undabang/push_message/entity/FcmToken.java
+++ b/src/main/java/com/project200/undabang/push_message/entity/FcmToken.java
@@ -72,6 +72,7 @@ public class FcmToken {
 
     public void deactivate() {
         this.fcmTokenIsActive = false;
+        this.fcmTokenActivatedAt = LocalDateTime.now();
     }
 
     public void delete() {

--- a/src/main/java/com/project200/undabang/push_message/entity/FcmToken.java
+++ b/src/main/java/com/project200/undabang/push_message/entity/FcmToken.java
@@ -1,5 +1,6 @@
-package com.project200.undabang.member.entity;
+package com.project200.undabang.push_message.entity;
 
+import com.project200.undabang.member.entity.Member;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
@@ -41,20 +42,49 @@ public class FcmToken {
     @Column(name = "fcm_token_user_agent")
     private String fcmTokenUserAgent;
 
+    @Builder.Default
+    @NotNull
+    @Comment("토큰 활성화 여부")
+    @ColumnDefault("1")
+    @Column(name = "fcm_token_is_active", nullable = false)
+    private Boolean fcmTokenIsActive = true;
+
+    @Builder.Default
     @NotNull
     @Comment("마지막 활성 일시")
-    @ColumnDefault("CURRENT_TIMESTAMP")
-    @Column(name = "fcm_token_activated_at", nullable = false)
-    private LocalDateTime fcmTokenActivatedAt;
+    @Column(name = "fcm_token_activated_at", nullable = false, columnDefinition = "DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP")
+    private LocalDateTime fcmTokenActivatedAt = LocalDateTime.now();
 
+    @Builder.Default
     @NotNull
     @Comment("생성일시")
-    @ColumnDefault("CURRENT_TIMESTAMP")
-    @Column(name = "fcm_token_created_at", nullable = false)
-    private LocalDateTime fcmTokenCreatedAt;
+    @Column(name = "fcm_token_created_at", nullable = false, columnDefinition = "DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP")
+    private LocalDateTime fcmTokenCreatedAt = LocalDateTime.now();
 
     @Comment("삭제일시")
     @Column(name = "fcm_token_deleted_at")
     private LocalDateTime fcmTokenDeletedAt;
+
+    public void activate() {
+        this.fcmTokenIsActive = true;
+        this.fcmTokenActivatedAt = LocalDateTime.now();
+    }
+
+    public void deactivate() {
+        this.fcmTokenIsActive = false;
+    }
+
+    public void delete() {
+        this.fcmTokenDeletedAt = LocalDateTime.now();
+        this.fcmTokenIsActive = false;
+    }
+
+    public boolean isActive() {
+        return this.fcmTokenIsActive;
+    }
+
+    public boolean isDeleted() {
+        return this.fcmTokenDeletedAt != null;
+    }
 
 }

--- a/src/main/java/com/project200/undabang/push_message/entity/NotificationMessage.java
+++ b/src/main/java/com/project200/undabang/push_message/entity/NotificationMessage.java
@@ -1,10 +1,9 @@
-package com.project200.undabang.common.entity;
+package com.project200.undabang.push_message.entity;
 
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 import lombok.*;
-import org.hibernate.annotations.ColumnDefault;
 import org.hibernate.annotations.Comment;
 
 import java.time.LocalDateTime;
@@ -43,17 +42,17 @@ public class NotificationMessage {
     @Column(name = "message_link_url")
     private String messageLinkUrl;
 
+    @Builder.Default
     @NotNull
     @Comment("생성일시")
-    @ColumnDefault("CURRENT_TIMESTAMP")
-    @Column(name = "message_created_at", nullable = false)
-    private LocalDateTime messageCreatedAt;
+    @Column(name = "message_created_at", nullable = false, columnDefinition = "DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP")
+    private LocalDateTime messageCreatedAt = LocalDateTime.now();
 
+    @Builder.Default
     @NotNull
     @Comment("수정일시")
-    @ColumnDefault("CURRENT_TIMESTAMP")
-    @Column(name = "message_updated_at", nullable = false)
-    private LocalDateTime messageUpdatedAt;
+    @Column(name = "message_updated_at", nullable = false, columnDefinition = "DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP")
+    private LocalDateTime messageUpdatedAt = LocalDateTime.now();
 
     @Comment("삭제일시")
     @Column(name = "message_deleted_at")

--- a/src/main/java/com/project200/undabang/push_message/entity/NotificationMessage.java
+++ b/src/main/java/com/project200/undabang/push_message/entity/NotificationMessage.java
@@ -4,6 +4,7 @@ import jakarta.persistence.*;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 import lombok.*;
+import org.hibernate.annotations.ColumnDefault;
 import org.hibernate.annotations.Comment;
 
 import java.time.LocalDateTime;
@@ -45,13 +46,15 @@ public class NotificationMessage {
     @Builder.Default
     @NotNull
     @Comment("생성일시")
-    @Column(name = "message_created_at", nullable = false, columnDefinition = "DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP")
+    @ColumnDefault("CURRENT_TIMESTAMP")
+    @Column(name = "message_created_at", nullable = false)
     private LocalDateTime messageCreatedAt = LocalDateTime.now();
 
     @Builder.Default
     @NotNull
     @Comment("수정일시")
-    @Column(name = "message_updated_at", nullable = false, columnDefinition = "DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP")
+    @ColumnDefault("CURRENT_TIMESTAMP")
+    @Column(name = "message_updated_at", nullable = false)
     private LocalDateTime messageUpdatedAt = LocalDateTime.now();
 
     @Comment("삭제일시")

--- a/src/main/java/com/project200/undabang/push_message/entity/NotificationScenario.java
+++ b/src/main/java/com/project200/undabang/push_message/entity/NotificationScenario.java
@@ -1,4 +1,4 @@
-package com.project200.undabang.common.entity;
+package com.project200.undabang.push_message.entity;
 
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotNull;
@@ -41,17 +41,17 @@ public class NotificationScenario {
     @Column(name = "scenario_is_enabled", nullable = false)
     private Boolean scenarioIsEnabled = true;
 
+    @Builder.Default
     @NotNull
     @Comment("생성일시")
-    @ColumnDefault("CURRENT_TIMESTAMP")
-    @Column(name = "scenario_created_at", nullable = false)
-    private LocalDateTime scenarioCreatedAt;
+    @Column(name = "scenario_created_at", nullable = false, columnDefinition = "DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP")
+    private LocalDateTime scenarioCreatedAt = LocalDateTime.now();
 
+    @Builder.Default
     @NotNull
     @Comment("수정일시")
-    @ColumnDefault("CURRENT_TIMESTAMP")
-    @Column(name = "scenario_updated_at", nullable = false)
-    private LocalDateTime scenarioUpdatedAt;
+    @Column(name = "scenario_updated_at", nullable = false, columnDefinition = "DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP")
+    private LocalDateTime scenarioUpdatedAt = LocalDateTime.now();
 
     @Comment("삭제일시")
     @Column(name = "scenario_deleted_at")

--- a/src/main/java/com/project200/undabang/push_message/entity/NotificationScenario.java
+++ b/src/main/java/com/project200/undabang/push_message/entity/NotificationScenario.java
@@ -44,13 +44,15 @@ public class NotificationScenario {
     @Builder.Default
     @NotNull
     @Comment("생성일시")
-    @Column(name = "scenario_created_at", nullable = false, columnDefinition = "DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP")
+    @ColumnDefault("CURRENT_TIMESTAMP")
+    @Column(name = "scenario_created_at", nullable = false)
     private LocalDateTime scenarioCreatedAt = LocalDateTime.now();
 
     @Builder.Default
     @NotNull
     @Comment("수정일시")
-    @Column(name = "scenario_updated_at", nullable = false, columnDefinition = "DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP")
+    @ColumnDefault("CURRENT_TIMESTAMP")
+    @Column(name = "scenario_updated_at", nullable = false)
     private LocalDateTime scenarioUpdatedAt = LocalDateTime.now();
 
     @Comment("삭제일시")

--- a/src/main/java/com/project200/undabang/push_message/entity/ScenarioMessageMapping.java
+++ b/src/main/java/com/project200/undabang/push_message/entity/ScenarioMessageMapping.java
@@ -1,4 +1,4 @@
-package com.project200.undabang.common.entity;
+package com.project200.undabang.push_message.entity;
 
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotNull;

--- a/src/main/java/com/project200/undabang/push_message/repository/FcmTokenRepository.java
+++ b/src/main/java/com/project200/undabang/push_message/repository/FcmTokenRepository.java
@@ -1,0 +1,13 @@
+package com.project200.undabang.push_message.repository;
+
+import com.project200.undabang.push_message.entity.FcmToken;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.lang.NonNull;
+
+import java.util.Optional;
+import java.util.UUID;
+
+public interface FcmTokenRepository extends JpaRepository<FcmToken, Long> {
+
+    Optional<FcmToken> findByFcmTokenValueAndMember_MemberId(@NonNull String fcmTokenValue, @NonNull UUID memberId);
+}

--- a/src/main/java/com/project200/undabang/push_message/service/FcmTokenCommandService.java
+++ b/src/main/java/com/project200/undabang/push_message/service/FcmTokenCommandService.java
@@ -1,0 +1,10 @@
+package com.project200.undabang.push_message.service;
+
+import com.project200.undabang.member.entity.Member;
+
+public interface FcmTokenCommandService {
+
+    void saveFcmToken(Member member, String fcmToken, String userAgent);
+
+    void deactivateFcmToken(Member member, String fcmToken);
+}

--- a/src/main/java/com/project200/undabang/push_message/service/impl/FcmTokenCommandServiceImpl.java
+++ b/src/main/java/com/project200/undabang/push_message/service/impl/FcmTokenCommandServiceImpl.java
@@ -1,0 +1,47 @@
+package com.project200.undabang.push_message.service.impl;
+
+import com.project200.undabang.member.entity.Member;
+import com.project200.undabang.push_message.entity.FcmToken;
+import com.project200.undabang.push_message.repository.FcmTokenRepository;
+import com.project200.undabang.push_message.service.FcmTokenCommandService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class FcmTokenCommandServiceImpl implements FcmTokenCommandService {
+
+    private final FcmTokenRepository fcmTokenRepository;
+
+    @Override
+    public void saveFcmToken(Member member, String fcmToken, String userAgent) {
+        fcmTokenRepository.findByFcmTokenValueAndMember_MemberId(fcmToken, member.getMemberId())
+                .ifPresentOrElse(existingToken -> {
+                    log.debug("FCM 토큰이 이미 존재합니다. 회원 id: {}", member.getMemberId());
+
+                    existingToken.activate();
+                }, () -> {
+                    log.debug("새로운 FCM 토큰을 저장합니다. 회원 id: {}", member.getMemberId());
+                    FcmToken newToken = FcmToken.builder()
+                            .member(member)
+                            .fcmTokenValue(fcmToken)
+                            .fcmTokenUserAgent(userAgent)
+                            .build();
+
+                    fcmTokenRepository.save(newToken);
+                });
+    }
+
+    @Override
+    public void deactivateFcmToken(Member member, String fcmToken) {
+        fcmTokenRepository.findByFcmTokenValueAndMember_MemberId(fcmToken, member.getMemberId())
+                .ifPresentOrElse(existingToken -> {
+                    log.debug("FCM 토큰을 비활성화합니다. 회원 id: {}", member.getMemberId());
+                    existingToken.deactivate();
+                }, () -> log.warn("비활성화할 FCM 토큰이 존재하지 않습니다. 회원 id: {}", member.getMemberId()));
+    }
+}

--- a/src/test/java/com/project200/undabang/auth/controller/AuthControllerTest.java
+++ b/src/test/java/com/project200/undabang/auth/controller/AuthControllerTest.java
@@ -1,0 +1,196 @@
+package com.project200.undabang.auth.controller;
+
+import com.project200.undabang.auth.service.AuthService;
+import com.project200.undabang.common.web.exception.CustomException;
+import com.project200.undabang.common.web.exception.ErrorCode;
+import com.project200.undabang.configuration.AbstractRestDocSupport;
+import com.project200.undabang.configuration.RestDocsUtils;
+import com.project200.undabang.member.entity.Member;
+import com.project200.undabang.push_message.service.FcmTokenCommandService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.mockito.BDDMockito;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.http.MediaType;
+import org.springframework.restdocs.payload.JsonFieldType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
+
+import java.util.UUID;
+
+import static com.project200.undabang.configuration.DocumentFormatGenerator.getTypeFormat;
+import static com.project200.undabang.configuration.HeadersGenerator.getCommonApiHeaders;
+import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
+import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
+import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+
+@WebMvcTest(AuthController.class)
+@DisplayName("AuthController 테스트")
+class AuthControllerTest extends AbstractRestDocSupport {
+
+    private final UUID memberId = UUID.randomUUID();
+    private final Member member = Member.builder().memberId(memberId).build();
+    @MockitoBean
+    private AuthService authService;
+    @MockitoBean
+    private FcmTokenCommandService fcmTokenCommandService;
+
+    @Nested
+    @DisplayName("로그인 API 테스트")
+    class Login {
+
+        @Test
+        @DisplayName("로그인 성공 - FCM 토큰 포함")
+        void loginMember_Success_WithFcmToken() throws Exception {
+            // given
+            String fcmToken = "test-fcm-token";
+            String userAgent = "Test-User-Agent";
+            BDDMockito.given(authService.login()).willReturn(member);
+
+            // when & then
+            mockMvc.perform(MockMvcRequestBuilders.post("/api/v1/login")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .accept(MediaType.APPLICATION_JSON)
+                            .header("User-Agent", userAgent)
+                            .header("X-Fcm-Token", fcmToken)
+                            .headers(getCommonApiHeaders(memberId)))
+                    .andExpect(MockMvcResultMatchers.status().isOk())
+                    .andDo(document.document(
+                            requestHeaders(
+                                    RestDocsUtils.HEADER_ACCESS_TOKEN,
+                                    headerWithName("User-Agent").attributes(getTypeFormat(JsonFieldType.STRING))
+                                            .description("사용자 디바이스 정보 (선택)").optional(),
+                                    headerWithName("X-Fcm-Token").attributes(getTypeFormat(JsonFieldType.STRING))
+                                            .description("FCM 푸시 알림을 위한 토큰 (선택)").optional()
+                            ),
+                            responseFields(
+                                    RestDocsUtils.commonResponseFieldsOnly()
+                            )
+                    ));
+
+            BDDMockito.then(authService).should().login();
+            BDDMockito.then(fcmTokenCommandService).should().saveFcmToken(member, fcmToken, userAgent);
+        }
+
+        @Test
+        @DisplayName("로그인 성공 - FCM 토큰 미포함")
+        void loginMember_Success_WithoutFcmToken() throws Exception {
+            // given
+            BDDMockito.given(authService.login()).willReturn(member);
+
+            // when & then
+            mockMvc.perform(MockMvcRequestBuilders.post("/api/v1/login")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .accept(MediaType.APPLICATION_JSON)
+                            .headers(getCommonApiHeaders(memberId)))
+                    .andExpect(MockMvcResultMatchers.status().isOk());
+
+            BDDMockito.then(authService).should().login();
+            BDDMockito.then(fcmTokenCommandService).shouldHaveNoInteractions();
+        }
+
+        @Test
+        @DisplayName("로그인 실패 - 존재하지 않는 회원")
+        void loginMember_Fail_MemberNotFound() throws Exception {
+            // given
+            BDDMockito.given(authService.login()).willThrow(new CustomException(ErrorCode.LOGIN_FAILED));
+
+
+            // when & then
+            mockMvc.perform(MockMvcRequestBuilders.post("/api/v1/login")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .accept(MediaType.APPLICATION_JSON)
+                            .headers(getCommonApiHeaders(UUID.randomUUID()))) // 존재하지 않는 UUID
+                    .andExpect(MockMvcResultMatchers.status().isUnauthorized())
+                    .andDo(document.document(
+                            requestHeaders(
+                                    RestDocsUtils.HEADER_ACCESS_TOKEN
+                            ),
+                            responseFields(
+                                    RestDocsUtils.commonResponseFieldsOnly()
+                            )
+                    ));
+
+            BDDMockito.then(authService).should().login();
+            BDDMockito.then(fcmTokenCommandService).shouldHaveNoInteractions();
+        }
+    }
+
+    @Nested
+    @DisplayName("로그아웃 API 테스트")
+    class Logout {
+
+        @Test
+        @DisplayName("로그아웃 성공 - FCM 토큰 포함")
+        void logoutMember_Success_WithFcmToken() throws Exception {
+            // given
+            String fcmToken = "test-fcm-token";
+            BDDMockito.given(authService.logout()).willReturn(member);
+
+            // when & then
+            mockMvc.perform(MockMvcRequestBuilders.post("/api/v1/logout")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .accept(MediaType.APPLICATION_JSON)
+                            .header("X-Fcm-Token", fcmToken)
+                            .headers(getCommonApiHeaders(memberId)))
+                    .andExpect(MockMvcResultMatchers.status().isOk())
+                    .andDo(document.document(
+                            requestHeaders(
+                                    RestDocsUtils.HEADER_ACCESS_TOKEN,
+                                    headerWithName("X-Fcm-Token").attributes(getTypeFormat(JsonFieldType.STRING))
+                                            .description("비활성화할 FCM 토큰 (선택)").optional()
+                            ),
+                            responseFields(
+                                    RestDocsUtils.commonResponseFieldsOnly()
+                            )
+                    ));
+
+            BDDMockito.then(authService).should().logout();
+            BDDMockito.then(fcmTokenCommandService).should().deactivateFcmToken(member, fcmToken);
+        }
+
+        @Test
+        @DisplayName("로그아웃 성공 - FCM 토큰 미포함")
+        void logoutMember_Success_WithoutFcmToken() throws Exception {
+            // given
+            BDDMockito.given(authService.logout()).willReturn(member);
+
+            // when & then
+            mockMvc.perform(MockMvcRequestBuilders.post("/api/v1/logout")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .accept(MediaType.APPLICATION_JSON)
+                            .headers(getCommonApiHeaders(memberId)))
+                    .andExpect(MockMvcResultMatchers.status().isOk());
+
+            BDDMockito.then(authService).should().logout();
+            BDDMockito.then(fcmTokenCommandService).shouldHaveNoInteractions();
+        }
+
+        @Test
+        @DisplayName("로그아웃 실패 - 존재하지 않는 회원")
+        void logoutMember_Fail_MemberNotFound() throws Exception {
+            // given
+            BDDMockito.given(authService.logout()).willThrow(new CustomException(ErrorCode.LOGOUT_FAILED));
+
+            // when & then
+            mockMvc.perform(MockMvcRequestBuilders.post("/api/v1/logout")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .accept(MediaType.APPLICATION_JSON)
+                            .headers(getCommonApiHeaders(UUID.randomUUID()))) // 존재하지 않는 UUID
+                    .andExpect(MockMvcResultMatchers.status().isUnauthorized())
+                    .andDo(document.document(
+                            requestHeaders(
+                                    RestDocsUtils.HEADER_ACCESS_TOKEN
+                            ),
+                            responseFields(
+                                    RestDocsUtils.commonResponseFieldsOnly()
+                            )
+                    ));
+
+            BDDMockito.then(authService).should().logout();
+            BDDMockito.then(fcmTokenCommandService).shouldHaveNoInteractions();
+        }
+    }
+}

--- a/src/test/java/com/project200/undabang/auth/service/impl/AuthServiceImplTest.java
+++ b/src/test/java/com/project200/undabang/auth/service/impl/AuthServiceImplTest.java
@@ -1,0 +1,120 @@
+package com.project200.undabang.auth.service.impl;
+
+import com.project200.undabang.common.context.UserContextHolder;
+import com.project200.undabang.common.web.exception.CustomException;
+import com.project200.undabang.common.web.exception.ErrorCode;
+import com.project200.undabang.member.entity.Member;
+import com.project200.undabang.member.repository.MemberRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.BDDMockito;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("AuthServiceImpl 테스트")
+class AuthServiceImplTest {
+
+    private final UUID testUserId = UUID.randomUUID();
+    private final Member member = Member.builder().memberId(testUserId).build();
+    @InjectMocks
+    private AuthServiceImpl authService;
+    @Mock
+    private MemberRepository memberRepository;
+
+    @Nested
+    @DisplayName("로그인 기능 테스트")
+    class Login {
+
+        @Test
+        @DisplayName("로그인 성공")
+        void login_Success() {
+            try (MockedStatic<UserContextHolder> ignored = BDDMockito.mockStatic(UserContextHolder.class)) {
+                // given
+                BDDMockito.given(UserContextHolder.getUserId()).willReturn(testUserId);
+                BDDMockito.given(memberRepository.findByMemberIdAndMemberDeletedAtNull(testUserId))
+                        .willReturn(Optional.of(member));
+
+                // when
+                Member result = authService.login();
+
+                // then
+                assertThat(result).as("반환된 Member 객체는 null이 아니어야 합니다.").isNotNull();
+                assertThat(result.getMemberId()).as("반환된 Member의 ID는 예상과 같아야 합니다.").isEqualTo(testUserId);
+                BDDMockito.then(memberRepository).should().findByMemberIdAndMemberDeletedAtNull(testUserId);
+            }
+        }
+
+        @Test
+        @DisplayName("로그인 실패 - 존재하지 않는 회원")
+        void login_Fail_MemberNotFound() {
+            try (MockedStatic<UserContextHolder> ignored = BDDMockito.mockStatic(UserContextHolder.class)) {
+                // given
+                BDDMockito.given(UserContextHolder.getUserId()).willReturn(testUserId);
+                BDDMockito.given(memberRepository.findByMemberIdAndMemberDeletedAtNull(testUserId))
+                        .willReturn(Optional.empty());
+
+                // when & then
+                assertThatThrownBy(() -> authService.login())
+                        .as("존재하지 않는 회원으로 로그인 시 CustomException이 발생해야 합니다.")
+                        .isInstanceOf(CustomException.class)
+                        .hasFieldOrPropertyWithValue("errorCode", ErrorCode.LOGIN_FAILED);
+
+                BDDMockito.then(memberRepository).should().findByMemberIdAndMemberDeletedAtNull(testUserId);
+            }
+        }
+    }
+
+    @Nested
+    @DisplayName("로그아웃 기능 테스트")
+    class Logout {
+
+        @Test
+        @DisplayName("로그아웃 성공")
+        void logout_Success() {
+            try (MockedStatic<UserContextHolder> ignored = BDDMockito.mockStatic(UserContextHolder.class)) {
+                // given
+                BDDMockito.given(UserContextHolder.getUserId()).willReturn(testUserId);
+                BDDMockito.given(memberRepository.findByMemberIdAndMemberDeletedAtNull(testUserId))
+                        .willReturn(Optional.of(member));
+
+                // when
+                Member result = authService.logout();
+
+                // then
+                assertThat(result).as("반환된 Member 객체는 null이 아니어야 합니다.").isNotNull();
+                assertThat(result.getMemberId()).as("반환된 Member의 ID는 예상과 같아야 합니다.").isEqualTo(testUserId);
+                BDDMockito.then(memberRepository).should().findByMemberIdAndMemberDeletedAtNull(testUserId);
+            }
+        }
+
+        @Test
+        @DisplayName("로그아웃 실패 - 존재하지 않는 회원")
+        void logout_Fail_MemberNotFound() {
+            try (MockedStatic<UserContextHolder> ignored = BDDMockito.mockStatic(UserContextHolder.class)) {
+                // given
+                BDDMockito.given(UserContextHolder.getUserId()).willReturn(testUserId);
+                BDDMockito.given(memberRepository.findByMemberIdAndMemberDeletedAtNull(testUserId))
+                        .willReturn(Optional.empty());
+
+                // when & then
+                assertThatThrownBy(() -> authService.logout())
+                        .as("존재하지 않는 회원으로 로그아웃 시 CustomException이 발생해야 합니다.")
+                        .isInstanceOf(CustomException.class)
+                        .hasFieldOrPropertyWithValue("errorCode", ErrorCode.LOGOUT_FAILED);
+
+                BDDMockito.then(memberRepository).should().findByMemberIdAndMemberDeletedAtNull(testUserId);
+            }
+        }
+    }
+}

--- a/src/test/java/com/project200/undabang/push_message/repository/FcmTokenRepositoryTest.java
+++ b/src/test/java/com/project200/undabang/push_message/repository/FcmTokenRepositoryTest.java
@@ -1,0 +1,126 @@
+package com.project200.undabang.push_message.repository;
+
+import com.project200.undabang.configuration.TestQuerydslConfig;
+import com.project200.undabang.member.entity.Member;
+import com.project200.undabang.push_message.entity.FcmToken;
+import jakarta.persistence.EntityManager;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DataJpaTest
+@Import(TestQuerydslConfig.class)
+@DisplayName("FcmTokenRepository 테스트")
+class FcmTokenRepositoryTest {
+
+    @Autowired
+    private FcmTokenRepository fcmTokenRepository;
+
+    @Autowired
+    private EntityManager em;
+
+    @Nested
+    @DisplayName("findByFcmTokenValueAndMember_MemberId 메소드 테스트")
+    class FindByFcmTokenAndMemberId {
+
+        @Test
+        @DisplayName("FCM 토큰과 회원 ID로 토큰 조회 성공")
+        void findByFcmTokenValueAndMember_MemberId_Success() {
+            // given
+            FcmToken persistedToken = persistMemberAndFcmToken();
+            String fcmTokenValue = persistedToken.getFcmTokenValue();
+            UUID memberId = persistedToken.getMember().getMemberId();
+
+            // when
+            Optional<FcmToken> foundTokenOpt = fcmTokenRepository.findByFcmTokenValueAndMember_MemberId(fcmTokenValue, memberId);
+
+            // then
+            assertThat(foundTokenOpt).as("FCM 토큰을 찾아야 합니다.").isPresent();
+            FcmToken foundToken = foundTokenOpt.get();
+            assertThat(foundToken.getId()).as("찾은 토큰의 ID가 일치해야 합니다.").isEqualTo(persistedToken.getId());
+            assertThat(foundToken.getFcmTokenValue()).as("찾은 토큰의 값이 일치해야 합니다.").isEqualTo(fcmTokenValue);
+            assertThat(foundToken.getMember().getMemberId()).as("찾은 토큰의 회원 ID가 일치해야 합니다.").isEqualTo(memberId);
+        }
+
+        @Test
+        @DisplayName("FCM 토큰이 일치하지 않으면 토큰을 찾지 못해야 한다")
+        void findByFcmTokenValueAndMember_MemberId_Fail_WrongToken() {
+            // given
+            FcmToken persistedToken = persistMemberAndFcmToken();
+            UUID memberId = persistedToken.getMember().getMemberId();
+            String wrongFcmToken = "wrong-fcm-token";
+
+            // when
+            Optional<FcmToken> foundToken = fcmTokenRepository.findByFcmTokenValueAndMember_MemberId(wrongFcmToken, memberId);
+
+            // then
+            assertThat(foundToken).as("잘못된 FCM 토큰 값으로는 토큰을 찾을 수 없어야 합니다.").isNotPresent();
+        }
+
+        @Test
+        @DisplayName("회원 ID가 일치하지 않으면 토큰을 찾지 못해야 한다")
+        void findByFcmTokenValueAndMember_MemberId_Fail_WrongMemberId() {
+            // given
+            FcmToken persistedToken = persistMemberAndFcmToken();
+            String fcmTokenValue = persistedToken.getFcmTokenValue();
+            UUID wrongUserId = UUID.randomUUID();
+
+            // when
+            Optional<FcmToken> foundToken = fcmTokenRepository.findByFcmTokenValueAndMember_MemberId(fcmTokenValue, wrongUserId);
+
+            // then
+            assertThat(foundToken).as("다른 회원의 ID로는 토큰을 찾을 수 없어야 합니다.").isNotPresent();
+        }
+
+
+        @Test
+        @DisplayName("FCM 토큰과 회원 ID가 모두 일치하지 않으면 토큰을 찾지 못해야 한다")
+        void findByFcmTokenValueAndMember_MemberId_Fail_BothWrong() {
+            // given
+            persistMemberAndFcmToken();
+            String wrongFcmToken = "wrong-fcm-token";
+            UUID wrongUserId = UUID.randomUUID();
+
+            // when
+            Optional<FcmToken> foundToken = fcmTokenRepository.findByFcmTokenValueAndMember_MemberId(wrongFcmToken, wrongUserId);
+
+            // then
+            assertThat(foundToken).as("FCM 토큰과 회원 ID가 모두 틀리면 토큰을 찾을 수 없어야 합니다.").isNotPresent();
+        }
+
+        /**
+         * 테스트 데이터 생성을 위한 헬퍼 메소드.
+         *
+         * @return 생성된 FcmToken 엔티티
+         */
+        private FcmToken persistMemberAndFcmToken() {
+            Member member = Member.builder()
+                    .memberId(UUID.randomUUID())
+                    .memberEmail("test@email.com")
+                    .memberNickname("test-user")
+                    .build();
+            em.persist(member);
+
+            FcmToken fcmToken = FcmToken.builder()
+                    .member(member)
+                    .fcmTokenValue("test-fcm-token")
+                    .fcmTokenUserAgent("Test-User-Agent")
+                    .build();
+            em.persist(fcmToken);
+
+            em.flush();
+            em.clear();
+
+            // 테스트에서 사용할 수 있도록 저장된 엔티티를 반환합니다.
+            return fcmToken;
+        }
+    }
+}

--- a/src/test/java/com/project200/undabang/push_message/service/impl/FcmTokenCommandServiceImplTest.java
+++ b/src/test/java/com/project200/undabang/push_message/service/impl/FcmTokenCommandServiceImplTest.java
@@ -1,0 +1,124 @@
+package com.project200.undabang.push_message.service.impl;
+
+import com.project200.undabang.member.entity.Member;
+import com.project200.undabang.push_message.entity.FcmToken;
+import com.project200.undabang.push_message.repository.FcmTokenRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.BDDMockito;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("FcmTokenCommandServiceImpl 테스트")
+class FcmTokenCommandServiceImplTest {
+
+    private final UUID testUserId = UUID.randomUUID();
+    private final Member member = Member.builder().memberId(testUserId).build();
+    private final String fcmTokenValue = "test-fcm-token";
+    private final String userAgent = "Test-User-Agent";
+    @InjectMocks
+    private FcmTokenCommandServiceImpl fcmTokenCommandService;
+    @Mock
+    private FcmTokenRepository fcmTokenRepository;
+
+    @Nested
+    @DisplayName("FCM 토큰 저장 기능 테스트")
+    class SaveFcmToken {
+
+        @Test
+        @DisplayName("새로운 FCM 토큰을 성공적으로 저장한다")
+        void saveFcmToken_NewToken_Success() {
+            // given
+            BDDMockito.given(fcmTokenRepository.findByFcmTokenValueAndMember_MemberId(fcmTokenValue, testUserId))
+                    .willReturn(Optional.empty());
+
+            // when
+            fcmTokenCommandService.saveFcmToken(member, fcmTokenValue, userAgent);
+
+            // then
+            ArgumentCaptor<FcmToken> fcmTokenCaptor = ArgumentCaptor.forClass(FcmToken.class);
+            BDDMockito.then(fcmTokenRepository).should().save(fcmTokenCaptor.capture());
+
+            FcmToken savedToken = fcmTokenCaptor.getValue();
+            assertThat(savedToken.getMember()).as("Member 정보가 정확히 저장되어야 합니다.").isEqualTo(member);
+            assertThat(savedToken.getFcmTokenValue()).as("FCM 토큰 값이 정확히 저장되어야 합니다.").isEqualTo(fcmTokenValue);
+            assertThat(savedToken.getFcmTokenUserAgent()).as("User-Agent 정보가 정확히 저장되어야 합니다.").isEqualTo(userAgent);
+            assertThat(savedToken.getFcmTokenIsActive()).as("새 토큰은 활성화 상태여야 합니다.").isTrue();
+        }
+
+        @Test
+        @DisplayName("이미 존재하는 비활성 FCM 토큰을 활성화한다")
+        void saveFcmToken_ExistingInactiveToken_Activates() {
+            // given
+            FcmToken existingToken = BDDMockito.spy(FcmToken.builder()
+                    .member(member)
+                    .fcmTokenValue(fcmTokenValue)
+                    .fcmTokenUserAgent(userAgent)
+                    .build());
+            existingToken.deactivate(); // 비활성 상태로 만듦
+
+            BDDMockito.given(fcmTokenRepository.findByFcmTokenValueAndMember_MemberId(fcmTokenValue, testUserId))
+                    .willReturn(Optional.of(existingToken));
+
+            // when
+            fcmTokenCommandService.saveFcmToken(member, fcmTokenValue, userAgent);
+
+            // then
+            BDDMockito.then(fcmTokenRepository).should(BDDMockito.never()).save(BDDMockito.any(FcmToken.class));
+            BDDMockito.then(existingToken).should().activate(); // activate 메소드 호출 검증
+            assertThat(existingToken.getFcmTokenIsActive()).as("기존 토큰이 활성화 상태로 변경되어야 합니다.").isTrue();
+        }
+    }
+
+    @Nested
+    @DisplayName("FCM 토큰 비활성화 기능 테스트")
+    class DeactivateFcmToken {
+
+        @Test
+        @DisplayName("존재하는 FCM 토큰을 성공적으로 비활성화한다")
+        void deactivateFcmToken_ExistingToken_Success() {
+            // given
+            FcmToken existingToken = BDDMockito.spy(FcmToken.builder()
+                    .member(member)
+                    .fcmTokenValue(fcmTokenValue)
+                    .build());
+
+            BDDMockito.given(fcmTokenRepository.findByFcmTokenValueAndMember_MemberId(fcmTokenValue, testUserId))
+                    .willReturn(Optional.of(existingToken));
+
+            // when
+            fcmTokenCommandService.deactivateFcmToken(member, fcmTokenValue);
+
+            // then
+            BDDMockito.then(existingToken).should().deactivate(); // deactivate 메소드 호출 검증
+            assertThat(existingToken.getFcmTokenIsActive()).as("토큰이 비활성화 상태여야 합니다.").isFalse();
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 FCM 토큰을 비활성화 시도 시 아무 작업도 수행하지 않는다")
+        void deactivateFcmToken_NonExistingToken_DoesNothing() {
+            // given
+            BDDMockito.given(fcmTokenRepository.findByFcmTokenValueAndMember_MemberId(fcmTokenValue, testUserId))
+                    .willReturn(Optional.empty());
+
+            // when
+            fcmTokenCommandService.deactivateFcmToken(member, fcmTokenValue);
+
+            // then
+            BDDMockito.then(fcmTokenRepository).should(BDDMockito.never()).save(BDDMockito.any(FcmToken.class));
+            // 아무런 추가적인 상호작용이 없었는지 확인
+            BDDMockito.then(fcmTokenRepository).should().findByFcmTokenValueAndMember_MemberId(fcmTokenValue, testUserId);
+            BDDMockito.then(fcmTokenRepository).shouldHaveNoMoreInteractions();
+        }
+    }
+}


### PR DESCRIPTION
## 📝작업 내용

- 로그인, 로그아웃 API를 만들었습니다.

- 로그인 API 기능: 회원 존재 여부 체크, fcm 토큰 저장, fcm 토큰 활성 여부 및 시간 갱신

- 로그아웃 API 기능: 회원 존재 여부 체크, fcm 토큰 활성 여부 및 시간 갱신

- 자세한 API 명세는 밑에 명세서 사진과 #203 이슈를 확인해주세요.

- `columnDefinition = "DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP")` 가 있으면 `@DataJpaTest`에서 오류가 발생했습니다. 그래서 제거하였습니다. 이걸 해결하기 위해 schema.sql 도입을 해보았는데 이유 모를 오류가 많이 나와서 실패했습니다. 차후 #211 이슈를 해결할 때 참고바랍니다.

## 💬리뷰 요구사항
- 현 PR을 먼저 합치고 #224 를 병합하는 건 어떨까요? 이 PR이 빨리 병합되어야 프론트에서 테스트가 용이할 것 같아서 그렇습니다.

### 스크린샷 

<img width="1220" height="213" alt="image" src="https://github.com/user-attachments/assets/7e48ca93-468b-43d1-955b-3bfe5b097989" />

- `AuthController`에서 분기 커버리지가 75%인 이유는 `Objects.nonNull(fcmToken) && !fcmToken.isBlank()` 부분에서 `!fcmToken.isBlank()`에서 커버리지 체크가 안되어 그렇습니다. 프론트에서 아예 안 보내주는 경우는 테스트를 했는데 빈 문자열만 오는 건 안해서 그렇습니다. 굳이 필요한 테스트가 아니라고 생각하여 생략하였는데 필요하다고 판단하시면 추가하겠습니다.

<img width="999" height="5784" alt="image" src="https://github.com/user-attachments/assets/ae985870-61c8-42b0-b0c4-fd96dd4f9c2b" />

## #️⃣연관된 이슈

Closes #203
