### PR TITLE
[Feat] 커스텀 타이머 삭제 기능 개발

### DIFF
--- a/src/docs/asciidoc/custom-timer/커스텀-타이머-삭제-API.adoc
+++ b/src/docs/asciidoc/custom-timer/커스텀-타이머-삭제-API.adoc
@@ -1,0 +1,32 @@
+== 커스텀 타이머 삭제 API
+
+=== 설명
+
+- #DELETE# `/api/v1/custom-timers/{customTimerId}`
+- 커스텀 타이머 삭제 API는 사용자가 자신이 생성한 커스텀 타이머와 커스텀 타이머 스텝들을 삭제하는 기능을 제공합니다.
+
+=== 개발 이력
+
+- Sprint 10 (2025-08-22): 기능 개발이 완료되었습니다.
+
+=== 개발 참고 사항
+
+- <<공통-개발-참고-사항,공통 개발 참고 사항>>을 참고하세요.
+
+=== 코드 샘플
+
+operation::delete-custom-timer/delete-custom-timer_-success[snippets="curl-request,http-request,http-response"]
+
+=== 매개 변수
+
+operation::delete-custom-timer/delete-custom-timer_-success[snippets="request-headers,response-fields"]
+
+==== 응답 상태 코드
+
+|===
+|상태 코드|설명
+|200| 커스텀 타이머가 성공적으로 삭제되었습니다.
+|404| 회원 정보가 올바르지 않습니다. +
+존재하지 않는 타이머입니다.
+|===
+

--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -154,3 +154,5 @@ include::overview/공통-개발-참고-사항.adoc[]
 - 커스텀 타이머 상세 조회 API #GET# `/api/v1/custom-timers/{customTimerId}`
 
 - 커스텀 타이머 생성 API #POST# `/api/v1/custom-timers`
+
+- 커스텀 타이머 삭제 API #DELETE# `/api/v1/custom-timers/{customTimerId}`

--- a/src/docs/asciidoc/커스텀-타이머-API.adoc
+++ b/src/docs/asciidoc/커스텀-타이머-API.adoc
@@ -24,3 +24,5 @@ include::custom-timer/커스텀-타이머-리스트-조회-API.adoc[]
 include::custom-timer/커스텀-타이머-상세-조회-API.adoc[]
 
 include::custom-timer/커스텀-타이머-생성-API.adoc[]
+
+include::custom-timer/커스텀-타이머-삭제-API.adoc[]

--- a/src/main/java/com/project200/undabang/timer/custom/controller/CustomTimerCommandController.java
+++ b/src/main/java/com/project200/undabang/timer/custom/controller/CustomTimerCommandController.java
@@ -8,10 +8,7 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
@@ -23,6 +20,13 @@ public class CustomTimerCommandController {
     public ResponseEntity<CommonResponse<CustomTimerCreateResponse>> createCustomTimer(@Valid @RequestBody CustomTimerCreateRequest request) {
 
         return ResponseEntity.status(HttpStatus.CREATED).body(CommonResponse.create(customTimerCommandService.createCustomTimer(request)));
+    }
+
+    @DeleteMapping("/v1/custom-timers/{customTimerId}")
+    public ResponseEntity<CommonResponse<Void>> deleteCustomTimer(@PathVariable Long customTimerId) {
+
+        customTimerCommandService.deleteCustomTimer(customTimerId);
+        return ResponseEntity.ok(CommonResponse.delete(null));
     }
 
 }

--- a/src/main/java/com/project200/undabang/timer/custom/entity/CustomTimer.java
+++ b/src/main/java/com/project200/undabang/timer/custom/entity/CustomTimer.java
@@ -58,4 +58,8 @@ public class CustomTimer {
                 .customTimerUpdatedAt(LocalDateTime.now())
                 .build();
     }
+
+    public void deleteCustomTimer() {
+        this.customTimerDeletedAt = LocalDateTime.now();
+    }
 }

--- a/src/main/java/com/project200/undabang/timer/custom/entity/CustomTimerStep.java
+++ b/src/main/java/com/project200/undabang/timer/custom/entity/CustomTimerStep.java
@@ -64,8 +64,4 @@ public class CustomTimerStep {
                 .customTimerStepUpdatedAt(LocalDateTime.now())
                 .build();
     }
-
-    public void deleteCustomTimerStep() {
-        this.customTimerStepDeletedAt = LocalDateTime.now();
-    }
 }

--- a/src/main/java/com/project200/undabang/timer/custom/entity/CustomTimerStep.java
+++ b/src/main/java/com/project200/undabang/timer/custom/entity/CustomTimerStep.java
@@ -64,4 +64,8 @@ public class CustomTimerStep {
                 .customTimerStepUpdatedAt(LocalDateTime.now())
                 .build();
     }
+
+    public void deleteCustomTimerStep() {
+        this.customTimerStepDeletedAt = LocalDateTime.now();
+    }
 }

--- a/src/main/java/com/project200/undabang/timer/custom/repository/CustomTimerRepository.java
+++ b/src/main/java/com/project200/undabang/timer/custom/repository/CustomTimerRepository.java
@@ -5,7 +5,10 @@ import com.project200.undabang.timer.custom.entity.CustomTimer;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface CustomTimerRepository extends JpaRepository<CustomTimer, Long> {
     List<CustomTimer> findAllByMemberAndCustomTimerDeletedAtNull(Member member);
+
+    Optional<CustomTimer> findByIdAndMemberAndCustomTimerDeletedAtNull(Long id, Member member);
 }

--- a/src/main/java/com/project200/undabang/timer/custom/repository/CustomTimerRepository.java
+++ b/src/main/java/com/project200/undabang/timer/custom/repository/CustomTimerRepository.java
@@ -9,6 +9,5 @@ import java.util.Optional;
 
 public interface CustomTimerRepository extends JpaRepository<CustomTimer, Long> {
     List<CustomTimer> findAllByMemberAndCustomTimerDeletedAtNull(Member member);
-
     Optional<CustomTimer> findByIdAndMemberAndCustomTimerDeletedAtNull(Long id, Member member);
 }

--- a/src/main/java/com/project200/undabang/timer/custom/repository/CustomTimerStepRepository.java
+++ b/src/main/java/com/project200/undabang/timer/custom/repository/CustomTimerStepRepository.java
@@ -6,6 +6,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
 
-public interface CustomTimerStepRepository extends JpaRepository<CustomTimerStep, Long> {
+public interface CustomTimerStepRepository extends JpaRepository<CustomTimerStep, Long>, CustomTimerStepRepositoryCustom {
     List<CustomTimerStep> findAllByCustomTimerAndCustomTimerStepDeletedAtNull(CustomTimer customTimer);
 }

--- a/src/main/java/com/project200/undabang/timer/custom/repository/CustomTimerStepRepositoryCustom.java
+++ b/src/main/java/com/project200/undabang/timer/custom/repository/CustomTimerStepRepositoryCustom.java
@@ -1,0 +1,7 @@
+package com.project200.undabang.timer.custom.repository;
+
+import com.project200.undabang.timer.custom.entity.CustomTimer;
+
+public interface CustomTimerStepRepositoryCustom {
+    void softDeleteAllByCustomTimer(CustomTimer customTimer);
+}

--- a/src/main/java/com/project200/undabang/timer/custom/repository/impl/CustomTimerStepRepositoryImpl.java
+++ b/src/main/java/com/project200/undabang/timer/custom/repository/impl/CustomTimerStepRepositoryImpl.java
@@ -1,0 +1,41 @@
+package com.project200.undabang.timer.custom.repository.impl;
+
+import com.project200.undabang.timer.custom.entity.CustomTimer;
+import com.project200.undabang.timer.custom.entity.QCustomTimerStep;
+import com.project200.undabang.timer.custom.repository.CustomTimerStepRepositoryCustom;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import lombok.RequiredArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@RequiredArgsConstructor
+public class CustomTimerStepRepositoryImpl implements CustomTimerStepRepositoryCustom {
+    private final JPAQueryFactory jpaQueryFactory;
+    private final EntityManager em;
+
+    /**
+     * 지정된 CustomTimer와 연관된 모든 CustomTimerStep 엔터티를 논리적으로 삭제합니다.
+     * @param customTimer 논리적으로 삭제할 CustomTimerStep과 연관된 CustomTimer 객체
+     */
+    @Override
+    public void softDeleteAllByCustomTimer(CustomTimer customTimer) {
+        QCustomTimerStep customTimerStep = QCustomTimerStep.customTimerStep;
+
+        // 이전에 작업한 부모 객체의 상태 변경내용을 DB에 저장
+        em.flush();
+
+        // 벌크 연산을 통해 DB에 Step 논리적 삭제 저장
+        jpaQueryFactory
+                .update(customTimerStep)
+                .set(customTimerStep.customTimerStepDeletedAt, LocalDateTime.now())
+                .where(
+                        customTimerStep.customTimer.eq(customTimer),
+                        customTimerStep.customTimerStepDeletedAt.isNull()
+                )
+                .execute();
+
+        // 영속성 컨텍스트 비우기
+        em.clear();
+    }
+}

--- a/src/main/java/com/project200/undabang/timer/custom/service/CustomTimerCommandService.java
+++ b/src/main/java/com/project200/undabang/timer/custom/service/CustomTimerCommandService.java
@@ -5,4 +5,6 @@ import com.project200.undabang.timer.custom.dto.response.CustomTimerCreateRespon
 
 public interface CustomTimerCommandService {
     CustomTimerCreateResponse createCustomTimer(CustomTimerCreateRequest dto);
+
+    void deleteCustomTimer(Long customTimerId);
 }

--- a/src/main/java/com/project200/undabang/timer/custom/service/CustomTimerCommandService.java
+++ b/src/main/java/com/project200/undabang/timer/custom/service/CustomTimerCommandService.java
@@ -5,6 +5,5 @@ import com.project200.undabang.timer.custom.dto.response.CustomTimerCreateRespon
 
 public interface CustomTimerCommandService {
     CustomTimerCreateResponse createCustomTimer(CustomTimerCreateRequest dto);
-
     void deleteCustomTimer(Long customTimerId);
 }

--- a/src/main/java/com/project200/undabang/timer/custom/service/impl/CustomTimerCommandServiceImpl.java
+++ b/src/main/java/com/project200/undabang/timer/custom/service/impl/CustomTimerCommandServiceImpl.java
@@ -34,6 +34,21 @@ public class CustomTimerCommandServiceImpl implements CustomTimerCommandService 
     private final PolicyService policyService;
 
     /**
+     * 주어진 사용자와 타이머 ID를 기반으로 커스텀 타이머를 삭제합니다.
+     * 타이머와 연관된 모든 스텝도 함께 삭제됩니다.
+     */
+    @Override
+    public void deleteCustomTimer(Long customTimerId) {
+        Member member = getMember(UserContextHolder.getUserId());
+
+        CustomTimer customTimer = getCustomTimer(member, customTimerId);
+        List<CustomTimerStep> customTimerSteps = customTimerStepRepository.findAllByCustomTimerAndCustomTimerStepDeletedAtNull(customTimer);
+
+        customTimerSteps.forEach(CustomTimerStep::deleteCustomTimerStep);
+        customTimer.deleteCustomTimer();
+    }
+
+    /**
      * 이 구현체는 다음의 순서로 커스텀 타이머를 생성합니다:
      * 요청한 사용자의 유효성을 확인합니다.
      * 커스텀 타이머 스텝의 개수와 순서의 유효성을 검증합니다.
@@ -98,5 +113,14 @@ public class CustomTimerCommandServiceImpl implements CustomTimerCommandService 
      */
     private Member getMember(UUID memberId) {
         return memberRepository.findById(memberId).orElseThrow(() -> new CustomException(ErrorCode.MEMBER_NOT_FOUND));
+    }
+
+    /**
+     * 주어진 사용자와 타이머 ID를 기반으로 커스텀 타이머를 조회합니다.
+     * 타이머가 존재하지 않거나 삭제된 상태일 경우 {@link CustomException}을 발생시킵니다.
+     */
+    private CustomTimer getCustomTimer(Member member, Long customTimerId) {
+        return customTimerRepository.findByIdAndMemberAndCustomTimerDeletedAtNull(customTimerId, member)
+                .orElseThrow(() -> new CustomException(ErrorCode.CUSTOM_TIMER_NOT_FOUND));
     }
 }

--- a/src/main/java/com/project200/undabang/timer/custom/service/impl/CustomTimerCommandServiceImpl.java
+++ b/src/main/java/com/project200/undabang/timer/custom/service/impl/CustomTimerCommandServiceImpl.java
@@ -40,12 +40,11 @@ public class CustomTimerCommandServiceImpl implements CustomTimerCommandService 
     @Override
     public void deleteCustomTimer(Long customTimerId) {
         Member member = getMember(UserContextHolder.getUserId());
-
         CustomTimer customTimer = getCustomTimer(member, customTimerId);
-        List<CustomTimerStep> customTimerSteps = customTimerStepRepository.findAllByCustomTimerAndCustomTimerStepDeletedAtNull(customTimer);
 
-        customTimerSteps.forEach(CustomTimerStep::deleteCustomTimerStep);
         customTimer.deleteCustomTimer();
+        // 벌크 연산을 사용하여 DB 접근 최소화 및 성능 향상
+        customTimerStepRepository.softDeleteAllByCustomTimer(customTimer);
     }
 
     /**

--- a/src/test/java/com/project200/undabang/timer/custom/controller/CustomTimerCommandControllerTest.java
+++ b/src/test/java/com/project200/undabang/timer/custom/controller/CustomTimerCommandControllerTest.java
@@ -1,6 +1,9 @@
 package com.project200.undabang.timer.custom.controller;
 
+import com.project200.undabang.common.web.exception.CustomException;
+import com.project200.undabang.common.web.exception.ErrorCode;
 import com.project200.undabang.configuration.AbstractRestDocSupport;
+import com.project200.undabang.configuration.RestDocsUtils;
 import com.project200.undabang.timer.custom.dto.request.CustomTimerCreateRequest;
 import com.project200.undabang.timer.custom.dto.request.CustomTimerStepCreateRequest;
 import com.project200.undabang.timer.custom.dto.response.CustomTimerCreateResponse;
@@ -10,20 +13,26 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.http.MediaType;
+import org.springframework.restdocs.payload.JsonFieldType;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 import java.util.List;
 import java.util.UUID;
 
+import static com.project200.undabang.configuration.DocumentFormatGenerator.getTypeFormat;
 import static com.project200.undabang.configuration.HeadersGenerator.getCommonApiHeaders;
 import static com.project200.undabang.configuration.RestDocsUtils.HEADER_ACCESS_TOKEN;
 import static com.project200.undabang.configuration.RestDocsUtils.commonResponseFields;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.BDDMockito.given;
-import static org.mockito.BDDMockito.then;
+import static org.mockito.BDDMockito.*;
+import static org.mockito.Mockito.doThrow;
 import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
 import static org.springframework.restdocs.payload.PayloadDocumentation.*;
+import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
+import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -32,6 +41,67 @@ class CustomTimerCommandControllerTest extends AbstractRestDocSupport {
 
     @MockitoBean
     private CustomTimerCommandService customTimerCommandService;
+
+    @Nested
+    @DisplayName("커스텀 타이머 삭제 API")
+    class DeleteCustomTimer {
+
+        @Test
+        @DisplayName("정상적으로 커스텀 타이머를 삭제한다")
+        void deleteCustomTimer_Success() throws Exception {
+            // given
+            UUID memberId = UUID.randomUUID();
+            Long timerId = 1L;
+
+            // 실제로 삭제하지 않기위해 willDoNothing() 사용
+            willDoNothing().given(customTimerCommandService).deleteCustomTimer(timerId);
+
+            // when & then
+            mockMvc.perform(delete("/api/v1/custom-timers/{customTimerId}", timerId)
+                            .headers(getCommonApiHeaders(memberId)))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.succeed").value(true))
+                    .andExpect(jsonPath("$.code").value("DELETED"))
+                    .andExpect(jsonPath("$.message").value("리소스가 성공적으로 삭제되었습니다."))
+                    .andExpect(jsonPath("$.data").doesNotExist())
+                    .andDo(print())
+                    .andDo(document.document(
+                            requestHeaders(
+                                    RestDocsUtils.HEADER_ACCESS_TOKEN
+                            ),
+                            pathParameters(
+                                    parameterWithName("customTimerId").attributes(getTypeFormat(JsonFieldType.NUMBER))
+                                            .description("삭제할 커스텀 타이머의 ID를 의미합니다.")
+                            ),
+                            responseFields(
+                                    RestDocsUtils.commonResponseFieldsOnly()
+                            )
+                    ));
+
+            then(customTimerCommandService).should().deleteCustomTimer(timerId);
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 타이머 삭제 시 404 에러를 반환한다")
+        void deleteCustomTimer_NotFound() throws Exception {
+            // given
+            UUID memberId = UUID.randomUUID();
+            Long timerId = 999L;
+
+            // 서비스 계층에서 예외 발생하도록 설정
+            doThrow(new CustomException(ErrorCode.CUSTOM_TIMER_NOT_FOUND))
+                    .when(customTimerCommandService).deleteCustomTimer(timerId);
+
+            // when & then
+            mockMvc.perform(delete("/api/v1/custom-timers/{customTimerId}", timerId)
+                            .headers(getCommonApiHeaders(memberId)))
+                    .andExpect(status().isNotFound())
+                    .andExpect(jsonPath("$.succeed").value(false))
+                    .andExpect(jsonPath("$.code").value(ErrorCode.CUSTOM_TIMER_NOT_FOUND.name()));
+
+            then(customTimerCommandService).should().deleteCustomTimer(timerId);
+        }
+    }
 
     @Nested
     @DisplayName("커스텀 타이머 생성 성공")

--- a/src/test/java/com/project200/undabang/timer/custom/repository/impl/CustomTimerStepRepositoryImplTest.java
+++ b/src/test/java/com/project200/undabang/timer/custom/repository/impl/CustomTimerStepRepositoryImplTest.java
@@ -1,0 +1,124 @@
+package com.project200.undabang.timer.custom.repository.impl;
+
+import com.project200.undabang.configuration.TestQuerydslConfig;
+import com.project200.undabang.member.entity.Member;
+import com.project200.undabang.member.enums.MemberGender;
+import com.project200.undabang.timer.custom.entity.CustomTimer;
+import com.project200.undabang.timer.custom.entity.CustomTimerStep;
+import com.project200.undabang.timer.custom.repository.CustomTimerStepRepository;
+import jakarta.persistence.EntityManager;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.UUID;
+
+@DataJpaTest
+@Import(TestQuerydslConfig.class)
+class CustomTimerStepRepositoryImplTest {
+    @Autowired
+    private EntityManager em;
+
+    @Autowired
+    private CustomTimerStepRepository customTimerStepRepository;
+
+    private Member createAndSaveMember(String nickname) {
+        Member member = Member.builder()
+                .memberId(UUID.randomUUID())
+                .memberEmail(nickname + "@email.com")
+                .memberNickname(nickname)
+                .memberGender(MemberGender.UNKNOWN) // 예시 값
+                .memberBday(LocalDate.of(2000, 1, 1))
+                .build();
+        em.persist(member);
+        return member;
+    }
+
+    private CustomTimer createAndSaveCustomTimer(Member member, String name) {
+        CustomTimer timer = CustomTimer.builder()
+                .member(member)
+                .customTimerName(name)
+                .build();
+        em.persist(timer);
+        return timer;
+    }
+
+    private CustomTimerStep createAndSaveCustomTimerStep(CustomTimer timer, String name, byte order) {
+        CustomTimerStep step = CustomTimerStep.builder()
+                .customTimer(timer)
+                .customTimerStepName(name)
+                .customTimerStepOrder(order)
+                .customTimerStepTime(60) // 기본값
+                .build();
+        em.persist(step);
+        return step;
+    }
+
+    private void flushAndClear() {
+        em.flush();
+        em.clear();
+    }
+
+    @Nested
+    @DisplayName("softDeleteAllByCustomTimer 메소드는")
+    class Describe_softDeleteAllByCustomTimer {
+
+        @Test
+        @DisplayName("주어진 타이머에 속한 활성 상태의 스텝들만 논리적으로 삭제한다")
+        void it_soft_deletes_only_active_steps_for_the_given_timer() {
+            // given
+            Member member = createAndSaveMember("testUser");
+            CustomTimer timerA = createAndSaveCustomTimer(member, "timerA");
+            CustomTimer timerB = createAndSaveCustomTimer(member, "timerB"); // 영향을 받지 않아야 할 다른 타이머
+
+            // timerA에 속한 스텝들 (활성 2개, 이미 삭제된 것 1개)
+            CustomTimerStep stepA1 = createAndSaveCustomTimerStep(timerA, "stepA1", (byte) 0);
+            CustomTimerStep stepA2 = createAndSaveCustomTimerStep(timerA, "stepA2", (byte) 1);
+            CustomTimerStep stepA3_deleted = createAndSaveCustomTimerStep(timerA, "stepA3_deleted", (byte) 2);
+            stepA3_deleted.deleteCustomTimerStep(); // 미리 삭제 처리
+
+            // timerB에 속한 스텝
+            CustomTimerStep stepB1 = createAndSaveCustomTimerStep(timerB, "stepB1", (byte) 0);
+
+            flushAndClear();
+
+            // when
+            customTimerStepRepository.softDeleteAllByCustomTimer(timerA);
+
+            // then
+            // 메소드 내부에서 clear()가 호출되므로, DB에서 직접 상태를 다시 조회하여 검증해야 함
+            CustomTimerStep foundStepA1 = em.find(CustomTimerStep.class, stepA1.getId());
+            CustomTimerStep foundStepA2 = em.find(CustomTimerStep.class, stepA2.getId());
+            CustomTimerStep foundStepA3 = em.find(CustomTimerStep.class, stepA3_deleted.getId());
+            CustomTimerStep foundStepB1 = em.find(CustomTimerStep.class, stepB1.getId());
+
+            Assertions.assertThat(foundStepA1.getCustomTimerStepDeletedAt()).isNotNull();
+            Assertions.assertThat(foundStepA2.getCustomTimerStepDeletedAt()).isNotNull();
+            Assertions.assertThat(foundStepA3.getCustomTimerStepDeletedAt()).isNotNull(); // 원래 삭제된 상태 유지
+            Assertions.assertThat(foundStepB1.getCustomTimerStepDeletedAt()).isNull(); // 다른 타이머 스텝은 영향 없음
+        }
+
+        @Test
+        @DisplayName("스텝이 없는 타이머에 대해 호출해도 아무런 작업을 수행하지 않고 오류를 발생시키지 않는다")
+        void it_does_nothing_when_timer_has_no_steps() {
+            // given
+            Member member = createAndSaveMember("testUser");
+            CustomTimer timerWithNoSteps = createAndSaveCustomTimer(member, "emptyTimer");
+            flushAndClear();
+
+            // when
+            // 예외가 발생하지 않으면 성공
+            customTimerStepRepository.softDeleteAllByCustomTimer(timerWithNoSteps);
+
+            // then
+            List<CustomTimerStep> steps = customTimerStepRepository.findAll();
+            Assertions.assertThat(steps).isEmpty();
+        }
+    }
+}

--- a/src/test/java/com/project200/undabang/timer/custom/service/impl/CustomTimerCommandServiceImplTest.java
+++ b/src/test/java/com/project200/undabang/timer/custom/service/impl/CustomTimerCommandServiceImplTest.java
@@ -73,28 +73,24 @@ class CustomTimerCommandServiceImplTest {
     class Describe_deleteCustomTimer {
 
         @Test
-        @DisplayName("유효한 회원과 타이머 ID가 주어지면 타이머와 스텝을 삭제한다")
+        @DisplayName("유효한 회원과 타이머 ID가 주어지면 타이머 삭제 로직을 올바르게 호출한다.")
         void shouldDeleteTimerAndSteps_whenValidRequest() {
             // given
             UUID userId = UUID.randomUUID();
             Member member = Member.builder().memberId(userId).build();
             Long timerId = 1L;
             CustomTimer timer = CustomTimer.builder().id(timerId).member(member).build();
-            CustomTimerStep step = CustomTimerStep.builder().customTimer(timer).build();
 
             try (MockedStatic<UserContextHolder> ignored = mockStatic(UserContextHolder.class)) {
                 ignored.when(UserContextHolder::getUserId).thenReturn(userId);
                 given(memberRepository.findById(userId)).willReturn(Optional.of(member));
                 given(customTimerRepository.findByIdAndMemberAndCustomTimerDeletedAtNull(timerId, member))
                         .willReturn(Optional.of(timer));
-                given(customTimerStepRepository.findAllByCustomTimerAndCustomTimerStepDeletedAtNull(timer))
-                        .willReturn(List.of(step));
-
                 // when
                 customTimerCommandService.deleteCustomTimer(timerId);
 
                 // then
-                verify(customTimerStepRepository, times(1)).findAllByCustomTimerAndCustomTimerStepDeletedAtNull(timer);
+                verify(customTimerStepRepository, times(1)).softDeleteAllByCustomTimer(timer);
                 // saveAll, save 호출 검증은 제거
             }
         }
@@ -138,7 +134,7 @@ class CustomTimerCommandServiceImplTest {
                         .isInstanceOf(CustomException.class)
                         .hasFieldOrPropertyWithValue("errorCode", ErrorCode.CUSTOM_TIMER_NOT_FOUND);
 
-                verify(customTimerStepRepository, never()).findAllByCustomTimerAndCustomTimerStepDeletedAtNull(any());
+                verify(customTimerStepRepository, never()).softDeleteAllByCustomTimer(any());
             }
         }
     }

--- a/src/test/java/com/project200/undabang/timer/custom/service/impl/CustomTimerCommandServiceImplTest.java
+++ b/src/test/java/com/project200/undabang/timer/custom/service/impl/CustomTimerCommandServiceImplTest.java
@@ -69,6 +69,81 @@ class CustomTimerCommandServiceImplTest {
     }
 
     @Nested
+    @DisplayName("deleteCustomTimer() 메소드는")
+    class Describe_deleteCustomTimer {
+
+        @Test
+        @DisplayName("유효한 회원과 타이머 ID가 주어지면 타이머와 스텝을 삭제한다")
+        void shouldDeleteTimerAndSteps_whenValidRequest() {
+            // given
+            UUID userId = UUID.randomUUID();
+            Member member = Member.builder().memberId(userId).build();
+            Long timerId = 1L;
+            CustomTimer timer = CustomTimer.builder().id(timerId).member(member).build();
+            CustomTimerStep step = CustomTimerStep.builder().customTimer(timer).build();
+
+            try (MockedStatic<UserContextHolder> ignored = mockStatic(UserContextHolder.class)) {
+                ignored.when(UserContextHolder::getUserId).thenReturn(userId);
+                given(memberRepository.findById(userId)).willReturn(Optional.of(member));
+                given(customTimerRepository.findByIdAndMemberAndCustomTimerDeletedAtNull(timerId, member))
+                        .willReturn(Optional.of(timer));
+                given(customTimerStepRepository.findAllByCustomTimerAndCustomTimerStepDeletedAtNull(timer))
+                        .willReturn(List.of(step));
+
+                // when
+                customTimerCommandService.deleteCustomTimer(timerId);
+
+                // then
+                verify(customTimerStepRepository, times(1)).findAllByCustomTimerAndCustomTimerStepDeletedAtNull(timer);
+                // saveAll, save 호출 검증은 제거
+            }
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 회원이면 CustomException(MEMBER_NOT_FOUND)을 던진다")
+        void shouldThrowException_whenMemberNotFound() {
+            // given
+            UUID userId = UUID.randomUUID();
+            Long timerId = 1L;
+
+            try (MockedStatic<UserContextHolder> ignored = mockStatic(UserContextHolder.class)) {
+                ignored.when(UserContextHolder::getUserId).thenReturn(userId);
+                given(memberRepository.findById(userId)).willReturn(Optional.empty());
+
+                // when & then
+                assertThatThrownBy(() -> customTimerCommandService.deleteCustomTimer(timerId))
+                        .isInstanceOf(CustomException.class)
+                        .hasFieldOrPropertyWithValue("errorCode", ErrorCode.MEMBER_NOT_FOUND);
+
+                verify(customTimerRepository, never()).findByIdAndMemberAndCustomTimerDeletedAtNull(any(), any());
+            }
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 타이머면 CustomException(CUSTOM_TIMER_NOT_FOUND)을 던진다")
+        void shouldThrowException_whenTimerNotFound() {
+            // given
+            UUID userId = UUID.randomUUID();
+            Member member = Member.builder().memberId(userId).build();
+            Long timerId = 1L;
+
+            try (MockedStatic<UserContextHolder> ignored = mockStatic(UserContextHolder.class)) {
+                ignored.when(UserContextHolder::getUserId).thenReturn(userId);
+                given(memberRepository.findById(userId)).willReturn(Optional.of(member));
+                given(customTimerRepository.findByIdAndMemberAndCustomTimerDeletedAtNull(timerId, member))
+                        .willReturn(Optional.empty());
+
+                // when & then
+                assertThatThrownBy(() -> customTimerCommandService.deleteCustomTimer(timerId))
+                        .isInstanceOf(CustomException.class)
+                        .hasFieldOrPropertyWithValue("errorCode", ErrorCode.CUSTOM_TIMER_NOT_FOUND);
+
+                verify(customTimerStepRepository, never()).findAllByCustomTimerAndCustomTimerStepDeletedAtNull(any());
+            }
+        }
+    }
+
+    @Nested
     @DisplayName("createCustomTimer() 메소드는")
     class Describe_createCustomTimer {
 
@@ -188,8 +263,8 @@ class CustomTimerCommandServiceImplTest {
             );
             CustomTimerCreateRequest request = new CustomTimerCreateRequest("정렬 안된 타이머", unsortedSteps);
 
-            try (MockedStatic<UserContextHolder> mockedContext = mockStatic(UserContextHolder.class)) {
-                mockedContext.when(UserContextHolder::getUserId).thenReturn(testUserId);
+            try (MockedStatic<UserContextHolder> ignored = mockStatic(UserContextHolder.class)) {
+                ignored.when(UserContextHolder::getUserId).thenReturn(testUserId);
                 given(memberRepository.findById(testUserId)).willReturn(Optional.of(testUser));
                 given(policyService.getPolicyValueAsInt(any(PolicyKey.class))).willReturn(1).willReturn(10);
 


### PR DESCRIPTION
## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

커스텀데이터 삭제 기능을 개발하였습니다.

삭제기능은 하나의 트랜잭션에서 두가지 기능(?)을 하도록 구현하였습니다.
JPA 의 변경감지를 사용하여 CustomTimer를 논리적으로 삭제하도록 하였습니다.
QueryDSL의 벌크 연산을 통해서 List<CustomTimerStep>을 논리적으로 삭제하도록 구현하였습니다.

QueryDSL의 벌크연산을 사용한 이유는 JPA 변경감지로 구현시 최악의 경우 매번 (3 + 50)번의 DB 접근이 이루어지지만, 벌크연산의 경우 5건으로 처리할 수 있기 때문입니다. 

테스트케이스는 100%를 유지하였습니다.

### 스크린샷 (선택)
테스트케이스 사진입니다. 
<img width="704" height="128" alt="image" src="https://github.com/user-attachments/assets/441776ca-41b7-44cf-9072-45f67ca462b2" />

API 명세서 사진입니다.
<img width="661" height="203" alt="image" src="https://github.com/user-attachments/assets/2677b2a7-a248-49d8-b685-90242744777a" />
<img width="994" height="404" alt="image" src="https://github.com/user-attachments/assets/d058ff58-97b7-4b18-93bd-46053b51b3af" />
<img width="996" height="749" alt="image" src="https://github.com/user-attachments/assets/d6c50dc7-93a0-4d6f-9a3b-e4316aa5e345" />
<img width="991" height="707" alt="image" src="https://github.com/user-attachments/assets/c60429c3-0f4b-4ea1-a0bd-456e2ff0e692" />
<img width="991" height="222" alt="image" src="https://github.com/user-attachments/assets/c90d933a-c166-4a44-9836-ba1d6107b3f8" />

## #️⃣연관된 이슈

> ex) #207 , Closes #250 