### PR TITLE
[Fix] 심플 타이머 에러코드 이름 변경

### DIFF
--- a/src/docs/asciidoc/simple-timer/심플-타이머-삭제-API.adoc
+++ b/src/docs/asciidoc/simple-timer/심플-타이머-삭제-API.adoc
@@ -28,6 +28,6 @@ operation::delete-simple-timer/delete-simple-timer_-success[snippets="request-he
 |200|심플 타이머 정보가 성공적으로 삭제되었습니다.
 |400|입력 정보가 정확하지 않습니다.
 |404|회원이 존재하지 않습니다. +
-심플 타이머가 존재하지 않습니다.
+존재하지 않는 타이머 입니다.
 |===
 

--- a/src/docs/asciidoc/simple-timer/심플-타이머-수정-API.adoc
+++ b/src/docs/asciidoc/simple-timer/심플-타이머-수정-API.adoc
@@ -28,6 +28,6 @@ operation::update-simple-timer/update-simple-timer_-success[snippets="request-he
 |200|심플 타이머 정보가 성공적으로 수정되었습니다.
 |400|입력 정보가 정확하지 않습니다.
 |404|회원이 존재하지 않습니다. +
-심플 타이머가 존재하지 않습니다.
+존재하지 않는 타이머 입니다.
 |===
 

--- a/src/main/java/com/project200/undabang/common/web/exception/ErrorCode.java
+++ b/src/main/java/com/project200/undabang/common/web/exception/ErrorCode.java
@@ -43,7 +43,7 @@ public enum ErrorCode {
     POLICY_NOT_FOUND(500, "POLICY_NOT_FOUND", "정책을 찾을 수 없습니다."),
 
     // 심플 타이머 관련 에러
-    SIMPLE_TIMER_NOT_EXIST(404, "SIMPLE_TIMER_NOT_EXIST", "존재하지 않는 타이머 입니다."),
+    SIMPLE_TIMER_NOT_FOUND(404, "SIMPLE_TIMER_NOT_FOUND", "존재하지 않는 타이머 입니다."),
     SIMPLE_TIMER_MAX_COUNT_VIOLATION(409, "SIMPLE_TIMER_MAX_COUNT_VIOLATION", "최대 심플 타이머 개수(6개)를 초과했습니다.");
 
     private final HttpStatusCode status;

--- a/src/main/java/com/project200/undabang/timer/simple/service/impl/SimpleTimerCommandServiceImpl.java
+++ b/src/main/java/com/project200/undabang/timer/simple/service/impl/SimpleTimerCommandServiceImpl.java
@@ -55,7 +55,7 @@ public class SimpleTimerCommandServiceImpl implements SimpleTimerCommandService 
                 .orElseThrow(() -> new CustomException(ErrorCode.MEMBER_NOT_FOUND));
 
         SimpleTimer timer = simpleTimerRepository.findByIdAndMemberAndSimpleTimerDeletedAtNull(simpleTimerId, member)
-                .orElseThrow(() -> new CustomException(ErrorCode.SIMPLE_TIMER_NOT_EXIST));
+                .orElseThrow(() -> new CustomException(ErrorCode.SIMPLE_TIMER_NOT_FOUND));
 
         timer.deleteSimpleTimer();
     }
@@ -69,7 +69,7 @@ public class SimpleTimerCommandServiceImpl implements SimpleTimerCommandService 
         Member member = memberRepository.findById(memberId).orElseThrow(() -> new CustomException(ErrorCode.MEMBER_NOT_FOUND));
 
         SimpleTimer timer = simpleTimerRepository.findByIdAndMemberAndSimpleTimerDeletedAtNull(simpleTimerId, member).orElseThrow(
-                () -> new CustomException(ErrorCode.SIMPLE_TIMER_NOT_EXIST));
+                () -> new CustomException(ErrorCode.SIMPLE_TIMER_NOT_FOUND));
 
         timer.updateSimpleTimer(dto.getTime());
     }

--- a/src/test/java/com/project200/undabang/timer/simple/controller/SimpleTimerCommandControllerTest.java
+++ b/src/test/java/com/project200/undabang/timer/simple/controller/SimpleTimerCommandControllerTest.java
@@ -175,15 +175,15 @@ class SimpleTimerCommandControllerTest extends AbstractRestDocSupport {
             Long nonExistentTimerId = 999L;
             UUID memberId = UUID.randomUUID();
 
-            willThrow(new CustomException(ErrorCode.SIMPLE_TIMER_NOT_EXIST))
+            willThrow(new CustomException(ErrorCode.SIMPLE_TIMER_NOT_FOUND))
                     .given(simpleTimerCommandService).deleteSimpleTimer(nonExistentTimerId);
 
             // when & then
             mockMvc.perform(delete("/api/v1/simple-timers/{simpleTimerId}", nonExistentTimerId)
                             .headers(getCommonApiHeaders(memberId)))
                     .andExpect(status().isNotFound())
-                    .andExpect(jsonPath("$.code").value(ErrorCode.SIMPLE_TIMER_NOT_EXIST.getCode()))
-                    .andExpect(jsonPath("$.message").value(ErrorCode.SIMPLE_TIMER_NOT_EXIST.getMessage()));
+                    .andExpect(jsonPath("$.code").value(ErrorCode.SIMPLE_TIMER_NOT_FOUND.getCode()))
+                    .andExpect(jsonPath("$.message").value(ErrorCode.SIMPLE_TIMER_NOT_FOUND.getMessage()));
 
             BDDMockito.then(simpleTimerCommandService).should().deleteSimpleTimer(nonExistentTimerId);
         }
@@ -281,7 +281,7 @@ class SimpleTimerCommandControllerTest extends AbstractRestDocSupport {
             UUID memberId = UUID.randomUUID();
             SimpleTimerUpdateRequestDto requestDto = new SimpleTimerUpdateRequestDto(180);
 
-            BDDMockito.willThrow(new CustomException(ErrorCode.SIMPLE_TIMER_NOT_EXIST))
+            BDDMockito.willThrow(new CustomException(ErrorCode.SIMPLE_TIMER_NOT_FOUND))
                     .given(simpleTimerCommandService).updateSimpleTimer(eq(nonExistentTimerId), any(SimpleTimerUpdateRequestDto.class));
 
             // when & then
@@ -290,8 +290,8 @@ class SimpleTimerCommandControllerTest extends AbstractRestDocSupport {
                             .headers(getCommonApiHeaders(memberId))
                             .content(objectMapper.writeValueAsString(requestDto)))
                     .andExpect(status().isNotFound())
-                    .andExpect(jsonPath("$.code").value(ErrorCode.SIMPLE_TIMER_NOT_EXIST.getCode()))
-                    .andExpect(jsonPath("$.message").value(ErrorCode.SIMPLE_TIMER_NOT_EXIST.getMessage()));
+                    .andExpect(jsonPath("$.code").value(ErrorCode.SIMPLE_TIMER_NOT_FOUND.getCode()))
+                    .andExpect(jsonPath("$.message").value(ErrorCode.SIMPLE_TIMER_NOT_FOUND.getMessage()));
 
             BDDMockito.then(simpleTimerCommandService).should().updateSimpleTimer(eq(nonExistentTimerId), any(SimpleTimerUpdateRequestDto.class));
         }

--- a/src/test/java/com/project200/undabang/timer/simple/service/impl/SimpleTimerCommandServiceImplTest.java
+++ b/src/test/java/com/project200/undabang/timer/simple/service/impl/SimpleTimerCommandServiceImplTest.java
@@ -185,7 +185,7 @@ class SimpleTimerCommandServiceImplTest {
         }
 
         @Test
-        @DisplayName("삭제하려는 타이머가 존재하지 않으면 SIMPLE_TIMER_NOT_EXIST 예외를 발생시킨다")
+        @DisplayName("삭제하려는 타이머가 존재하지 않으면 SIMPLE_TIMER_NOT_FOUND 예외를 발생시킨다")
         void deleteSimpleTimer_Fail_TimerNotExist() {
             // given
             Long nonExistentTimerId = 999L;
@@ -201,7 +201,7 @@ class SimpleTimerCommandServiceImplTest {
                 // when & then
                 assertThatThrownBy(() -> simpleTimerCommandService.deleteSimpleTimer(nonExistentTimerId))
                         .isInstanceOf(CustomException.class)
-                        .hasMessage(ErrorCode.SIMPLE_TIMER_NOT_EXIST.getMessage());
+                        .hasMessage(ErrorCode.SIMPLE_TIMER_NOT_FOUND.getMessage());
 
                 then(simpleTimerRepository).should().findByIdAndMemberAndSimpleTimerDeletedAtNull(nonExistentTimerId, member);
             }
@@ -275,7 +275,7 @@ class SimpleTimerCommandServiceImplTest {
         }
 
         @Test
-        @DisplayName("수정하려는 타이머가 존재하지 않으면 CustomException(SIMPLE_TIMER_NOT_EXIST)을 발생시킨다")
+        @DisplayName("수정하려는 타이머가 존재하지 않으면 CustomException(SIMPLE_TIMER_NOT_FOUND)을 발생시킨다")
         void updateSimpleTimer_Fail_TimerNotExist() {
             // given
             Long nonExistentTimerId = 999L;
@@ -293,7 +293,7 @@ class SimpleTimerCommandServiceImplTest {
                 // when & then
                 assertThatThrownBy(() -> simpleTimerCommandService.updateSimpleTimer(nonExistentTimerId, requestDto))
                         .isInstanceOf(CustomException.class)
-                        .hasMessage(ErrorCode.SIMPLE_TIMER_NOT_EXIST.getMessage());
+                        .hasMessage(ErrorCode.SIMPLE_TIMER_NOT_FOUND.getMessage());
             }
         }
 


### PR DESCRIPTION
## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

기존 심플타이머의 404 SIMPLE_TIMER_NOT_EXIST 에러코드를 404 SIMPLE_TIMER_NOT_FOUND 로 변경하였습니다.
또한 응답시 문구를 "심플 타이머가 존재하지 않습니다." 에서 "존재하지 않는 타이머 입니다."로 통일하였습니다.

해당 변경 이후, 테스트코드 잘 돌아가는것 확인하였고, 로컬에서 변경된 문구로 응답 확인하였습니다. 

### 스크린샷 (선택)
API 응답 사진입니다.
<img width="353" height="203" alt="image" src="https://github.com/user-attachments/assets/c78eb9df-ad34-43d2-a455-6868e05a5202" />

테스트코드 커버리지 사진입니다.
<img width="704" height="112" alt="image" src="https://github.com/user-attachments/assets/53fdaef5-b9e0-4d0a-a6c5-808072c5868a" />

변경된 API 명세서 사진입니다.
<img width="644" height="218" alt="image" src="https://github.com/user-attachments/assets/aed80096-d23f-4a5e-9f70-7481166a5ca7" />
<img width="899" height="402" alt="image" src="https://github.com/user-attachments/assets/5bc7dbdd-d5bf-4845-ac9d-7a3a984eef9f" />
<img width="987" height="267" alt="image" src="https://github.com/user-attachments/assets/f9400cfe-f9d3-4ee6-bc54-3b15f22ae98e" />
<img width="330" height="86" alt="image" src="https://github.com/user-attachments/assets/8f6a023b-a698-4584-b5f9-174f82e49844" />
<img width="992" height="264" alt="image" src="https://github.com/user-attachments/assets/e8c41b7c-94ab-4abd-8e45-e20bb21f04c3" />



## #️⃣연관된 이슈

> ex) Closes #244