### PR TITLE
[Feat] 회원 테이블에 외래 키 제약조건 추가 및 DDL 수정

### DIFF
--- a/documents/Undabang SQL/Undabang Database DDL.sql
+++ b/documents/Undabang SQL/Undabang Database DDL.sql
@@ -188,8 +188,7 @@ create table if not exists members
     constraint member_nickname
         unique (member_nickname),
     constraint check_member_gender
-        check (member_gender in ('M', 'F', 'U')),
-    constraint FK_member_pictures_TO_members_1 FOREIGN KEY (member_picture_id) REFERENCES member_pictures (picture_id)
+        check (member_gender in ('M', 'F', 'U'))
 );
 
 create table if not exists chatrooms
@@ -306,6 +305,12 @@ create table if not exists member_pictures
     constraint FK_mp_pictures
         foreign key (picture_id) references pictures (picture_id)
 );
+
+ALTER TABLE members
+    -- 외래 키(Foreign Key) 제약조건 추가
+    ADD CONSTRAINT FK_member_pictures_TO_members_1
+        FOREIGN KEY (member_picture_id)
+            REFERENCES member_pictures (picture_id);
 
 create table if not exists policies
 (


### PR DESCRIPTION
## 📝작업 내용

오류: 회원에서 회원 사진 참조하는데 회원 사진에서도 회원을 참조해서 DDL 실패하는 오류 발생
해결: 회원 만들고 사진 만들고 회원 사진 만들고 alter로 외래 제약조건 추가하도록 설정