### PR TITLE
[Fix] : 커스텀 타이머 API 명세서 수정

### DIFF
--- a/src/docs/asciidoc/custom-timer/커스텀-타이머-생성-API.adoc
+++ b/src/docs/asciidoc/custom-timer/커스텀-타이머-생성-API.adoc
@@ -20,7 +20,7 @@ operation::create-custom-timer/create-custom-timer_-success[snippets="curl-reque
 
 === 매개 변수
 
-operation::create-custom-timer/create-custom-timer_-success[snippets="request-headers,response-fields"]
+operation::create-custom-timer/create-custom-timer_-success[snippets="request-headers,request-fields,response-fields"]
 
 ==== 응답 상태 코드
 

--- a/src/docs/asciidoc/custom-timer/커스텀-타이머-이름-수정-API.adoc
+++ b/src/docs/asciidoc/custom-timer/커스텀-타이머-이름-수정-API.adoc
@@ -19,7 +19,7 @@ operation::update-custom-timer-name/update-custom-timer-name_-success[snippets="
 
 === 매개 변수
 
-operation::update-custom-timer-name/update-custom-timer-name_-success[snippets="request-headers,path-parameters,response-fields"]
+operation::update-custom-timer-name/update-custom-timer-name_-success[snippets="request-headers,path-parameters,request-fields,response-fields"]
 
 ==== 응답 상태 코드
 

--- a/src/test/java/com/project200/undabang/timer/custom/controller/CustomTimerCommandControllerTest.java
+++ b/src/test/java/com/project200/undabang/timer/custom/controller/CustomTimerCommandControllerTest.java
@@ -79,7 +79,7 @@ class CustomTimerCommandControllerTest extends AbstractRestDocSupport {
                                             .description("수정할 커스텀 타이머의 ID를 의미합니다.")
                             ),
                             requestFields(
-                                    fieldWithPath("customTimerName").description("새롭게 변경할 커스텀 타이머의 이름입니다.")
+                                    fieldWithPath("customTimerName").description("새롭게 변경할 커스텀 타이머의 이름입니다. 커스텀 타이머 이름은 최소 1글자, 최대 100글자 이내여야 합니다.")
                             ),
                             responseFields(
                                     RestDocsUtils.commonResponseFieldsOnly()
@@ -237,11 +237,11 @@ class CustomTimerCommandControllerTest extends AbstractRestDocSupport {
                             requestHeaders(HEADER_ACCESS_TOKEN),
                             // 요청 본문의 필드를 문서화합니다.
                             requestFields(
-                                    fieldWithPath("customTimerName").description("생성할 커스텀 타이머의 이름입니다."),
+                                    fieldWithPath("customTimerName").description("생성할 커스텀 타이머의 이름입니다. 커스텀 타이머 이름은 최소 1글자, 최대 100글자 이내여야 합니다."),
                                     fieldWithPath("customTimerSteps").description("커스텀 타이머에 포함될 스텝 목록입니다."),
-                                    fieldWithPath("customTimerSteps[].customTimerStepName").description("스텝의 이름입니다."),
-                                    fieldWithPath("customTimerSteps[].customTimerStepOrder").description("스텝의 순서입니다."),
-                                    fieldWithPath("customTimerSteps[].customTimerStepTime").description("스텝의 시간(초)입니다.")
+                                    fieldWithPath("customTimerSteps[].customTimerStepName").description("스텝의 이름입니다. 커스텀 타이머 스텝 이름은 최소 1글자, 최대 50글자 이내여야 합니다."),
+                                    fieldWithPath("customTimerSteps[].customTimerStepOrder").description("스텝의 순서입니다. 커스텀 타이머의 순서는 0~49 이내의 연속적인 정수여야 합니다."),
+                                    fieldWithPath("customTimerSteps[].customTimerStepTime").description("스텝의 시간(초)입니다. 커스텀 타이머의 시간은 1 ~ 3599 이내의 값을 입력해야 합니다.")
                             ),
                             // 응답 본문의 필드를 문서화합니다.
                             responseFields(commonResponseFields(


### PR DESCRIPTION
## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

기존 커스텀 타이머 API 명세서에서 제약사항이 미비한 부분을 추가하였습니다.

### 스크린샷 (선택)
커스텀 타이머 생성 제약조건 추가 사진입니다.
<img width="1000" height="809" alt="image" src="https://github.com/user-attachments/assets/f5c7edab-5637-41dc-91af-40157fdd8413" />

커스텀 타이머 이름 수정 제약조건 추가 사진입니다.
<img width="988" height="518" alt="image" src="https://github.com/user-attachments/assets/3aed3b47-c42e-45af-ade1-fe45aa53cffe" />

## #️⃣연관된 이슈

> ex) #207 , Closes #256 