### PR TITLE
[Feat] 커스텀 타이머 상세 조회 기능 개발

### DIFF
--- a/src/docs/asciidoc/custom-timer/커스텀-타이머-상세-조회-API.adoc
+++ b/src/docs/asciidoc/custom-timer/커스텀-타이머-상세-조회-API.adoc
@@ -1,0 +1,33 @@
+== 커스텀 타이머 상세 조회 API
+
+=== 설명
+
+- #GET# `/api/v1/custom-timers/{customTimerId}`
+- 커스텀 타이머 상세 조회 API는 사용자가 자신이 저장한 커스텀 타이머와 커스텀 타이머 스텝들을 조회하는 기능을 제공합니다.
+
+=== 개발 이력
+
+- Sprint 9 (2025-08-18): 기능 개발이 완료되었습니다.
+
+=== 개발 참고 사항
+
+- <<공통-개발-참고-사항,공통 개발 참고 사항>>을 참고하세요.
+
+=== 코드 샘플
+
+operation::get-custom-timer-detail/get-custom-timer-detail_-success[snippets="curl-request,http-request,http-response"]
+
+=== 매개 변수
+
+operation::get-custom-timer-detail/get-custom-timer-detail_-success[snippets="request-headers,response-fields"]
+
+==== 응답 상태 코드
+
+|===
+|상태 코드|설명
+|200|커스텀 타이머 및 스텝들의 상세 정보가 성공적으로 조회되었습니다.
+|403|접근 권한이 없습니다.
+|404|회원 정보가 올바르지 않습니다. +
+커스텀 타이머가 존재하지 않습니다.
+|===
+

--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -148,3 +148,5 @@ include::overview/공통-개발-참고-사항.adoc[]
 === xref:커스텀-타이머-API.html[커스텀 타이머 API]
 
 - 커스텀 타이머 리스트 조회 API #GET# `/api/v1/custom-timers`
+
+- 커스텀 타이머 상세 조회 API #GET# `/api/v1/custom-timers/{customTimerId}`

--- a/src/docs/asciidoc/커스텀-타이머-API.adoc
+++ b/src/docs/asciidoc/커스텀-타이머-API.adoc
@@ -20,3 +20,5 @@
 include::overview/공통-개발-참고-사항.adoc[]
 
 include::custom-timer/커스텀-타이머-리스트-조회-API.adoc[]
+
+include::custom-timer/커스텀-타이머-상세-조회-API.adoc[]

--- a/src/main/java/com/project200/undabang/common/web/exception/ErrorCode.java
+++ b/src/main/java/com/project200/undabang/common/web/exception/ErrorCode.java
@@ -43,7 +43,10 @@ public enum ErrorCode {
     POLICY_NOT_FOUND(500, "POLICY_NOT_FOUND", "정책을 찾을 수 없습니다."),
 
     // 심플 타이머 관련 에러
-    SIMPLE_TIMER_NOT_EXIST(404, "SIMPLE_TIMER_NOT_EXIST", "존재하지 않는 타이머 입니다.");
+    SIMPLE_TIMER_NOT_EXIST(404, "SIMPLE_TIMER_NOT_EXIST", "존재하지 않는 타이머 입니다."),
+
+    // 커스텀 타이머 관련 에러
+    CUSTOM_TIMER_NOT_FOUND(404, "CUSTOM_TIMER_NOT_FOUND", "존재하지 않는 타이머 입니다.");
 
     private final HttpStatusCode status;
     private final String code;

--- a/src/main/java/com/project200/undabang/policy/entity/PolicyKey.java
+++ b/src/main/java/com/project200/undabang/policy/entity/PolicyKey.java
@@ -27,5 +27,5 @@ public enum PolicyKey {
     // 심플 타이머
     SIMPLE_TIMER_INIT_COUNT, // 심플 타이머 초기 생성 갯수
     SIMPLE_TIMER_INIT_VALUES, // 심플 타이머 초기 값. 회원 가입시 추가해줘야 함
-
+    SIMPLE_TIMER_MAX_COUNT, // 심플 타이머 최대 보유 갯수
 }

--- a/src/main/java/com/project200/undabang/timer/custom/controller/CustomTimerQueryController.java
+++ b/src/main/java/com/project200/undabang/timer/custom/controller/CustomTimerQueryController.java
@@ -1,11 +1,13 @@
 package com.project200.undabang.timer.custom.controller;
 
 import com.project200.undabang.common.web.response.CommonResponse;
+import com.project200.undabang.timer.custom.dto.response.CustomTimerDetailResponse;
 import com.project200.undabang.timer.custom.dto.response.CustomTimerListResponse;
 import com.project200.undabang.timer.custom.service.CustomTimerQueryService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -19,5 +21,11 @@ public class CustomTimerQueryController {
     public ResponseEntity<CommonResponse<CustomTimerListResponse>> getCustomTimerList() {
 
         return ResponseEntity.ok(CommonResponse.success(customTimerQueryService.getCustomTimerList()));
+    }
+
+    @GetMapping("/v1/custom-timers/{customTimerId}")
+    public ResponseEntity<CommonResponse<CustomTimerDetailResponse>> getCustomTimer(@PathVariable Long customTimerId) {
+
+        return ResponseEntity.ok(CommonResponse.success(customTimerQueryService.getCustomTimerDetail(customTimerId)));
     }
 }

--- a/src/main/java/com/project200/undabang/timer/custom/dto/response/CustomTimerDetailResponse.java
+++ b/src/main/java/com/project200/undabang/timer/custom/dto/response/CustomTimerDetailResponse.java
@@ -13,10 +13,10 @@ import java.util.List;
 @NoArgsConstructor
 @AllArgsConstructor
 public class CustomTimerDetailResponse {
-    List<CustomTimerStepRecord> customTimerSteps;
     private long customTimerId;
     private String customTimerName;
     private int customTimerStepCount;
+    List<CustomTimerStepRecord> customTimerSteps;
 
     public static CustomTimerDetailResponse from(CustomTimer customTimer, List<CustomTimerStepRecord> customTimerSteps) {
         return CustomTimerDetailResponse.builder()

--- a/src/main/java/com/project200/undabang/timer/custom/dto/response/CustomTimerDetailResponse.java
+++ b/src/main/java/com/project200/undabang/timer/custom/dto/response/CustomTimerDetailResponse.java
@@ -1,0 +1,29 @@
+package com.project200.undabang.timer.custom.dto.response;
+
+import com.project200.undabang.timer.custom.entity.CustomTimer;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class CustomTimerDetailResponse {
+    List<CustomTimerStepRecord> customTimerSteps;
+    private long customTimerId;
+    private String customTimerName;
+    private int customTimerStepCount;
+
+    public static CustomTimerDetailResponse from(CustomTimer customTimer, List<CustomTimerStepRecord> customTimerSteps) {
+        return CustomTimerDetailResponse.builder()
+                .customTimerId(customTimer.getId())
+                .customTimerName(customTimer.getCustomTimerName())
+                .customTimerStepCount(customTimerSteps.size())
+                .customTimerSteps(customTimerSteps)
+                .build();
+    }
+}

--- a/src/main/java/com/project200/undabang/timer/custom/dto/response/CustomTimerStepRecord.java
+++ b/src/main/java/com/project200/undabang/timer/custom/dto/response/CustomTimerStepRecord.java
@@ -1,0 +1,5 @@
+package com.project200.undabang.timer.custom.dto.response;
+
+public record CustomTimerStepRecord(Long customTimerStepId, String customTimerStepName, Byte customTimerStepOrder,
+                                    Integer customTimerStepTime) {
+}

--- a/src/main/java/com/project200/undabang/timer/custom/repository/CustomTimerStepRepository.java
+++ b/src/main/java/com/project200/undabang/timer/custom/repository/CustomTimerStepRepository.java
@@ -1,0 +1,11 @@
+package com.project200.undabang.timer.custom.repository;
+
+import com.project200.undabang.timer.custom.entity.CustomTimer;
+import com.project200.undabang.timer.custom.entity.CustomTimerStep;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface CustomTimerStepRepository extends JpaRepository<CustomTimerStep, Long> {
+    List<CustomTimerStep> findAllByCustomTimerAndCustomTimerStepDeletedAtNull(CustomTimer customTimer);
+}

--- a/src/main/java/com/project200/undabang/timer/custom/service/CustomTimerQueryService.java
+++ b/src/main/java/com/project200/undabang/timer/custom/service/CustomTimerQueryService.java
@@ -1,7 +1,10 @@
 package com.project200.undabang.timer.custom.service;
 
+import com.project200.undabang.timer.custom.dto.response.CustomTimerDetailResponse;
 import com.project200.undabang.timer.custom.dto.response.CustomTimerListResponse;
 
 public interface CustomTimerQueryService {
     CustomTimerListResponse getCustomTimerList();
+
+    CustomTimerDetailResponse getCustomTimerDetail(Long customTimerId);
 }

--- a/src/main/java/com/project200/undabang/timer/custom/service/impl/CustomTimerQueryServiceImpl.java
+++ b/src/main/java/com/project200/undabang/timer/custom/service/impl/CustomTimerQueryServiceImpl.java
@@ -5,10 +5,13 @@ import com.project200.undabang.common.web.exception.CustomException;
 import com.project200.undabang.common.web.exception.ErrorCode;
 import com.project200.undabang.member.entity.Member;
 import com.project200.undabang.member.repository.MemberRepository;
+import com.project200.undabang.timer.custom.dto.response.CustomTimerDetailResponse;
 import com.project200.undabang.timer.custom.dto.response.CustomTimerListResponse;
 import com.project200.undabang.timer.custom.dto.response.CustomTimerRecord;
+import com.project200.undabang.timer.custom.dto.response.CustomTimerStepRecord;
 import com.project200.undabang.timer.custom.entity.CustomTimer;
 import com.project200.undabang.timer.custom.repository.CustomTimerRepository;
+import com.project200.undabang.timer.custom.repository.CustomTimerStepRepository;
 import com.project200.undabang.timer.custom.service.CustomTimerQueryService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -22,7 +25,27 @@ import java.util.UUID;
 @RequiredArgsConstructor
 public class CustomTimerQueryServiceImpl implements CustomTimerQueryService {
     private final CustomTimerRepository customTimerRepository;
+    private final CustomTimerStepRepository customTimerStepRepository;
     private final MemberRepository memberRepository;
+
+    /**
+     * 지정된 사용자 정의 타이머 ID를 기반으로 타이머의 세부 정보를 조회하고 반환합니다.
+     * 사용자와 타이머 소유자가 일치하지 않을 경우 권한 오류를 발생시킵니다.
+     */
+    @Override
+    public CustomTimerDetailResponse getCustomTimerDetail(Long customTimerId) {
+        Member member = getMember();
+        CustomTimer timer = customTimerRepository.findById(customTimerId)
+                .orElseThrow(() -> new CustomException(ErrorCode.CUSTOM_TIMER_NOT_FOUND));
+
+        // 회원이 다른 사람의 커스텀 리스트를 조회하려 하는 경우 예외 발생
+        if (!timer.getMember().equals(member)) {
+            throw new CustomException(ErrorCode.AUTHORIZATION_DENIED);
+        }
+
+        // 자신의 커스텀 리스트와 스텝 반환
+        return findCustomTimerStepListAndMapToResponse(timer);
+    }
 
     /**
      * 현재 사용자 ID를 기반으로 해당 사용자가 생성한 사용자 정의 타이머 목록을 반환합니다.
@@ -30,13 +53,34 @@ public class CustomTimerQueryServiceImpl implements CustomTimerQueryService {
      */
     @Override
     public CustomTimerListResponse getCustomTimerList() {
-        UUID memberId = UserContextHolder.getUserId();
-        Member member = memberRepository.findById(memberId).orElseThrow(() -> new CustomException(ErrorCode.MEMBER_NOT_FOUND));
+        Member member = getMember();
 
         List<CustomTimerRecord> recordList = findActiveTimersAndMapToRecords(member);
 
         return CustomTimerListResponse.from(recordList);
     }
+
+    /**
+     * 주어진 CustomTimer 객체를 기반으로 사용자 정의 타이머 단계 목록을 조회하고,
+     * 이를 매핑하여 CustomTimerDetailResponse 객체로 반환합니다.
+     */
+    private CustomTimerDetailResponse findCustomTimerStepListAndMapToResponse(CustomTimer customTimer) {
+        List<CustomTimerStepRecord> customTimerStepRecordList = customTimerStepRepository.findAllByCustomTimerAndCustomTimerStepDeletedAtNull(customTimer)
+                .stream().map(step -> new CustomTimerStepRecord(step.getId(), step.getCustomTimerStepName(), step.getCustomTimerStepOrder(), step.getCustomTimerStepTime()))
+                .toList();
+
+        return CustomTimerDetailResponse.from(customTimer, customTimerStepRecordList);
+    }
+
+    /**
+     * 현재 컨텍스트의 사용자 ID를 기반으로 데이터베이스에서 회원 정보를 조회합니다.
+     * 해당 ID로 회원이 존재하지 않을 경우 CustomException을 발생시킵니다.
+     */
+    private Member getMember() {
+        UUID memberId = UserContextHolder.getUserId();
+        return memberRepository.findById(memberId).orElseThrow(() -> new CustomException(ErrorCode.MEMBER_NOT_FOUND));
+    }
+
 
     /**
      * 주어진 회원 정보를 기반으로 사용자 정의 타이머의 목록중 삭제되지 않은 타이머를

--- a/src/test/java/com/project200/undabang/timer/custom/controller/CustomTimerQueryControllerTest.java
+++ b/src/test/java/com/project200/undabang/timer/custom/controller/CustomTimerQueryControllerTest.java
@@ -3,8 +3,10 @@ package com.project200.undabang.timer.custom.controller;
 import com.project200.undabang.common.web.exception.CustomException;
 import com.project200.undabang.common.web.exception.ErrorCode;
 import com.project200.undabang.configuration.AbstractRestDocSupport;
+import com.project200.undabang.timer.custom.dto.response.CustomTimerDetailResponse;
 import com.project200.undabang.timer.custom.dto.response.CustomTimerListResponse;
 import com.project200.undabang.timer.custom.dto.response.CustomTimerRecord;
+import com.project200.undabang.timer.custom.dto.response.CustomTimerStepRecord;
 import com.project200.undabang.timer.custom.service.CustomTimerQueryService;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -33,6 +35,88 @@ class CustomTimerQueryControllerTest extends AbstractRestDocSupport {
 
     @MockitoBean
     private CustomTimerQueryService customTimerQueryService;
+
+    @Nested
+    @DisplayName("GET /api/v1/custom-timers/{customTimerId} API는")
+    class GetCustomTimerDetail {
+
+        @Test
+        @DisplayName("정상적으로 커스텀 타이머 상세 정보를 반환한다")
+        void getCustomTimerDetail_Success() throws Exception {
+            // given
+            UUID memberId = UUID.randomUUID();
+            Long customTimerId = 1L;
+            List<CustomTimerStepRecord> steps = List.of(
+                    new CustomTimerStepRecord(10L, "운동1", (byte) 1, 60),
+                    new CustomTimerStepRecord(11L, "휴식1", (byte) 2, 30),
+                    new CustomTimerStepRecord(12L, "운동2", (byte) 3, 60),
+                    new CustomTimerStepRecord(13L, "휴식2", (byte) 4, 30)
+            );
+            CustomTimerDetailResponse response = CustomTimerDetailResponse.builder()
+                    .customTimerId(customTimerId)
+                    .customTimerName("타이머")
+                    .customTimerStepCount(steps.size())
+                    .customTimerSteps(steps)
+                    .build();
+
+            BDDMockito.given(customTimerQueryService.getCustomTimerDetail(customTimerId)).willReturn(response);
+
+            // when & then
+            mockMvc.perform(get("/api/v1/custom-timers/{customTimerId}", customTimerId)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .accept(MediaType.APPLICATION_JSON)
+                            .headers(getCommonApiHeaders(memberId)))
+                    .andExpectAll(
+                            status().isOk(),
+                            jsonPath("$.succeed").value(true),
+                            jsonPath("$.code").value("SUCCESS"),
+                            jsonPath("$.data.customTimerId").value(customTimerId),
+                            jsonPath("$.data.customTimerName").value("타이머"),
+                            jsonPath("$.data.customTimerStepCount").value(4),
+                            jsonPath("$.data.customTimerSteps").isArray(),
+                            jsonPath("$.data.customTimerSteps[0].customTimerStepName").value("운동1")
+                    )
+                    .andDo(document.document(
+                            requestHeaders(HEADER_ACCESS_TOKEN),
+                            responseFields(commonResponseFields(
+                                    fieldWithPath("data.customTimerId").type(NUMBER).description("커스텀 타이머 식별자 입니다."),
+                                    fieldWithPath("data.customTimerName").type(STRING).description("커스텀 타이머 이름 입니다."),
+                                    fieldWithPath("data.customTimerStepCount").type(NUMBER).description("커스텀 타이머 스텝 리스트의 크기를 담고있는 데이터 입니다."),
+                                    fieldWithPath("data.customTimerSteps").type(ARRAY).description("커스텀 타이머 스텝 리스트 입니다. 내용에는 스텝의 식별자, 이름, 순서, 시간이 포함됩니다"),
+                                    fieldWithPath("data.customTimerSteps[].customTimerStepId").type(NUMBER).description("커스텀 타이머 스텝의 식별자 정보입니다."),
+                                    fieldWithPath("data.customTimerSteps[].customTimerStepName").type(STRING).description("커스텀 타이머 스텝의 이름 정보입니다."),
+                                    fieldWithPath("data.customTimerSteps[].customTimerStepOrder").type(NUMBER).description("커스텀 타이머 스텝의 순서 정보입니다."),
+                                    fieldWithPath("data.customTimerSteps[].customTimerStepTime").type(NUMBER).description("커스텀 타이머 스텝의 시간 정보를 의미합니다. 단위는 초 입니다.")
+                            ))
+                    ));
+
+            BDDMockito.then(customTimerQueryService).should(BDDMockito.times(1)).getCustomTimerDetail(customTimerId);
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 타이머 조회 시 실패한다")
+        void getCustomTimerDetail_Fail_NotFound() throws Exception {
+            // given
+            UUID memberId = UUID.randomUUID();
+            Long customTimerId = 999L;
+            BDDMockito.given(customTimerQueryService.getCustomTimerDetail(customTimerId))
+                    .willThrow(new CustomException(ErrorCode.CUSTOM_TIMER_NOT_FOUND));
+
+            // when & then
+            mockMvc.perform(get("/api/v1/custom-timers/{customTimerId}", customTimerId)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .accept(MediaType.APPLICATION_JSON)
+                            .headers(getCommonApiHeaders(memberId)))
+                    .andExpectAll(
+                            status().isNotFound(),
+                            jsonPath("$.succeed").value(false),
+                            jsonPath("$.code").value(ErrorCode.CUSTOM_TIMER_NOT_FOUND.getCode()),
+                            jsonPath("$.message").value(ErrorCode.CUSTOM_TIMER_NOT_FOUND.getMessage())
+                    );
+
+            BDDMockito.then(customTimerQueryService).should(BDDMockito.times(1)).getCustomTimerDetail(customTimerId);
+        }
+    }
 
     @Nested
     @DisplayName("GET /api/v1/custom-timers API는")

--- a/src/test/java/com/project200/undabang/timer/custom/repository/CustomTimerRepositoryTest.java
+++ b/src/test/java/com/project200/undabang/timer/custom/repository/CustomTimerRepositoryTest.java
@@ -3,7 +3,6 @@ package com.project200.undabang.timer.custom.repository;
 import com.project200.undabang.configuration.TestQuerydslConfig;
 import com.project200.undabang.member.entity.Member;
 import com.project200.undabang.member.enums.MemberGender;
-import com.project200.undabang.member.repository.MemberRepository;
 import com.project200.undabang.timer.custom.entity.CustomTimer;
 import jakarta.persistence.EntityManager;
 import org.junit.jupiter.api.DisplayName;
@@ -29,35 +28,6 @@ class CustomTimerRepositoryTest {
 
     @Autowired
     private CustomTimerRepository customTimerRepository;
-
-    @Autowired
-    private MemberRepository memberRepository;
-
-    private Member createAndSaveMember(String nickname) {
-        Member member = Member.builder()
-                .memberId(UUID.randomUUID())
-                .memberEmail(nickname + "@email.com")
-                .memberNickname(nickname)
-                .memberGender(MemberGender.UNKNOWN)
-                .memberBday(LocalDate.of(2000, 1, 1))
-                .build();
-        em.persist(member);
-        return member;
-    }
-
-    private CustomTimer createAndSaveCustomTimer(Member member, String name) {
-        CustomTimer timer = CustomTimer.builder()
-                .member(member)
-                .customTimerName(name)
-                .build();
-        em.persist(timer);
-        return timer;
-    }
-
-    private void flushAndClear() {
-        em.flush();
-        em.clear();
-    }
 
     @Nested
     @DisplayName("findByMemberAndCustomTimerDeletedAtNull 메소드는")
@@ -120,5 +90,31 @@ class CustomTimerRepositoryTest {
             assertThat(foundTimers).hasSize(1);
             assertThat(foundTimers.get(0).getId()).isEqualTo(activeTimer.getId());
         }
+    }
+
+    private Member createAndSaveMember(String nickname) {
+        Member member = Member.builder()
+                .memberId(UUID.randomUUID())
+                .memberEmail(nickname + "@email.com")
+                .memberNickname(nickname)
+                .memberGender(MemberGender.UNKNOWN)
+                .memberBday(LocalDate.of(2000, 1, 1))
+                .build();
+        em.persist(member);
+        return member;
+    }
+
+    private CustomTimer createAndSaveCustomTimer(Member member, String name) {
+        CustomTimer timer = CustomTimer.builder()
+                .member(member)
+                .customTimerName(name)
+                .build();
+        em.persist(timer);
+        return timer;
+    }
+
+    private void flushAndClear() {
+        em.flush();
+        em.clear();
     }
 }

--- a/src/test/java/com/project200/undabang/timer/custom/repository/CustomTimerStepRepositoryTest.java
+++ b/src/test/java/com/project200/undabang/timer/custom/repository/CustomTimerStepRepositoryTest.java
@@ -1,0 +1,119 @@
+package com.project200.undabang.timer.custom.repository;
+
+import com.project200.undabang.configuration.TestQuerydslConfig;
+import com.project200.undabang.member.entity.Member;
+import com.project200.undabang.member.enums.MemberGender;
+import com.project200.undabang.timer.custom.entity.CustomTimer;
+import com.project200.undabang.timer.custom.entity.CustomTimerStep;
+import jakarta.persistence.EntityManager;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+
+@DataJpaTest
+@Import(TestQuerydslConfig.class)
+class CustomTimerStepRepositoryTest {
+
+    @Autowired
+    private EntityManager em;
+
+    @Autowired
+    private CustomTimerStepRepository customTimerStepRepository;
+
+    private Member createAndSaveMember() {
+        Member member = Member.builder()
+                .memberId(UUID.randomUUID())
+                .memberEmail("test@email.com")
+                .memberNickname("test")
+                .memberGender(MemberGender.UNKNOWN)
+                .memberBday(LocalDate.of(2000, 1, 1))
+                .build();
+        em.persist(member);
+        return member;
+    }
+
+    private CustomTimer createAndSaveCustomTimer(Member member) {
+        CustomTimer timer = CustomTimer.builder()
+                .member(member)
+                .customTimerName("timer")
+                .build();
+        em.persist(timer);
+        return timer;
+    }
+
+    private CustomTimerStep createAndSaveStep(CustomTimer timer, String name, byte order) {
+        CustomTimerStep step = CustomTimerStep.builder()
+                .customTimer(timer)
+                .customTimerStepName(name)
+                .customTimerStepOrder(order)
+                .customTimerStepTime(60)
+                .build();
+        em.persist(step);
+        return step;
+    }
+
+    private void flushAndClear() {
+        em.flush();
+        em.clear();
+    }
+
+    @Nested
+    @DisplayName("findAllByCustomTimerAndCustomTimerStepDeletedAtNull 메소드는")
+    class Describe_findAllByCustomTimerAndCustomTimerStepDeletedAtNull {
+
+        @Test
+        @DisplayName("특정 타이머의 삭제되지 않은 스텝 목록을 반환한다")
+        void it_returns_active_steps() {
+            // given
+            Member member = createAndSaveMember();
+            CustomTimer timer = createAndSaveCustomTimer(member);
+
+            CustomTimerStep step1 = createAndSaveStep(timer, "step1", (byte) 1);
+            CustomTimerStep step2 = createAndSaveStep(timer, "step2", (byte) 2);
+
+            // 삭제된 스텝
+            CustomTimerStep deletedStep = CustomTimerStep.builder()
+                    .customTimer(timer)
+                    .customTimerStepName("deleted")
+                    .customTimerStepOrder((byte) 3)
+                    .customTimerStepTime(30)
+                    .customTimerStepDeletedAt(LocalDateTime.now())
+                    .build();
+            em.persist(deletedStep);
+
+            flushAndClear();
+
+            // when
+            List<CustomTimerStep> foundSteps = customTimerStepRepository.findAllByCustomTimerAndCustomTimerStepDeletedAtNull(timer);
+
+            // then
+            Assertions.assertThat(foundSteps).hasSize(2);
+            Assertions.assertThat(foundSteps).extracting(CustomTimerStep::getCustomTimerStepName)
+                    .containsExactlyInAnyOrder("step1", "step2");
+        }
+
+        @Test
+        @DisplayName("스텝이 없는 경우 빈 리스트를 반환한다")
+        void it_returns_empty_list_when_no_steps() {
+            // given
+            Member member = createAndSaveMember();
+            CustomTimer timer = createAndSaveCustomTimer(member);
+            flushAndClear();
+
+            // when
+            List<CustomTimerStep> foundSteps = customTimerStepRepository.findAllByCustomTimerAndCustomTimerStepDeletedAtNull(timer);
+
+            // then
+            Assertions.assertThat(foundSteps).isNotNull().isEmpty();
+        }
+    }
+}

--- a/src/test/java/com/project200/undabang/timer/custom/service/impl/CustomTimerQueryServiceImplTest.java
+++ b/src/test/java/com/project200/undabang/timer/custom/service/impl/CustomTimerQueryServiceImplTest.java
@@ -5,9 +5,12 @@ import com.project200.undabang.common.web.exception.CustomException;
 import com.project200.undabang.common.web.exception.ErrorCode;
 import com.project200.undabang.member.entity.Member;
 import com.project200.undabang.member.repository.MemberRepository;
+import com.project200.undabang.timer.custom.dto.response.CustomTimerDetailResponse;
 import com.project200.undabang.timer.custom.dto.response.CustomTimerListResponse;
 import com.project200.undabang.timer.custom.entity.CustomTimer;
+import com.project200.undabang.timer.custom.entity.CustomTimerStep;
 import com.project200.undabang.timer.custom.repository.CustomTimerRepository;
+import com.project200.undabang.timer.custom.repository.CustomTimerStepRepository;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -28,6 +31,10 @@ import static org.mockito.Mockito.mockStatic;
 
 @ExtendWith(MockitoExtension.class)
 class CustomTimerQueryServiceImplTest {
+
+    @Mock
+    private CustomTimerStepRepository customTimerStepRepository;
+
     @Mock
     private CustomTimerRepository customTimerRepository;
 
@@ -36,6 +43,75 @@ class CustomTimerQueryServiceImplTest {
 
     @InjectMocks
     private CustomTimerQueryServiceImpl customTimerQueryService;
+
+    @Nested
+    @DisplayName("getCustomTimerDetail() 메소드는")
+    class Describe_getCustomTimerDetail {
+
+        @Test
+        @DisplayName("정상적으로 타이머 상세 정보를 반환한다")
+        void returns_detail_response() {
+            // given
+            UUID userId = UUID.randomUUID();
+            Member member = Member.builder().memberId(userId).build();
+            CustomTimer timer = CustomTimer.builder().id(1L).member(member).customTimerName("타이머").build();
+            CustomTimerStep step = CustomTimerStep.builder().id(10L).customTimer(timer).customTimerStepName("스텝1").customTimerStepOrder((byte) 1).customTimerStepTime(60).build();
+
+            try (MockedStatic<UserContextHolder> ignored = mockStatic(UserContextHolder.class)) {
+                given(UserContextHolder.getUserId()).willReturn(userId);
+                given(memberRepository.findById(userId)).willReturn(Optional.of(member));
+                given(customTimerRepository.findById(1L)).willReturn(Optional.of(timer));
+                given(customTimerStepRepository.findAllByCustomTimerAndCustomTimerStepDeletedAtNull(timer)).willReturn(List.of(step));
+
+                // when
+                CustomTimerDetailResponse response = customTimerQueryService.getCustomTimerDetail(1L);
+
+                // then
+                assertThat(response).isNotNull();
+                assertThat(response.getCustomTimerId()).isEqualTo(timer.getId());
+                assertThat(response.getCustomTimerName()).isEqualTo(timer.getCustomTimerName());
+                assertThat(response.getCustomTimerSteps()).hasSize(1);
+                assertThat(response.getCustomTimerSteps().get(0).customTimerStepName()).isEqualTo("스텝1");
+            }
+        }
+
+        @Test
+        @DisplayName("타이머가 존재하지 않으면 예외를 던진다")
+        void throws_when_timer_not_found() {
+            UUID userId = UUID.randomUUID();
+            Member member = Member.builder().memberId(userId).build();
+
+            try (MockedStatic<UserContextHolder> ignored = mockStatic(UserContextHolder.class)) {
+                given(UserContextHolder.getUserId()).willReturn(userId);
+                given(memberRepository.findById(userId)).willReturn(Optional.of(member));
+                given(customTimerRepository.findById(1L)).willReturn(Optional.empty());
+
+                assertThatThrownBy(() -> customTimerQueryService.getCustomTimerDetail(1L))
+                        .isInstanceOf(CustomException.class)
+                        .hasFieldOrPropertyWithValue("errorCode", ErrorCode.CUSTOM_TIMER_NOT_FOUND);
+            }
+        }
+
+        @Test
+        @DisplayName("타이머 소유자가 아니면 권한 예외를 던진다")
+        void throws_when_not_owner() {
+            UUID userId = UUID.randomUUID();
+            UUID otherUserId = UUID.randomUUID();
+            Member member = Member.builder().memberId(userId).build();
+            Member otherMember = Member.builder().memberId(otherUserId).build();
+            CustomTimer timer = CustomTimer.builder().id(1L).member(otherMember).customTimerName("타이머").build();
+
+            try (MockedStatic<UserContextHolder> ignored = mockStatic(UserContextHolder.class)) {
+                given(UserContextHolder.getUserId()).willReturn(userId);
+                given(memberRepository.findById(userId)).willReturn(Optional.of(member));
+                given(customTimerRepository.findById(1L)).willReturn(Optional.of(timer));
+
+                assertThatThrownBy(() -> customTimerQueryService.getCustomTimerDetail(1L))
+                        .isInstanceOf(CustomException.class)
+                        .hasFieldOrPropertyWithValue("errorCode", ErrorCode.AUTHORIZATION_DENIED);
+            }
+        }
+    }
 
     @Nested
     @DisplayName("getCustomTimerList() 메소드는")


### PR DESCRIPTION
## 📝작업 내용

커스텀 타이머 상세 조회 기능을 개발하였습니다.
기존 API 설계를 기반으로 작성되었으며, 이전 기능 개발과 마찬가지로 테스트케이스 100%를 유지하였습니다.
<img width="700" height="63" alt="image" src="https://github.com/user-attachments/assets/1f040091-f33b-455d-82ac-b86718ee3390" />

API 명세서는 다음과 같이 작성하였습니다.
<img width="682" height="145" alt="image" src="https://github.com/user-attachments/assets/5f625a11-00a1-4df3-bbee-4441cb15ffd9" />
<img width="994" height="655" alt="image" src="https://github.com/user-attachments/assets/92f481cc-347d-45b7-b37e-82cc3c57918d" />
<img width="996" height="208" alt="image" src="https://github.com/user-attachments/assets/9785049c-187a-40eb-a913-02ec5bf9baf5" />
<img width="1004" height="762" alt="image" src="https://github.com/user-attachments/assets/67892a5d-df87-47c5-8fb3-08565b9035af" />
<img width="1010" height="213" alt="image" src="https://github.com/user-attachments/assets/c6ce6e98-1fd5-4def-962a-22635b0e845e" />
<img width="998" height="816" alt="image" src="https://github.com/user-attachments/assets/4ba398f8-3816-4b06-9d4b-32451e9aa9fe" />
<img width="1000" height="802" alt="image" src="https://github.com/user-attachments/assets/dda8eaa9-c247-4ee0-95e4-64bd1f85ae00" />
<img width="999" height="295" alt="image" src="https://github.com/user-attachments/assets/0f191395-76b5-4147-8525-45f48d7bfadc" />

실제 응답 결과는 다음과 같습니다. 내용이 너무 길어 맨 처음 스텝 내용을 제외하고 나머지 내용은 요약된 상태로 캡쳐하였습니다.
<img width="886" height="537" alt="image" src="https://github.com/user-attachments/assets/59d8e6b5-1d40-4d0d-8581-553bc9c43e8f" />


## #️⃣연관된 이슈

> API 설계 #207 , Closes #235 