### PR TITLE
[Feat] 커스텀 타이머 수정 기능 개발 [0.2.9] -> [0.2.10]

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ plugins {
 }
 
 group = 'com.project200'
-version = '0.2.9-SNAPSHOT'
+version = '0.2.10-SNAPSHOT'
 
 java {
     toolchain {

--- a/src/docs/asciidoc/custom-timer/커스텀-타이머-수정-API.adoc
+++ b/src/docs/asciidoc/custom-timer/커스텀-타이머-수정-API.adoc
@@ -1,0 +1,36 @@
+== 커스텀 타이머 수정 API
+
+=== 설명
+
+- #PUT# `/api/v1/custom-timers/{customTimerId}`
+- 커스텀 타이머 수정 API는 사용자가 생성한 커스텀 타이머의 이름과 커스텀 타이머 스텝들을 수정하는 기능을 제공합니다.
+- 커스텀 타이머 스텝 수정시 스텝 순서는 0 부터 49 까지 중복없이 순차적으로 생성해야 합니다.
+
+=== 개발 이력
+
+- Sprint 10 (2025-08-25): 기능 개발이 완료되었습니다.
+
+=== 개발 참고 사항
+
+- <<공통-개발-참고-사항,공통 개발 참고 사항>>을 참고하세요.
+
+=== 코드 샘플
+
+operation::update-custom-timer/update-custom-timer_-success[snippets="curl-request,http-request,http-response"]
+
+=== 매개 변수
+
+operation::update-custom-timer/update-custom-timer_-success[snippets="request-headers,path-parameters,request-fields,response-fields"]
+
+==== 응답 상태 코드
+
+|===
+|상태 코드|설명
+|200| 커스텀 타이머가 성공적으로 수정되었습니다.
+|404| 회원 정보가 올바르지 않습니다. +
+존재하지 않는 타이머 입니다.
+|409| 최소 1개 이상의 커스텀 타이머 스텝을 보유해야 합니다. +
+최대 커스텀 타이머 스텝 개수(50개)를 초과했습니다. +
+스텝 순서가 잘못되었습니다.
+|===
+

--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -157,4 +157,6 @@ include::overview/공통-개발-참고-사항.adoc[]
 
 - 커스텀 타이머 삭제 API #DELETE# `/api/v1/custom-timers/{customTimerId}`
 
+- 커스텀 타이머 수정 API #PUT# `/api/v1/custom-timers/{customTimerId}`
+
 - 커스텀 타이머 이름 수정 API #PATCH# `/api/v1/custom-timers/{customTimerId}`

--- a/src/docs/asciidoc/커스텀-타이머-API.adoc
+++ b/src/docs/asciidoc/커스텀-타이머-API.adoc
@@ -27,4 +27,6 @@ include::custom-timer/커스텀-타이머-생성-API.adoc[]
 
 include::custom-timer/커스텀-타이머-삭제-API.adoc[]
 
+include::custom-timer/커스텀-타이머-수정-API.adoc[]
+
 include::custom-timer/커스텀-타이머-이름-수정-API.adoc[]

--- a/src/main/java/com/project200/undabang/timer/custom/controller/CustomTimerCommandController.java
+++ b/src/main/java/com/project200/undabang/timer/custom/controller/CustomTimerCommandController.java
@@ -45,5 +45,4 @@ public class CustomTimerCommandController {
         customTimerCommandService.updateCustomTimer(customTimerId, request);
         return ResponseEntity.ok(CommonResponse.update(null));
     }
-
 }

--- a/src/main/java/com/project200/undabang/timer/custom/controller/CustomTimerCommandController.java
+++ b/src/main/java/com/project200/undabang/timer/custom/controller/CustomTimerCommandController.java
@@ -38,4 +38,12 @@ public class CustomTimerCommandController {
         return ResponseEntity.ok(CommonResponse.update(null));
     }
 
+    @PutMapping("/v1/custom-timers/{customTimerId}")
+    public ResponseEntity<CommonResponse<Void>> updateCustomTimer(@PathVariable("customTimerId") Long customTimerId,
+                                                                  @Valid @RequestBody CustomTimerCreateRequest request) {
+
+        customTimerCommandService.updateCustomTimer(customTimerId, request);
+        return ResponseEntity.ok(CommonResponse.update(null));
+    }
+
 }

--- a/src/main/java/com/project200/undabang/timer/custom/service/CustomTimerCommandService.java
+++ b/src/main/java/com/project200/undabang/timer/custom/service/CustomTimerCommandService.java
@@ -8,6 +8,5 @@ public interface CustomTimerCommandService {
     CustomTimerCreateResponse createCustomTimer(CustomTimerCreateRequest dto);
     void deleteCustomTimer(Long customTimerId);
     void updateCustomTimerName(Long customTimerId, CustomTimerNameUpdateRequest request);
-
     void updateCustomTimer(Long customTimerId, CustomTimerCreateRequest request);
 }

--- a/src/main/java/com/project200/undabang/timer/custom/service/CustomTimerCommandService.java
+++ b/src/main/java/com/project200/undabang/timer/custom/service/CustomTimerCommandService.java
@@ -8,4 +8,6 @@ public interface CustomTimerCommandService {
     CustomTimerCreateResponse createCustomTimer(CustomTimerCreateRequest dto);
     void deleteCustomTimer(Long customTimerId);
     void updateCustomTimerName(Long customTimerId, CustomTimerNameUpdateRequest request);
+
+    void updateCustomTimer(Long customTimerId, CustomTimerCreateRequest request);
 }

--- a/src/main/java/com/project200/undabang/timer/custom/service/impl/CustomTimerCommandServiceImpl.java
+++ b/src/main/java/com/project200/undabang/timer/custom/service/impl/CustomTimerCommandServiceImpl.java
@@ -70,7 +70,8 @@ public class CustomTimerCommandServiceImpl implements CustomTimerCommandService 
     }
 
     /**
-     * 주어진 사용자와 커스텀 타이머 ID를 기반으로 기존의 커스텀 타이머를 업데이트합니다.
+     * 주어진 커스텀 타이머 ID와 요청 데이터로 커스텀 타이머를 업데이트합니다.
+     * 요청된 타이머 스텝의 유효성을 검사하고, 기존 스텝을 삭제한 후 새로운 스텝을 추가합니다.
      */
     @Override
     public void updateCustomTimer(Long customTimerId, CustomTimerCreateRequest request) {

--- a/src/main/java/com/project200/undabang/timer/custom/service/impl/CustomTimerCommandServiceImpl.java
+++ b/src/main/java/com/project200/undabang/timer/custom/service/impl/CustomTimerCommandServiceImpl.java
@@ -35,14 +35,24 @@ public class CustomTimerCommandServiceImpl implements CustomTimerCommandService 
     private final PolicyService policyService;
 
     /**
-     * 주어진 사용자와 커스텀 타이머 ID를 기반으로 커스텀 타이머의 이름을 업데이트합니다.
+     * 이 구현체는 다음의 순서로 커스텀 타이머를 생성합니다:
+     * 요청한 사용자의 유효성을 확인합니다.
+     * 커스텀 타이머 스텝의 개수와 순서의 유효성을 검증합니다.
+     * {@link CustomTimer} 엔티티를 먼저 저장합니다.
+     * 연관된 {@link CustomTimerStep} 엔티티들을 일괄 저장합니다.
      */
     @Override
-    public void updateCustomTimerName(Long customTimerId, CustomTimerNameUpdateRequest request) {
+    public CustomTimerCreateResponse createCustomTimer(CustomTimerCreateRequest dto) {
         Member member = getMember(UserContextHolder.getUserId());
-        CustomTimer customTimer = getCustomTimer(member, customTimerId);
 
-        customTimer.updateCustomTimerName(request.getCustomTimerName());
+        validateCustomTimerSteps(dto.getCustomTimerSteps());
+
+        CustomTimer customTimer = CustomTimer.of(member, dto.getCustomTimerName());
+        CustomTimer savedTimer = customTimerRepository.save(customTimer);
+
+        createStepTimerList(savedTimer, dto.getCustomTimerSteps());
+
+        return new CustomTimerCreateResponse(savedTimer.getId());
     }
 
     /**
@@ -60,32 +70,50 @@ public class CustomTimerCommandServiceImpl implements CustomTimerCommandService 
     }
 
     /**
-     * 이 구현체는 다음의 순서로 커스텀 타이머를 생성합니다:
-     * 요청한 사용자의 유효성을 확인합니다.
-     * 커스텀 타이머 스텝의 개수와 순서의 유효성을 검증합니다.
-     * {@link CustomTimer} 엔티티를 먼저 저장합니다.
-     * 연관된 {@link CustomTimerStep} 엔티티들을 일괄 저장합니다.
+     * 주어진 사용자와 커스텀 타이머 ID를 기반으로 기존의 커스텀 타이머를 업데이트합니다.
      */
     @Override
-    public CustomTimerCreateResponse createCustomTimer(CustomTimerCreateRequest dto) {
+    public void updateCustomTimer(Long customTimerId, CustomTimerCreateRequest request) {
         Member member = getMember(UserContextHolder.getUserId());
+        CustomTimer customTimer = getCustomTimer(member, customTimerId);
 
-        checkCustomTimerCountLimit(dto.getCustomTimerSteps());
-        validateCustomTimerStepOrder(dto.getCustomTimerSteps());
+        // 커스텀 타이머 스텝 제약사항 검사
+        validateCustomTimerSteps(request.getCustomTimerSteps());
 
-        CustomTimer customTimer = CustomTimer.of(member, dto.getCustomTimerName());
-        CustomTimer savedTimer = customTimerRepository.save(customTimer);
+        // 커스텀 타이머 이름 변경
+        customTimer.updateCustomTimerName(request.getCustomTimerName());
 
-        createStepTimerList(savedTimer, dto.getCustomTimerSteps());
+        // 커스텀 타이머 스텝 전체 논리적 삭제
+        customTimerStepRepository.softDeleteAllByCustomTimer(customTimer);
 
-        return new CustomTimerCreateResponse(savedTimer.getId());
+        // 커스텀 타이머 스텝 추가
+        createStepTimerList(customTimer, request.getCustomTimerSteps());
+    }
+
+    /**
+     * 주어진 사용자와 커스텀 타이머 ID를 기반으로 커스텀 타이머의 이름을 업데이트합니다.
+     */
+    @Override
+    public void updateCustomTimerName(Long customTimerId, CustomTimerNameUpdateRequest request) {
+        Member member = getMember(UserContextHolder.getUserId());
+        CustomTimer customTimer = getCustomTimer(member, customTimerId);
+
+        customTimer.updateCustomTimerName(request.getCustomTimerName());
+    }
+
+    /**
+     * 스텝 관련 유효성 검사를 하나의 메서드로 묶음
+     * create, update에서 재활용 가능한 형태로 변경
+     */
+    private void validateCustomTimerSteps(List<CustomTimerStepCreateRequest> steps) {
+        validateCustomTimerStepOrder(steps);
+        checkCustomTimerCountLimit(steps);
     }
 
     /**
      * 커스텀 타이머 스텝의 순서가 정확한지 검증합니다.
      */
     private void validateCustomTimerStepOrder(List<CustomTimerStepCreateRequest> request) {
-        // CustomTimerStepOrder 순서검사
         for (int i = 0; i < request.size(); i++) {
             if (request.get(i).getCustomTimerStepOrder() != i) {
                 throw new CustomException(ErrorCode.CUSTOM_TIMER_STEP_ORDER_INVALID);

--- a/src/test/java/com/project200/undabang/timer/custom/controller/CustomTimerCommandControllerTest.java
+++ b/src/test/java/com/project200/undabang/timer/custom/controller/CustomTimerCommandControllerTest.java
@@ -32,8 +32,7 @@ import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuild
 import static org.springframework.restdocs.payload.PayloadDocumentation.*;
 import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
 import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -43,6 +42,342 @@ class CustomTimerCommandControllerTest extends AbstractRestDocSupport {
 
     @MockitoBean
     private CustomTimerCommandService customTimerCommandService;
+
+    @Nested
+    @DisplayName("커스텀 타이머 생성 성공")
+    class CreateCustomTimer {
+
+        @Test
+        @DisplayName("커스텀 타이머를 성공적으로 생성한다")
+        void createCustomTimer_Success() throws Exception {
+            // given
+            UUID memberId = UUID.randomUUID();
+
+            // 요청 본문 DTO 생성
+            List<CustomTimerStepCreateRequest> steps = List.of(
+                    new CustomTimerStepCreateRequest("데드리프트", (byte) 0, 180),
+                    new CustomTimerStepCreateRequest("휴식", (byte) 1, 60),
+                    new CustomTimerStepCreateRequest("스쿼트", (byte) 2, 120)
+            );
+            CustomTimerCreateRequest request = new CustomTimerCreateRequest("3대 운동 루틴", steps);
+
+            // 서비스 계층의 응답 객체 생성
+            CustomTimerCreateResponse expectedResponse = new CustomTimerCreateResponse(1L);
+
+            // 서비스 메소드가 어떤 요청이든(any) 받으면, 미리 정의된 응답을 반환하도록 설정
+            given(customTimerCommandService.createCustomTimer(any(CustomTimerCreateRequest.class)))
+                    .willReturn(expectedResponse);
+
+            // when & then
+            mockMvc.perform(post("/api/v1/custom-timers") // POST 요청
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .accept(MediaType.APPLICATION_JSON)
+                            .headers(getCommonApiHeaders(memberId))
+                            .content(objectMapper.writeValueAsString(request))) // 요청 본문 추가
+                    .andExpectAll(
+                            status().isCreated(), // 201 Created 상태 코드를 기대
+                            jsonPath("$.succeed").value(true),
+                            jsonPath("$.code").value("CREATED"),
+                            jsonPath("$.data.customTimerId").value(expectedResponse.customTimerId())
+                    )
+                    .andDo(document.document(
+                            requestHeaders(HEADER_ACCESS_TOKEN),
+                            // 요청 본문의 필드를 문서화합니다.
+                            requestFields(
+                                    fieldWithPath("customTimerName").description("생성할 커스텀 타이머의 이름입니다."),
+                                    fieldWithPath("customTimerSteps").description("커스텀 타이머에 포함될 스텝 목록입니다."),
+                                    fieldWithPath("customTimerSteps[].customTimerStepName").description("스텝의 이름입니다."),
+                                    fieldWithPath("customTimerSteps[].customTimerStepOrder").description("스텝의 순서입니다."),
+                                    fieldWithPath("customTimerSteps[].customTimerStepTime").description("스텝의 시간(초)입니다.")
+                            ),
+                            // 응답 본문의 필드를 문서화합니다.
+                            responseFields(commonResponseFields(
+                                    fieldWithPath("data.customTimerId").description("새롭게 생성된 커스텀 타이머의 ID입니다.")
+                            ))
+                    ));
+
+            // 서비스 메소드가 정확히 1번 호출되었는지 검증
+            then(customTimerCommandService).should().createCustomTimer(any(CustomTimerCreateRequest.class));
+            then(customTimerCommandService).shouldHaveNoMoreInteractions();
+        }
+
+        @Test
+        @DisplayName("타이머 이름이 비어있으면 400 에러를 반환한다")
+        void shouldFail_whenNameIsBlank() throws Exception {
+            // given
+            UUID memberId = UUID.randomUUID();
+            List<CustomTimerStepCreateRequest> steps = List.of(new CustomTimerStepCreateRequest("스텝 1", (byte) 1, 30));
+            CustomTimerCreateRequest request = new CustomTimerCreateRequest("", steps); // Invalid: blank name
+
+            // when & then
+            mockMvc.perform(post("/api/v1/custom-timers")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .headers(getCommonApiHeaders(memberId))
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andExpect(status().isBadRequest());
+
+            then(customTimerCommandService).shouldHaveNoInteractions();
+        }
+
+        @Test
+        @DisplayName("타이머 스텝 리스트가 null이면 400 에러를 반환한다")
+        void shouldFail_whenStepsListIsNull() throws Exception {
+            // given
+            UUID memberId = UUID.randomUUID();
+            CustomTimerCreateRequest request = new CustomTimerCreateRequest("유효한 이름", null); // Invalid: null steps
+
+            // when & then
+            mockMvc.perform(post("/api/v1/custom-timers")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .headers(getCommonApiHeaders(memberId))
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andExpect(status().isBadRequest());
+
+            then(customTimerCommandService).shouldHaveNoInteractions();
+        }
+
+        @Test
+        @DisplayName("타이머 스텝의 이름이 비어있으면(@Valid) 400 에러를 반환한다")
+        void shouldFail_whenNestedStepNameIsBlank() throws Exception {
+            // given
+            UUID memberId = UUID.randomUUID();
+            List<CustomTimerStepCreateRequest> steps = List.of(
+                    new CustomTimerStepCreateRequest("", (byte) 1, 30) // Invalid: blank step name
+            );
+            CustomTimerCreateRequest request = new CustomTimerCreateRequest("유효한 이름", steps);
+
+            // when & then
+            mockMvc.perform(post("/api/v1/custom-timers")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .headers(getCommonApiHeaders(memberId))
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andExpect(status().isBadRequest());
+
+            then(customTimerCommandService).shouldHaveNoInteractions();
+        }
+
+        @Test
+        @DisplayName("타이머 스텝의 시간이 1보다 작으면(@Min) 400 에러를 반환한다")
+        void shouldFail_whenNestedStepTimeIsInvalid() throws Exception {
+            // given
+            UUID memberId = UUID.randomUUID();
+            List<CustomTimerStepCreateRequest> steps = List.of(
+                    new CustomTimerStepCreateRequest("유효한 스텝 이름", (byte) 1, 0) // Invalid: time is 0
+            );
+            CustomTimerCreateRequest request = new CustomTimerCreateRequest("유효한 이름", steps);
+
+            // when & then
+            mockMvc.perform(post("/api/v1/custom-timers")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .headers(getCommonApiHeaders(memberId))
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andExpect(status().isBadRequest());
+
+            then(customTimerCommandService).shouldHaveNoInteractions();
+        }
+    }
+
+    @Nested
+    @DisplayName("커스텀 타이머 삭제 API")
+    class DeleteCustomTimer {
+
+        @Test
+        @DisplayName("정상적으로 커스텀 타이머를 삭제한다")
+        void deleteCustomTimer_Success() throws Exception {
+            // given
+            UUID memberId = UUID.randomUUID();
+            Long timerId = 1L;
+
+            // 실제로 삭제하지 않기위해 willDoNothing() 사용
+            willDoNothing().given(customTimerCommandService).deleteCustomTimer(timerId);
+
+            // when & then
+            mockMvc.perform(delete("/api/v1/custom-timers/{customTimerId}", timerId)
+                            .headers(getCommonApiHeaders(memberId)))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.succeed").value(true))
+                    .andExpect(jsonPath("$.code").value("DELETED"))
+                    .andExpect(jsonPath("$.message").value("리소스가 성공적으로 삭제되었습니다."))
+                    .andExpect(jsonPath("$.data").doesNotExist())
+                    .andDo(print())
+                    .andDo(document.document(
+                            requestHeaders(
+                                    RestDocsUtils.HEADER_ACCESS_TOKEN
+                            ),
+                            pathParameters(
+                                    parameterWithName("customTimerId").attributes(getTypeFormat(JsonFieldType.NUMBER))
+                                            .description("삭제할 커스텀 타이머의 ID를 의미합니다.")
+                            ),
+                            responseFields(
+                                    RestDocsUtils.commonResponseFieldsOnly()
+                            )
+                    ));
+
+            then(customTimerCommandService).should().deleteCustomTimer(timerId);
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 타이머 삭제 시 404 에러를 반환한다")
+        void deleteCustomTimer_NotFound() throws Exception {
+            // given
+            UUID memberId = UUID.randomUUID();
+            Long timerId = 999L;
+
+            // 서비스 계층에서 예외 발생하도록 설정
+            doThrow(new CustomException(ErrorCode.CUSTOM_TIMER_NOT_FOUND))
+                    .when(customTimerCommandService).deleteCustomTimer(timerId);
+
+            // when & then
+            mockMvc.perform(delete("/api/v1/custom-timers/{customTimerId}", timerId)
+                            .headers(getCommonApiHeaders(memberId)))
+                    .andExpect(status().isNotFound())
+                    .andExpect(jsonPath("$.succeed").value(false))
+                    .andExpect(jsonPath("$.code").value(ErrorCode.CUSTOM_TIMER_NOT_FOUND.name()));
+
+            then(customTimerCommandService).should().deleteCustomTimer(timerId);
+        }
+    }
+
+    @Nested
+    @DisplayName("커스텀 타이머 전체 수정 API")
+    class UpdateCustomTimer {
+
+        @Test
+        @DisplayName("정상적으로 커스텀 타이머를 수정한다 (이름 변경 + 스텝 교체)")
+        void updateCustomTimer_Success() throws Exception {
+            // given
+            UUID memberId = UUID.randomUUID();
+            Long timerId = 1L;
+
+            // 요청 본문 DTO 생성
+            List<CustomTimerStepCreateRequest> newSteps = List.of(
+                    new CustomTimerStepCreateRequest("새로운 스텝 1", (byte) 0, 120),
+                    new CustomTimerStepCreateRequest("새로운 휴식", (byte) 1, 30)
+            );
+            CustomTimerCreateRequest request = new CustomTimerCreateRequest("새로운 타이머 이름", newSteps);
+
+            // 서비스 계층의 void 메소드는 willDoNothing()으로 모킹
+            willDoNothing().given(customTimerCommandService)
+                    .updateCustomTimer(eq(timerId), any(CustomTimerCreateRequest.class));
+
+            // when & then
+            mockMvc.perform(put("/api/v1/custom-timers/{customTimerId}", timerId) // PUT 요청
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .headers(getCommonApiHeaders(memberId))
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.succeed").value(true))
+                    .andExpect(jsonPath("$.code").value("UPDATED"))
+                    .andExpect(jsonPath("$.message").value("리소스가 성공적으로 수정되었습니다."))
+                    .andExpect(jsonPath("$.data").doesNotExist())
+                    .andDo(print())
+                    .andDo(document.document(
+                            requestHeaders(
+                                    RestDocsUtils.HEADER_ACCESS_TOKEN
+                            ),
+                            pathParameters(
+                                    parameterWithName("customTimerId").attributes(getTypeFormat(JsonFieldType.NUMBER))
+                                            .description("수정할 커스텀 타이머의 ID입니다.")
+                            ),
+                            requestFields(
+                                    fieldWithPath("customTimerName").description("생성할 커스텀 타이머의 이름입니다. 커스텀 타이머 이름은 최소 1글자, 최대 100글자 이내여야 합니다."),
+                                    fieldWithPath("customTimerSteps").description("커스텀 타이머에 포함될 스텝 목록입니다."),
+                                    fieldWithPath("customTimerSteps[].customTimerStepName").description("스텝의 이름입니다. 커스텀 타이머 스텝 이름은 최소 1글자, 최대 50글자 이내여야 합니다."),
+                                    fieldWithPath("customTimerSteps[].customTimerStepOrder").description("스텝의 순서입니다. 커스텀 타이머의 순서는 0~49 이내의 연속적인 정수여야 합니다."),
+                                    fieldWithPath("customTimerSteps[].customTimerStepTime").description("스텝의 시간(초)입니다. 커스텀 타이머의 시간은 1 ~ 3599 이내의 값을 입력해야 합니다.")
+                            ),
+                            responseFields(
+                                    RestDocsUtils.commonResponseFieldsOnly()
+                            )
+                    ));
+
+            // 서비스 메소드가 정확한 인자와 함께 1번 호출되었는지 검증
+            then(customTimerCommandService).should()
+                    .updateCustomTimer(eq(timerId), any(CustomTimerCreateRequest.class));
+        }
+
+        @Test
+        @DisplayName("타이머 이름이 비어있으면(@NotBlank) 400 에러를 반환한다")
+        void updateCustomTimer_ValidationFail_BlankName() throws Exception {
+            // given
+            UUID memberId = UUID.randomUUID();
+            Long timerId = 1L;
+            List<CustomTimerStepCreateRequest> steps = List.of(new CustomTimerStepCreateRequest("유효한 스텝", (byte) 0, 30));
+            // 유효성 검사에 실패할 요청 DTO (이름이 비어있음)
+            CustomTimerCreateRequest request = new CustomTimerCreateRequest("", steps);
+
+            // when & then
+            mockMvc.perform(put("/api/v1/custom-timers/{customTimerId}", timerId)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .headers(getCommonApiHeaders(memberId))
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andExpect(status().isBadRequest());
+
+            // 유효성 검사 단계에서 실패했으므로 서비스 계층은 호출되지 않아야 함
+            then(customTimerCommandService).shouldHaveNoInteractions();
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 타이머 수정 시 404 에러를 반환한다")
+        void updateCustomTimer_NotFound() throws Exception {
+            // given
+            UUID memberId = UUID.randomUUID();
+            Long nonExistentTimerId = 999L;
+            CustomTimerCreateRequest request = new CustomTimerCreateRequest("유효한 이름", List.of(new CustomTimerStepCreateRequest("유효한 스텝", (byte) 0, 30)));
+
+            // 서비스 계층에서 예외가 발생하도록 설정
+            doThrow(new CustomException(ErrorCode.CUSTOM_TIMER_NOT_FOUND))
+                    .when(customTimerCommandService)
+                    .updateCustomTimer(eq(nonExistentTimerId), any(CustomTimerCreateRequest.class));
+
+            // when & then
+            mockMvc.perform(put("/api/v1/custom-timers/{customTimerId}", nonExistentTimerId)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .headers(getCommonApiHeaders(memberId))
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andExpect(status().isNotFound())
+                    .andExpect(jsonPath("$.succeed").value(false))
+                    .andExpect(jsonPath("$.code").value(ErrorCode.CUSTOM_TIMER_NOT_FOUND.name()));
+
+            // 예외는 발생했지만 서비스 메소드 자체는 호출되었음을 검증
+            then(customTimerCommandService).should()
+                    .updateCustomTimer(eq(nonExistentTimerId), any(CustomTimerCreateRequest.class));
+        }
+
+        @Test
+        @DisplayName("스텝 개수가 정책상 최대치를 초과하면 409 Conflict 에러를 반환한다")
+        void updateCustomTimer_Conflict_MaxStepsExceeded() throws Exception {
+            // given
+            UUID memberId = UUID.randomUUID();
+            Long timerId = 1L;
+
+            // 정책 위반을 유발할 요청 DTO (스텝이 너무 많음)
+            List<CustomTimerStepCreateRequest> tooManySteps = List.of(
+                    new CustomTimerStepCreateRequest("스텝 1", (byte) 0, 30),
+                    new CustomTimerStepCreateRequest("스텝 2", (byte) 1, 30),
+                    new CustomTimerStepCreateRequest("스텝 3", (byte) 2, 30)
+            );
+            CustomTimerCreateRequest request = new CustomTimerCreateRequest("스텝이 너무 많은 타이머", tooManySteps);
+
+            // 서비스 계층에서 '정책 위반' 예외가 발생하도록 설정
+            doThrow(new CustomException(ErrorCode.CUSTOM_TIMER_STEP_MAX_COUNT_VIOLATION))
+                    .when(customTimerCommandService)
+                    .updateCustomTimer(eq(timerId), any(CustomTimerCreateRequest.class));
+
+            // when & then
+            mockMvc.perform(put("/api/v1/custom-timers/{customTimerId}", timerId)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .headers(getCommonApiHeaders(memberId))
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andExpect(status().isConflict()) // 409 Conflict 상태 코드를 기대
+                    .andExpect(jsonPath("$.succeed").value(false))
+                    .andExpect(jsonPath("$.code").value(ErrorCode.CUSTOM_TIMER_STEP_MAX_COUNT_VIOLATION.name()));
+
+            // 서비스 메소드 자체는 호출되었음을 검증
+            then(customTimerCommandService).should()
+                    .updateCustomTimer(eq(timerId), any(CustomTimerCreateRequest.class));
+        }
+    }
 
     @Nested
     @DisplayName("커스텀 타이머 이름 수정 API")
@@ -132,206 +467,6 @@ class CustomTimerCommandControllerTest extends AbstractRestDocSupport {
                     .andExpect(jsonPath("$.code").value(ErrorCode.CUSTOM_TIMER_NOT_FOUND.name()));
 
             then(customTimerCommandService).should().updateCustomTimerName(eq(nonExistentTimerId), any(CustomTimerNameUpdateRequest.class));
-        }
-    }
-
-    @Nested
-    @DisplayName("커스텀 타이머 삭제 API")
-    class DeleteCustomTimer {
-
-        @Test
-        @DisplayName("정상적으로 커스텀 타이머를 삭제한다")
-        void deleteCustomTimer_Success() throws Exception {
-            // given
-            UUID memberId = UUID.randomUUID();
-            Long timerId = 1L;
-
-            // 실제로 삭제하지 않기위해 willDoNothing() 사용
-            willDoNothing().given(customTimerCommandService).deleteCustomTimer(timerId);
-
-            // when & then
-            mockMvc.perform(delete("/api/v1/custom-timers/{customTimerId}", timerId)
-                            .headers(getCommonApiHeaders(memberId)))
-                    .andExpect(status().isOk())
-                    .andExpect(jsonPath("$.succeed").value(true))
-                    .andExpect(jsonPath("$.code").value("DELETED"))
-                    .andExpect(jsonPath("$.message").value("리소스가 성공적으로 삭제되었습니다."))
-                    .andExpect(jsonPath("$.data").doesNotExist())
-                    .andDo(print())
-                    .andDo(document.document(
-                            requestHeaders(
-                                    RestDocsUtils.HEADER_ACCESS_TOKEN
-                            ),
-                            pathParameters(
-                                    parameterWithName("customTimerId").attributes(getTypeFormat(JsonFieldType.NUMBER))
-                                            .description("삭제할 커스텀 타이머의 ID를 의미합니다.")
-                            ),
-                            responseFields(
-                                    RestDocsUtils.commonResponseFieldsOnly()
-                            )
-                    ));
-
-            then(customTimerCommandService).should().deleteCustomTimer(timerId);
-        }
-
-        @Test
-        @DisplayName("존재하지 않는 타이머 삭제 시 404 에러를 반환한다")
-        void deleteCustomTimer_NotFound() throws Exception {
-            // given
-            UUID memberId = UUID.randomUUID();
-            Long timerId = 999L;
-
-            // 서비스 계층에서 예외 발생하도록 설정
-            doThrow(new CustomException(ErrorCode.CUSTOM_TIMER_NOT_FOUND))
-                    .when(customTimerCommandService).deleteCustomTimer(timerId);
-
-            // when & then
-            mockMvc.perform(delete("/api/v1/custom-timers/{customTimerId}", timerId)
-                            .headers(getCommonApiHeaders(memberId)))
-                    .andExpect(status().isNotFound())
-                    .andExpect(jsonPath("$.succeed").value(false))
-                    .andExpect(jsonPath("$.code").value(ErrorCode.CUSTOM_TIMER_NOT_FOUND.name()));
-
-            then(customTimerCommandService).should().deleteCustomTimer(timerId);
-        }
-    }
-
-    @Nested
-    @DisplayName("커스텀 타이머 생성 성공")
-    class CreateCustomTimer {
-
-        @Test
-        @DisplayName("커스텀 타이머를 성공적으로 생성한다")
-        void createCustomTimer_Success() throws Exception {
-            // given
-            UUID memberId = UUID.randomUUID();
-
-            // 요청 본문 DTO 생성
-            List<CustomTimerStepCreateRequest> steps = List.of(
-                    new CustomTimerStepCreateRequest("데드리프트", (byte) 0, 180),
-                    new CustomTimerStepCreateRequest("휴식", (byte) 1, 60),
-                    new CustomTimerStepCreateRequest("스쿼트", (byte) 2, 120)
-            );
-            CustomTimerCreateRequest request = new CustomTimerCreateRequest("3대 운동 루틴", steps);
-
-            // 서비스 계층의 응답 객체 생성
-            CustomTimerCreateResponse expectedResponse = new CustomTimerCreateResponse(1L);
-
-            // 서비스 메소드가 어떤 요청이든(any) 받으면, 미리 정의된 응답을 반환하도록 설정
-            given(customTimerCommandService.createCustomTimer(any(CustomTimerCreateRequest.class)))
-                    .willReturn(expectedResponse);
-
-            // when & then
-            mockMvc.perform(post("/api/v1/custom-timers") // POST 요청
-                            .contentType(MediaType.APPLICATION_JSON)
-                            .accept(MediaType.APPLICATION_JSON)
-                            .headers(getCommonApiHeaders(memberId))
-                            .content(objectMapper.writeValueAsString(request))) // 요청 본문 추가
-                    .andExpectAll(
-                            status().isCreated(), // 201 Created 상태 코드를 기대
-                            jsonPath("$.succeed").value(true),
-                            jsonPath("$.code").value("CREATED"),
-                            jsonPath("$.data.customTimerId").value(expectedResponse.customTimerId())
-                    )
-                    .andDo(document.document(
-                            requestHeaders(HEADER_ACCESS_TOKEN),
-                            // 요청 본문의 필드를 문서화합니다.
-                            requestFields(
-                                    fieldWithPath("customTimerName").description("생성할 커스텀 타이머의 이름입니다."),
-                                    fieldWithPath("customTimerSteps").description("커스텀 타이머에 포함될 스텝 목록입니다."),
-                                    fieldWithPath("customTimerSteps[].customTimerStepName").description("스텝의 이름입니다."),
-                                    fieldWithPath("customTimerSteps[].customTimerStepOrder").description("스텝의 순서입니다."),
-                                    fieldWithPath("customTimerSteps[].customTimerStepTime").description("스텝의 시간(초)입니다.")
-                            ),
-                            // 응답 본문의 필드를 문서화합니다.
-                            responseFields(commonResponseFields(
-                                    fieldWithPath("data.customTimerId").description("새롭게 생성된 커스텀 타이머의 ID입니다.")
-                            ))
-                    ));
-
-            // 서비스 메소드가 정확히 1번 호출되었는지 검증
-            then(customTimerCommandService).should().createCustomTimer(any(CustomTimerCreateRequest.class));
-            then(customTimerCommandService).shouldHaveNoMoreInteractions();
-        }
-    }
-
-    @Nested
-    @DisplayName("커스텀 타이머 생성 실패")
-    class CreateFailure {
-
-        @Test
-        @DisplayName("타이머 이름이 비어있으면 400 에러를 반환한다")
-        void shouldFail_whenNameIsBlank() throws Exception {
-            // given
-            UUID memberId = UUID.randomUUID();
-            List<CustomTimerStepCreateRequest> steps = List.of(new CustomTimerStepCreateRequest("스텝 1", (byte) 1, 30));
-            CustomTimerCreateRequest request = new CustomTimerCreateRequest("", steps); // Invalid: blank name
-
-            // when & then
-            mockMvc.perform(post("/api/v1/custom-timers")
-                            .contentType(MediaType.APPLICATION_JSON)
-                            .headers(getCommonApiHeaders(memberId))
-                            .content(objectMapper.writeValueAsString(request)))
-                    .andExpect(status().isBadRequest());
-
-            then(customTimerCommandService).shouldHaveNoInteractions();
-        }
-
-        @Test
-        @DisplayName("타이머 스텝 리스트가 null이면 400 에러를 반환한다")
-        void shouldFail_whenStepsListIsNull() throws Exception {
-            // given
-            UUID memberId = UUID.randomUUID();
-            CustomTimerCreateRequest request = new CustomTimerCreateRequest("유효한 이름", null); // Invalid: null steps
-
-            // when & then
-            mockMvc.perform(post("/api/v1/custom-timers")
-                            .contentType(MediaType.APPLICATION_JSON)
-                            .headers(getCommonApiHeaders(memberId))
-                            .content(objectMapper.writeValueAsString(request)))
-                    .andExpect(status().isBadRequest());
-
-            then(customTimerCommandService).shouldHaveNoInteractions();
-        }
-
-        @Test
-        @DisplayName("타이머 스텝의 이름이 비어있으면(@Valid) 400 에러를 반환한다")
-        void shouldFail_whenNestedStepNameIsBlank() throws Exception {
-            // given
-            UUID memberId = UUID.randomUUID();
-            List<CustomTimerStepCreateRequest> steps = List.of(
-                    new CustomTimerStepCreateRequest("", (byte) 1, 30) // Invalid: blank step name
-            );
-            CustomTimerCreateRequest request = new CustomTimerCreateRequest("유효한 이름", steps);
-
-            // when & then
-            mockMvc.perform(post("/api/v1/custom-timers")
-                            .contentType(MediaType.APPLICATION_JSON)
-                            .headers(getCommonApiHeaders(memberId))
-                            .content(objectMapper.writeValueAsString(request)))
-                    .andExpect(status().isBadRequest());
-
-            then(customTimerCommandService).shouldHaveNoInteractions();
-        }
-
-        @Test
-        @DisplayName("타이머 스텝의 시간이 1보다 작으면(@Min) 400 에러를 반환한다")
-        void shouldFail_whenNestedStepTimeIsInvalid() throws Exception {
-            // given
-            UUID memberId = UUID.randomUUID();
-            List<CustomTimerStepCreateRequest> steps = List.of(
-                    new CustomTimerStepCreateRequest("유효한 스텝 이름", (byte) 1, 0) // Invalid: time is 0
-            );
-            CustomTimerCreateRequest request = new CustomTimerCreateRequest("유효한 이름", steps);
-
-            // when & then
-            mockMvc.perform(post("/api/v1/custom-timers")
-                            .contentType(MediaType.APPLICATION_JSON)
-                            .headers(getCommonApiHeaders(memberId))
-                            .content(objectMapper.writeValueAsString(request)))
-                    .andExpect(status().isBadRequest());
-
-            then(customTimerCommandService).shouldHaveNoInteractions();
         }
     }
 }

--- a/src/test/java/com/project200/undabang/timer/custom/service/impl/CustomTimerCommandServiceImplTest.java
+++ b/src/test/java/com/project200/undabang/timer/custom/service/impl/CustomTimerCommandServiceImplTest.java
@@ -137,21 +137,6 @@ class CustomTimerCommandServiceImplTest {
         return new CustomTimerNameUpdateRequest(newName);
     }
 
-    private Member createTestUser(UUID userId) {
-        return Member.builder().memberId(userId).build();
-    }
-
-    private CustomTimerCreateRequest createRequest(int stepCount) {
-        List<CustomTimerStepCreateRequest> steps = IntStream.range(0, stepCount)
-                .mapToObj(i -> new CustomTimerStepCreateRequest(
-                        "스텝 " + i,
-                        (byte) i,
-                        60
-                ))
-                .toList();
-        return new CustomTimerCreateRequest("테스트 타이머", steps);
-    }
-
     @Nested
     @DisplayName("updateCustomTimerName() 메소드는")
     class Describe_updateCustomTimerName {
@@ -230,6 +215,21 @@ class CustomTimerCommandServiceImplTest {
         }
     }
 
+    private Member createTestUser(UUID userId) {
+        return Member.builder().memberId(userId).build();
+    }
+
+    private CustomTimerCreateRequest createRequest(int stepCount) {
+        List<CustomTimerStepCreateRequest> steps = IntStream.range(0, stepCount)
+                .mapToObj(i -> new CustomTimerStepCreateRequest(
+                        "스텝 " + i,
+                        (byte) i,
+                        60
+                ))
+                .toList();
+        return new CustomTimerCreateRequest("테스트 타이머", steps);
+    }
+
     @Nested
     @DisplayName("createCustomTimer() 메소드는")
     class Describe_createCustomTimer {
@@ -257,6 +257,9 @@ class CustomTimerCommandServiceImplTest {
                 assertThat(response).isNotNull();
                 assertThat(response.customTimerId()).isEqualTo(1L);
 
+                verify(policyService, times(1)).getPolicyValueAsInt(PolicyKey.CUSTOM_TIMER_STEP_MIN_COUNT);
+                verify(policyService, times(1)).getPolicyValueAsInt(PolicyKey.CUSTOM_TIMER_STEP_MAX_COUNT);
+
                 ArgumentCaptor<CustomTimer> timerCaptor = ArgumentCaptor.forClass(CustomTimer.class);
                 verify(customTimerRepository, times(1)).save(timerCaptor.capture());
                 assertThat(timerCaptor.getValue().getMember()).isEqualTo(testUser);
@@ -265,7 +268,6 @@ class CustomTimerCommandServiceImplTest {
                 ArgumentCaptor<List<CustomTimerStep>> stepsCaptor = ArgumentCaptor.forClass(List.class);
                 verify(customTimerStepRepository, times(1)).saveAll(stepsCaptor.capture());
                 assertThat(stepsCaptor.getValue()).hasSize(3);
-                assertThat(stepsCaptor.getValue().get(0).getCustomTimerStepName()).isEqualTo("스텝 0");
             }
         }
 
@@ -353,7 +355,6 @@ class CustomTimerCommandServiceImplTest {
             try (MockedStatic<UserContextHolder> ignored = mockStatic(UserContextHolder.class)) {
                 ignored.when(UserContextHolder::getUserId).thenReturn(testUserId);
                 given(memberRepository.findById(testUserId)).willReturn(Optional.of(testUser));
-                given(policyService.getPolicyValueAsInt(any(PolicyKey.class))).willReturn(1).willReturn(10);
 
                 // when & then
                 assertThatThrownBy(() -> customTimerCommandService.createCustomTimer(request))
@@ -361,6 +362,85 @@ class CustomTimerCommandServiceImplTest {
                         .hasFieldOrPropertyWithValue("errorCode", ErrorCode.CUSTOM_TIMER_STEP_ORDER_INVALID);
 
                 verify(customTimerRepository, never()).save(any());
+                verify(customTimerStepRepository, never()).saveAll(any());
+            }
+        }
+    }
+
+    @Nested
+    @DisplayName("updateCustomTimer() 메소드는")
+    class Describe_updateCustomTimer {
+
+        @Test
+        @DisplayName("유효한 요청이 주어지면, 타이머 이름 변경 및 스텝 교체를 성공적으로 수행한다")
+        void shouldUpdateNameAndReplaceSteps_whenRequestIsValid() {
+            // given
+            UUID userId = UUID.randomUUID();
+            Member member = createTestUser(userId);
+            Long timerId = 1L;
+            CustomTimerCreateRequest request = createRequest(2); // 2개의 새 스텝으로 교체 요청
+
+            // 엔티티의 실제 메소드 호출을 검증하기 위해 Spy 객체 사용
+            CustomTimer originalTimer = spy(CustomTimer.builder()
+                    .id(timerId)
+                    .member(member)
+                    .customTimerName("오래된 이름")
+                    .build());
+
+            try (MockedStatic<UserContextHolder> ignored = mockStatic(UserContextHolder.class)) {
+                ignored.when(UserContextHolder::getUserId).thenReturn(userId);
+
+                // --- Mocking ---
+                // 1. 사용자 및 타이머 조회 성공
+                given(memberRepository.findById(userId)).willReturn(Optional.of(member));
+                given(customTimerRepository.findByIdAndMemberAndCustomTimerDeletedAtNull(timerId, member))
+                        .willReturn(Optional.of(originalTimer));
+                // 2. 유효성 검사 통과를 위한 정책 모킹
+                given(policyService.getPolicyValueAsInt(any(PolicyKey.class))).willReturn(1).willReturn(10);
+
+                // when
+                customTimerCommandService.updateCustomTimer(timerId, request);
+
+                // then
+                // 1. 타이머 이름이 올바르게 업데이트 되었는지 검증
+                verify(originalTimer, times(1)).updateCustomTimerName(request.getCustomTimerName());
+
+                // 2. 기존 스텝들이 삭제 처리 되었는지 검증
+                verify(customTimerStepRepository, times(1)).softDeleteAllByCustomTimer(originalTimer);
+
+                // 3. 새로운 스텝들이 저장 처리 되었는지 검증
+                ArgumentCaptor<List<CustomTimerStep>> stepsCaptor = ArgumentCaptor.forClass(List.class);
+                verify(customTimerStepRepository, times(1)).saveAll(stepsCaptor.capture());
+                assertThat(stepsCaptor.getValue()).hasSize(2); // 요청한 대로 2개의 스텝이 생성되었는지 확인
+                assertThat(stepsCaptor.getValue().get(0).getCustomTimerStepName()).isEqualTo("스텝 0");
+            }
+        }
+
+        @Test
+        @DisplayName("스텝 개수가 정책상 최소치보다 적으면 CustomException을 던지고 아무 작업도 수행하지 않는다")
+        void shouldThrowExceptionAndDoNothing_whenStepCountIsBelowMin() {
+            // given
+            UUID userId = UUID.randomUUID();
+            Member member = createTestUser(userId);
+            Long timerId = 1L;
+            CustomTimerCreateRequest request = createRequest(1); // 정책 위반 (2개 미만)
+            CustomTimer timer = spy(CustomTimer.builder().id(timerId).member(member).build());
+
+            try (MockedStatic<UserContextHolder> ignored = mockStatic(UserContextHolder.class)) {
+                ignored.when(UserContextHolder::getUserId).thenReturn(userId);
+                given(memberRepository.findById(userId)).willReturn(Optional.of(member));
+                given(customTimerRepository.findByIdAndMemberAndCustomTimerDeletedAtNull(timerId, member))
+                        .willReturn(Optional.of(timer));
+                given(policyService.getPolicyValueAsInt(PolicyKey.CUSTOM_TIMER_STEP_MIN_COUNT)).willReturn(2); // 정책: 최소 2개
+
+                // when & then
+                assertThatThrownBy(() -> customTimerCommandService.updateCustomTimer(timerId, request))
+                        .isInstanceOf(CustomException.class)
+                        .hasFieldOrPropertyWithValue("errorCode", ErrorCode.CUSTOM_TIMER_STEP_MIN_COUNT_VIOLATION);
+
+                // 예외 발생 후 DB 변경 작업이 전혀 호출되지 않았는지 검증 (중요)
+                verify(timer, never()).updateCustomTimerName(anyString());
+                verify(customTimerStepRepository, never()).softDeleteAllByCustomTimer(any());
                 verify(customTimerStepRepository, never()).saveAll(any());
             }
         }


### PR DESCRIPTION
## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

커스텀 데이터 수정 기능을 개발하였습니다.

이전 기능들과 마찬가지로 테스트케이스 100%을 유지하였습니다.

이전 개발한 기능들을 최대한 재사용하여 개발하였습니다.(검증, 이름 변경, 논리적 삭제, 스텝 추가 등)

또한, 수정 = 삭제 + 생성 의 느낌으로 개발을 진행하였으므로, 생성의 요청 DTO를 재사용 하였습니다.

### 스크린샷 (선택)
테스트케이스 사진입니다.
<img width="704" height="128" alt="image" src="https://github.com/user-attachments/assets/ab132789-1066-46de-8f77-432c3ba8990e" />

API 명세서 사진입니다.
<img width="693" height="282" alt="image" src="https://github.com/user-attachments/assets/8832f8c5-5013-4fa9-9a46-cc91695bf196" />
<img width="948" height="446" alt="image" src="https://github.com/user-attachments/assets/3672ae5a-0fa4-412c-8473-f6a9d31145c0" />
<img width="992" height="492" alt="image" src="https://github.com/user-attachments/assets/2a869630-3a08-410d-b940-5344f36b4938" />
<img width="988" height="508" alt="image" src="https://github.com/user-attachments/assets/aba02da2-d7c5-48bb-9470-07149e8900f2" />
<img width="997" height="398" alt="image" src="https://github.com/user-attachments/assets/2799d43c-e78b-470d-ae98-6ae587dd4dfc" />
<img width="994" height="361" alt="image" src="https://github.com/user-attachments/assets/9904ac05-ac69-4292-94b8-431e931a79e7" />
<img width="998" height="614" alt="image" src="https://github.com/user-attachments/assets/3653d627-c02f-4879-8474-8543cb86eaa6" />
<img width="991" height="507" alt="image" src="https://github.com/user-attachments/assets/943dc471-ee7c-43c0-b357-a4e74c7d2a64" />
<img width="993" height="355" alt="image" src="https://github.com/user-attachments/assets/708aa614-eb7b-4216-a04c-833f7a67cace" />

## #️⃣연관된 이슈

 API 명세서 #207,
 Closes #251 