### PR TITLE
[Feat] 심플 타이머 조회시 정렬기능 추가

### DIFF
--- a/src/main/java/com/project200/undabang/policy/entity/PolicyKey.java
+++ b/src/main/java/com/project200/undabang/policy/entity/PolicyKey.java
@@ -27,5 +27,5 @@ public enum PolicyKey {
     // 심플 타이머
     SIMPLE_TIMER_INIT_COUNT, // 심플 타이머 초기 생성 갯수
     SIMPLE_TIMER_INIT_VALUES, // 심플 타이머 초기 값. 회원 가입시 추가해줘야 함
-
+    SIMPLE_TIMER_MAX_COUNT, // 심플 타이머 최대 보유 갯수
 }

--- a/src/main/java/com/project200/undabang/timer/simple/controller/SimpleTimerQueryController.java
+++ b/src/main/java/com/project200/undabang/timer/simple/controller/SimpleTimerQueryController.java
@@ -1,7 +1,7 @@
 package com.project200.undabang.timer.simple.controller;
 
 import com.project200.undabang.common.web.response.CommonResponse;
-import com.project200.undabang.timer.simple.dto.response.GetSimpleTimerResponseDto;
+import com.project200.undabang.timer.simple.dto.response.SimpleTimerListResponse;
 import com.project200.undabang.timer.simple.service.SimpleTimerQueryService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -16,7 +16,7 @@ public class SimpleTimerQueryController {
     private final SimpleTimerQueryService simpleTimerQueryService;
 
     @GetMapping("/v1/simple-timers")
-    public ResponseEntity<CommonResponse<GetSimpleTimerResponseDto>> getSimpleTimers() {
+    public ResponseEntity<CommonResponse<SimpleTimerListResponse>> getSimpleTimers() {
         return ResponseEntity.ok(CommonResponse.success(simpleTimerQueryService.getSimpleTimers()));
     }
 }

--- a/src/main/java/com/project200/undabang/timer/simple/dto/response/SimpleTimerListResponse.java
+++ b/src/main/java/com/project200/undabang/timer/simple/dto/response/SimpleTimerListResponse.java
@@ -11,12 +11,12 @@ import java.util.List;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
-public class GetSimpleTimerResponseDto {
+public class SimpleTimerListResponse {
     private int simpleTimerCount;
     private List<SimpleTimerRecord> simpleTimers;
 
-    public static GetSimpleTimerResponseDto of(List<SimpleTimerRecord> simpleTimers) {
-        return GetSimpleTimerResponseDto.builder()
+    public static SimpleTimerListResponse of(List<SimpleTimerRecord> simpleTimers) {
+        return SimpleTimerListResponse.builder()
                 .simpleTimerCount(simpleTimers.size())
                 .simpleTimers(simpleTimers)
                 .build();

--- a/src/main/java/com/project200/undabang/timer/simple/repository/SimpleTimerRepository.java
+++ b/src/main/java/com/project200/undabang/timer/simple/repository/SimpleTimerRepository.java
@@ -8,6 +8,6 @@ import java.util.List;
 import java.util.Optional;
 
 public interface SimpleTimerRepository extends JpaRepository<SimpleTimer, Long> {
-    List<SimpleTimer> findByMemberAndSimpleTimerDeletedAtNull(Member member);
+    List<SimpleTimer> findByMemberAndSimpleTimerDeletedAtNullOrderBySimpleTimerTimeAsc(Member member);
     Optional<SimpleTimer> findByIdAndMemberAndSimpleTimerDeletedAtNull(Long id, Member member);
 }

--- a/src/main/java/com/project200/undabang/timer/simple/service/SimpleTimerQueryService.java
+++ b/src/main/java/com/project200/undabang/timer/simple/service/SimpleTimerQueryService.java
@@ -1,7 +1,7 @@
 package com.project200.undabang.timer.simple.service;
 
-import com.project200.undabang.timer.simple.dto.response.GetSimpleTimerResponseDto;
+import com.project200.undabang.timer.simple.dto.response.SimpleTimerListResponse;
 
 public interface SimpleTimerQueryService {
-    GetSimpleTimerResponseDto getSimpleTimers();
+    SimpleTimerListResponse getSimpleTimers();
 }

--- a/src/main/java/com/project200/undabang/timer/simple/service/impl/SimpleTimerQueryServiceImpl.java
+++ b/src/main/java/com/project200/undabang/timer/simple/service/impl/SimpleTimerQueryServiceImpl.java
@@ -5,7 +5,7 @@ import com.project200.undabang.common.web.exception.CustomException;
 import com.project200.undabang.common.web.exception.ErrorCode;
 import com.project200.undabang.member.entity.Member;
 import com.project200.undabang.member.repository.MemberRepository;
-import com.project200.undabang.timer.simple.dto.response.GetSimpleTimerResponseDto;
+import com.project200.undabang.timer.simple.dto.response.SimpleTimerListResponse;
 import com.project200.undabang.timer.simple.dto.response.SimpleTimerRecord;
 import com.project200.undabang.timer.simple.entity.SimpleTimer;
 import com.project200.undabang.timer.simple.repository.SimpleTimerRepository;
@@ -27,21 +27,21 @@ public class SimpleTimerQueryServiceImpl implements SimpleTimerQueryService {
     private final MemberRepository memberRepository;
 
     @Override
-    public GetSimpleTimerResponseDto getSimpleTimers() {
+    public SimpleTimerListResponse getSimpleTimers() {
         UUID memberId = UserContextHolder.getUserId();
         Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> new CustomException(ErrorCode.MEMBER_NOT_FOUND));
 
-        List<SimpleTimer> simpleTimerList = simpleTimerRepository.findByMemberAndSimpleTimerDeletedAtNull(member);
+        List<SimpleTimer> simpleTimerList = simpleTimerRepository.findByMemberAndSimpleTimerDeletedAtNullOrderBySimpleTimerTimeAsc(member);
 
         return createSimpleTimerResponse(simpleTimerList);
     }
 
-    private GetSimpleTimerResponseDto createSimpleTimerResponse(List<SimpleTimer> simpleTimerList) {
+    private SimpleTimerListResponse createSimpleTimerResponse(List<SimpleTimer> simpleTimerList) {
         List<SimpleTimerRecord> simpleTimerRecordList = simpleTimerList.stream()
                 .map(SimpleTimerRecord::from)
                 .toList();
 
-        return GetSimpleTimerResponseDto.of(simpleTimerRecordList);
+        return SimpleTimerListResponse.of(simpleTimerRecordList);
     }
 }

--- a/src/test/java/com/project200/undabang/timer/simple/controller/SimpleTimerQueryControllerTest.java
+++ b/src/test/java/com/project200/undabang/timer/simple/controller/SimpleTimerQueryControllerTest.java
@@ -2,7 +2,7 @@ package com.project200.undabang.timer.simple.controller;
 
 import com.project200.undabang.common.web.exception.ErrorCode;
 import com.project200.undabang.configuration.AbstractRestDocSupport;
-import com.project200.undabang.timer.simple.dto.response.GetSimpleTimerResponseDto;
+import com.project200.undabang.timer.simple.dto.response.SimpleTimerListResponse;
 import com.project200.undabang.timer.simple.dto.response.SimpleTimerRecord;
 import com.project200.undabang.timer.simple.service.SimpleTimerQueryService;
 import org.junit.jupiter.api.DisplayName;
@@ -42,7 +42,7 @@ class SimpleTimerQueryControllerTest extends AbstractRestDocSupport {
             // given
             UUID memberId = UUID.randomUUID();
             List<SimpleTimerRecord> recordList =createSimpleTimerRecordList();
-            GetSimpleTimerResponseDto expectedResponse = GetSimpleTimerResponseDto.builder()
+            SimpleTimerListResponse expectedResponse = SimpleTimerListResponse.builder()
                     .simpleTimerCount(recordList.size())
                     .simpleTimers(recordList)
                     .build();

--- a/src/test/java/com/project200/undabang/timer/simple/repository/SimpleTimerRepositoryTest.java
+++ b/src/test/java/com/project200/undabang/timer/simple/repository/SimpleTimerRepositoryTest.java
@@ -5,7 +5,6 @@ import com.project200.undabang.member.entity.Member;
 import com.project200.undabang.member.enums.MemberGender;
 import com.project200.undabang.timer.simple.entity.SimpleTimer;
 import jakarta.persistence.EntityManager;
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -14,7 +13,6 @@ import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.context.annotation.Import;
 
 import java.time.LocalDate;
-import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
@@ -32,29 +30,52 @@ class SimpleTimerRepositoryTest {
     private SimpleTimerRepository simpleTimerRepository;
 
     @Nested
-    @DisplayName("findByMemberAndSimpleTimerDeletedAtNull 메소드는")
-    class Describe_findByMemberAndSimpleTimerDeletedAtNull {
+    @DisplayName("findByMemberAndSimpleTimerDeletedAtNullOrderBySimpleTimerTimeAsc 메소드는")
+    class Describe_findByMemberAndSimpleTimerDeletedAtNullOrderBySimpleTimerTimeAsc {
 
         @Test
-        @DisplayName("특정 회원이 가지고 있는 삭제되지 않은 심플 타이머 목록을 조회한다")
-        void it_returns_timers_for_the_given_member() {
+        @DisplayName("특정 회원이 가지고 있는 삭제되지 않은 심플 타이머 목록을 시간 오름차순으로 조회한다")
+        void it_returns_timers_for_the_given_member_ordered_by_time_asc() {
             // given
             Member member1 = createAndSaveMember("testMember1");
             Member member2 = createAndSaveMember("testMember2");
 
-            SimpleTimer timer1 = createAndSaveSimpleTimer(member1, 30);
+            SimpleTimer timer4 = createAndSaveSimpleTimer(member1, 60);
             SimpleTimer timer2 = createAndSaveSimpleTimer(member1, 40);
+            SimpleTimer timer1 = createAndSaveSimpleTimer(member1, 30);
+            SimpleTimer timer3 = createAndSaveSimpleTimer(member1, 50);
             createAndSaveSimpleTimer(member2, 300); // 다른 회원의 타이머
 
             flushAndClear();
 
             // when
-            List<SimpleTimer> foundTimers = simpleTimerRepository.findByMemberAndSimpleTimerDeletedAtNull(member1);
+            List<SimpleTimer> foundTimers = simpleTimerRepository.findByMemberAndSimpleTimerDeletedAtNullOrderBySimpleTimerTimeAsc(member1);
 
             // then
-            assertThat(foundTimers).hasSize(2);
+            assertThat(foundTimers).hasSize(4);
             assertThat(foundTimers).extracting(SimpleTimer::getId)
-                    .containsExactlyInAnyOrder(timer1.getId(), timer2.getId());
+                    .containsExactly(timer1.getId(), timer2.getId(), timer3.getId(), timer4.getId());
+        }
+
+        @Test
+        @DisplayName("삭제된 타이머는 조회 결과에서 제외한다")
+        void it_excludes_deleted_timers() {
+            // given
+            Member member = createAndSaveMember("testMember");
+
+            SimpleTimer activeTimer = createAndSaveSimpleTimer(member, 30);
+            SimpleTimer deletedTimer = createAndSaveSimpleTimer(member, 60);
+            deletedTimer.deleteSimpleTimer(); // 수정된 부분
+            em.persist(deletedTimer);
+
+            flushAndClear();
+
+            // when
+            List<SimpleTimer> foundTimers = simpleTimerRepository.findByMemberAndSimpleTimerDeletedAtNullOrderBySimpleTimerTimeAsc(member);
+
+            // then
+            assertThat(foundTimers).hasSize(1);
+            assertThat(foundTimers.get(0).getId()).isEqualTo(activeTimer.getId());
         }
 
         @Test
@@ -65,11 +86,34 @@ class SimpleTimerRepositoryTest {
             flushAndClear();
 
             // when
-            List<SimpleTimer> foundTimers = simpleTimerRepository.findByMemberAndSimpleTimerDeletedAtNull(member);
+            List<SimpleTimer> foundTimers = simpleTimerRepository.findByMemberAndSimpleTimerDeletedAtNullOrderBySimpleTimerTimeAsc(member);
 
             // then
             assertThat(foundTimers).isNotNull().isEmpty();
         }
+    }
+
+    @Nested
+    @DisplayName("findByIdAndMemberAndSimpleTimerDeletedAtNull 메소드는")
+    class Describe_findByIdAndMemberAndSimpleTimerDeletedAtNull {
+
+        @Test
+        @DisplayName("ID와 회원 정보가 일치하는 삭제되지 않은 타이머를 조회한다")
+        void it_returns_a_timer_for_the_given_id_and_member() {
+            // given
+            Member member = createAndSaveMember("testMember");
+            SimpleTimer timer = createAndSaveSimpleTimer(member, 180);
+            flushAndClear();
+
+            // when
+            Optional<SimpleTimer> foundTimerOpt = simpleTimerRepository.findByIdAndMemberAndSimpleTimerDeletedAtNull(timer.getId(), member);
+
+            // then
+            assertThat(foundTimerOpt).isPresent();
+            assertThat(foundTimerOpt.get().getId()).isEqualTo(timer.getId());
+            assertThat(foundTimerOpt.get().getMember().getMemberId()).isEqualTo(member.getMemberId()); // 수정된 부분
+        }
+
 
         @Test
         @DisplayName("타이머는 존재하지만 다른 회원의 소유일 경우 빈 Optional을 반환한다")
@@ -107,71 +151,16 @@ class SimpleTimerRepositoryTest {
         void it_returns_empty_optional_for_deleted_timer() {
             // given
             Member member = createAndSaveMember("testMember");
-            SimpleTimer deletedTimer = SimpleTimer.builder()
-                    .member(member)
-                    .simpleTimerTime(180)
-                    .simpleTimerDeletedAt(LocalDateTime.now())
-                    .build();
-            em.persist(deletedTimer);
+            SimpleTimer timer = createAndSaveSimpleTimer(member, 180);
+            timer.deleteSimpleTimer(); // 수정된 부분
+            em.persist(timer);
             flushAndClear();
 
             // when
-            Optional<SimpleTimer> foundTimerOpt = simpleTimerRepository.findByIdAndMemberAndSimpleTimerDeletedAtNull(deletedTimer.getId(), member);
+            Optional<SimpleTimer> foundTimerOpt = simpleTimerRepository.findByIdAndMemberAndSimpleTimerDeletedAtNull(timer.getId(), member);
 
             // then
             assertThat(foundTimerOpt).isNotPresent();
-        }
-    }
-
-    @Nested
-    @DisplayName("findByMember 메소드는")
-    class Describe_findByMember {
-
-        @Test
-        @DisplayName("특정 회원이 가지고 있는 심플 타이머 목록을 조회한다")
-        void it_returns_timers_for_the_given_member() {
-            // given
-            Member member1 = createAndSaveMember("testMember1");
-            Member member2 = createAndSaveMember("testMember2");
-
-            SimpleTimer timer1 = createAndSaveSimpleTimer(member1, 30);
-            SimpleTimer timer2 = createAndSaveSimpleTimer(member1, 40);
-            SimpleTimer timer3 = createAndSaveSimpleTimer(member1, 50);
-            SimpleTimer timer4 = createAndSaveSimpleTimer(member1, 60);
-            SimpleTimer timer5 = createAndSaveSimpleTimer(member1, 75);
-            SimpleTimer timer6 = createAndSaveSimpleTimer(member1, 90);
-
-            createAndSaveSimpleTimer(member2, 300); // 다른 회원의 타이머
-
-            flushAndClear();
-
-            // when
-            List<SimpleTimer> foundTimers = simpleTimerRepository.findByMemberAndSimpleTimerDeletedAtNull(member1);
-
-            // then
-            Assertions.assertThat(foundTimers).hasSize(6);
-            Assertions.assertThat(foundTimers).extracting(SimpleTimer::getId)
-                    .containsExactlyInAnyOrder(timer1.getId(),
-                            timer2.getId(),
-                            timer3.getId(),
-                            timer4.getId(),
-                            timer5.getId(),
-                            timer6.getId());
-        }
-
-        @Test
-        @DisplayName("심플 타이머가 없는 회원을 조회하면 빈 리스트를 반환한다")
-        void it_returns_an_empty_list_when_no_timers_exist() {
-            // given
-            Member member = createAndSaveMember("testMember");
-            flushAndClear();
-
-            // when
-            List<SimpleTimer> foundTimers = simpleTimerRepository.findByMemberAndSimpleTimerDeletedAtNull(member);
-
-            // then
-            assertThat(foundTimers).isNotNull();
-            assertThat(foundTimers).isEmpty();
         }
     }
 

--- a/src/test/java/com/project200/undabang/timer/simple/service/impl/SimpleTimerQueryServiceImplTest.java
+++ b/src/test/java/com/project200/undabang/timer/simple/service/impl/SimpleTimerQueryServiceImplTest.java
@@ -5,7 +5,7 @@ import com.project200.undabang.common.web.exception.CustomException;
 import com.project200.undabang.common.web.exception.ErrorCode;
 import com.project200.undabang.member.entity.Member;
 import com.project200.undabang.member.repository.MemberRepository;
-import com.project200.undabang.timer.simple.dto.response.GetSimpleTimerResponseDto;
+import com.project200.undabang.timer.simple.dto.response.SimpleTimerListResponse;
 import com.project200.undabang.timer.simple.entity.SimpleTimer;
 import com.project200.undabang.timer.simple.repository.SimpleTimerRepository;
 import org.assertj.core.api.Assertions;
@@ -51,10 +51,10 @@ class SimpleTimerQueryServiceImplTest {
             try(MockedStatic<UserContextHolder> ignored = mockStatic(UserContextHolder.class)) {
                 given(UserContextHolder.getUserId()).willReturn(testUserId);
                 given(memberRepository.findById(testUserId)).willReturn(Optional.of(testUser));
-                given(simpleTimerRepository.findByMemberAndSimpleTimerDeletedAtNull(testUser)).willReturn(simpleTimerList);
+                given(simpleTimerRepository.findByMemberAndSimpleTimerDeletedAtNullOrderBySimpleTimerTimeAsc(testUser)).willReturn(simpleTimerList);
 
                 // when
-                GetSimpleTimerResponseDto responseDto = simpleTimerQueryService.getSimpleTimers();
+                SimpleTimerListResponse responseDto = simpleTimerQueryService.getSimpleTimers();
 
                 // then
                 Assertions.assertThat(responseDto).isNotNull();


### PR DESCRIPTION
## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

조회시 SimpleTimer의 id 가 기준이 아닌 Time을 기준으로 오름차순 정렬하도록 구현하였습니다.

반환 DTO 의 이름을 변경하였으며, 테스트코드 동작에 문제가 없음을 확인하였습니다.(마찬가지로 100% 유지중입니다.)
<img width="713" height="89" alt="image" src="https://github.com/user-attachments/assets/06fc71f6-35a6-4106-be25-e81fc0061fb7" />

## #️⃣연관된 이슈

> ex) Closes #241 