### PR TITLE
[Feat] 마이페이지 조회 기능 개발 [0.3.2]

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ plugins {
 }
 
 group = 'com.project200'
-version = '0.3.0-SNAPSHOT'
+version = '0.3.2-SNAPSHOT'
 
 java {
     toolchain {

--- a/src/docs/asciidoc/member/회원-점수-조회-API.adoc
+++ b/src/docs/asciidoc/member/회원-점수-조회-API.adoc
@@ -15,10 +15,12 @@
 - <<공통-개발-참고-사항,공통 개발 참고 사항>>을 참고하세요.
 
 === 코드 샘플
-operation::member-rest-controller-test/get-member-score_success[snippets="curl-request,http-request,http-response"]
+
+operation::get-member-score/get-member-score_success[snippets="curl-request,http-request,http-response"]
 
 === 매개 변수
-operation::member-rest-controller-test/get-member-score_success[snippets="request-headers,response-fields"]
+
+operation::get-member-score/get-member-score_success[snippets="request-headers,response-fields"]
 
 ==== 응답 상태 코드
 |===

--- a/src/main/java/com/project200/undabang/member/repository/MemberRepositoryCustom.java
+++ b/src/main/java/com/project200/undabang/member/repository/MemberRepositoryCustom.java
@@ -1,6 +1,10 @@
 package com.project200.undabang.member.repository;
 
+import java.util.UUID;
+
 public interface MemberRepositoryCustom {
 
+    Long countMemberExerciseInLastDays(UUID memberId, int daysAgo);
 
+    Long countMemberExerciseInThisYear(UUID memberId);
 }

--- a/src/main/java/com/project200/undabang/member/repository/impl/MemberRepositoryImpl.java
+++ b/src/main/java/com/project200/undabang/member/repository/impl/MemberRepositoryImpl.java
@@ -27,15 +27,17 @@ public class MemberRepositoryImpl implements MemberRepositoryCustom {
     public Long countMemberExerciseInLastDays(UUID memberId, int daysAgo) {
         QExercise exercise = QExercise.exercise;
 
-        LocalDateTime exerciseStartDate = LocalDateTime.now().minusDays(daysAgo);
-        LocalDateTime exerciseEndDate = LocalDate.now().plusDays(1).atStartOfDay();
+        LocalDate now = LocalDate.now();
+
+        LocalDateTime exerciseStartDate = now.minusDays(daysAgo).atStartOfDay(); // N일전 00:00:00 부터 체크
+        LocalDateTime endOfToday = now.plusDays(1).atStartOfDay(); // 오늘 23:59:59 까지 체크
 
         return queryFactory.select(exercise.count())
                 .from(exercise)
                 .where(
                         exercise.member.memberId.eq(memberId), // 특정 회원 조회
                         exercise.exerciseStartedAt.goe(exerciseStartDate), // 파라미터로 받은 기간 이후 수행한 운동
-                        exercise.exerciseStartedAt.lt(exerciseEndDate), // 오늘을 포함한 날짜까지 검색
+                        exercise.exerciseStartedAt.lt(endOfToday), // 오늘을 포함한 날짜까지 검색
                         exercise.exerciseDeletedAt.isNull() // 삭제하지 않은 운동만 검색
                 )
                 .fetchOne();
@@ -48,15 +50,17 @@ public class MemberRepositoryImpl implements MemberRepositoryCustom {
     public Long countMemberExerciseInThisYear(UUID memberId) {
         QExercise exercise = QExercise.exercise;
 
-        LocalDateTime firstDateOfYear = LocalDate.now().withDayOfYear(1).atStartOfDay();
-        LocalDateTime untilToday = LocalDate.now().plusDays(1).atStartOfDay();
+        LocalDate now = LocalDate.now();
+
+        LocalDateTime firstDateOfYear = now.withDayOfYear(1).atStartOfDay(); // 올해 1월 1일 00:00:00 부터 체크
+        LocalDateTime endOfToday = now.plusDays(1).atStartOfDay(); // 오늘 23:59:59 까지 체크
 
         return queryFactory.select(exercise.exerciseStartedAt.dayOfYear().countDistinct())
                 .from(exercise)
                 .where(
                         exercise.member.memberId.eq(memberId), // 특정 회원 조회
                         exercise.exerciseStartedAt.goe(firstDateOfYear), // 올해 1월 1일부터 카운트
-                        exercise.exerciseStartedAt.lt(untilToday), // 오늘까지만 검색
+                        exercise.exerciseStartedAt.lt(endOfToday), // 오늘까지만 검색
                         exercise.exerciseDeletedAt.isNull() // 삭제하지 않은 운동만 검색
                 )
                 .fetchOne();

--- a/src/main/java/com/project200/undabang/member/repository/impl/MemberRepositoryImpl.java
+++ b/src/main/java/com/project200/undabang/member/repository/impl/MemberRepositoryImpl.java
@@ -1,9 +1,14 @@
 package com.project200.undabang.member.repository.impl;
 
+import com.project200.undabang.exercise.entity.QExercise;
 import com.project200.undabang.member.repository.MemberRepositoryCustom;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.UUID;
 
 @Repository
 @RequiredArgsConstructor
@@ -11,5 +16,49 @@ public class MemberRepositoryImpl implements MemberRepositoryCustom {
 
     private final JPAQueryFactory queryFactory;
 
+    /**
+     * 특정 회원이 지정된 기간 내에 수행한 운동 기록의 개수를 계산합니다.
+     *
+     * @param memberId 조회할 회원의 고유 식별자 (UUID 형식)
+     * @param daysAgo  몇 일 전부터의 운동 기록을 조회할지 지정하는 날짜 수
+     * @return 지정된 기간 동안의 회원 운동 기록 개수
+     */
+    @Override
+    public Long countMemberExerciseInLastDays(UUID memberId, int daysAgo) {
+        QExercise exercise = QExercise.exercise;
 
+        LocalDateTime exerciseStartDate = LocalDateTime.now().minusDays(daysAgo);
+        LocalDateTime exerciseEndDate = LocalDate.now().plusDays(1).atStartOfDay();
+
+        return queryFactory.select(exercise.count())
+                .from(exercise)
+                .where(
+                        exercise.member.memberId.eq(memberId), // 특정 회원 조회
+                        exercise.exerciseStartedAt.goe(exerciseStartDate), // 파라미터로 받은 기간 이후 수행한 운동
+                        exercise.exerciseStartedAt.lt(exerciseEndDate), // 오늘을 포함한 날짜까지 검색
+                        exercise.exerciseDeletedAt.isNull() // 삭제하지 않은 운동만 검색
+                )
+                .fetchOne();
+    }
+
+    /**
+     * 특정 회원이 현재 연도에 수행한 운동 일수(고유 날짜 기준)를 계산합니다.
+     */
+    @Override
+    public Long countMemberExerciseInThisYear(UUID memberId) {
+        QExercise exercise = QExercise.exercise;
+
+        LocalDateTime firstDateOfYear = LocalDate.now().withDayOfYear(1).atStartOfDay();
+        LocalDateTime untilToday = LocalDate.now().plusDays(1).atStartOfDay();
+
+        return queryFactory.select(exercise.exerciseStartedAt.dayOfYear().countDistinct())
+                .from(exercise)
+                .where(
+                        exercise.member.memberId.eq(memberId), // 특정 회원 조회
+                        exercise.exerciseStartedAt.goe(firstDateOfYear), // 올해 1월 1일부터 카운트
+                        exercise.exerciseStartedAt.lt(untilToday), // 오늘까지만 검색
+                        exercise.exerciseDeletedAt.isNull() // 삭제하지 않은 운동만 검색
+                )
+                .fetchOne();
+    }
 }

--- a/src/main/java/com/project200/undabang/member/repository/impl/MemberRepositoryImpl.java
+++ b/src/main/java/com/project200/undabang/member/repository/impl/MemberRepositoryImpl.java
@@ -30,7 +30,7 @@ public class MemberRepositoryImpl implements MemberRepositoryCustom {
         LocalDate now = LocalDate.now();
 
         LocalDateTime exerciseStartDate = now.minusDays(daysAgo).atStartOfDay(); // N일전 00:00:00 부터 체크
-        LocalDateTime endOfToday = now.plusDays(1).atStartOfDay(); // 오늘 23:59:59 까지 체크
+        LocalDateTime endOfToday = now.plusDays(1).atStartOfDay(); // 내일 00:00:00 미만까지 체크(오늘 전체 포함)
 
         return queryFactory.select(exercise.count())
                 .from(exercise)
@@ -53,7 +53,7 @@ public class MemberRepositoryImpl implements MemberRepositoryCustom {
         LocalDate now = LocalDate.now();
 
         LocalDateTime firstDateOfYear = now.withDayOfYear(1).atStartOfDay(); // 올해 1월 1일 00:00:00 부터 체크
-        LocalDateTime endOfToday = now.plusDays(1).atStartOfDay(); // 오늘 23:59:59 까지 체크
+        LocalDateTime endOfToday = now.plusDays(1).atStartOfDay(); // 내일 00:00:00 미만까지 체크(오늘 전체 포함)
 
         return queryFactory.select(exercise.exerciseStartedAt.dayOfYear().countDistinct())
                 .from(exercise)

--- a/src/main/java/com/project200/undabang/member/service/impl/MemberQueryServiceImpl.java
+++ b/src/main/java/com/project200/undabang/member/service/impl/MemberQueryServiceImpl.java
@@ -26,6 +26,8 @@ public class MemberQueryServiceImpl implements MemberQueryService {
 
     private final PolicyService policyService;
 
+    private static final int RECENT_EXERCISE_PERIOD_DAYS = 30; // 최근 운동기간
+
     @Override
     public MemberRegistrationStatusResponseDto getRegistrationStatus() {
         UUID userId = UserContextHolder.getUserId();
@@ -63,6 +65,10 @@ public class MemberQueryServiceImpl implements MemberQueryService {
         Member member = memberRepository.findMemberProfileByMemberIdAndMemberDeletedAtNull(UserContextHolder.getUserId())
                 .orElseThrow(() -> new CustomException(ErrorCode.MEMBER_NOT_FOUND));
 
-        return MemberProfileResponse.of(member, 0, 0);
+        int yearlyExerciseCounts = memberRepository.countMemberExerciseInThisYear(member.getMemberId()).intValue();
+
+        int exerciseCountInLastDays = memberRepository.countMemberExerciseInLastDays(member.getMemberId(), RECENT_EXERCISE_PERIOD_DAYS).intValue();
+
+        return MemberProfileResponse.of(member, yearlyExerciseCounts, exerciseCountInLastDays);
     }
 }

--- a/src/test/java/com/project200/undabang/member/repository/MemberRepositoryTest.java
+++ b/src/test/java/com/project200/undabang/member/repository/MemberRepositoryTest.java
@@ -2,6 +2,7 @@ package com.project200.undabang.member.repository;
 
 import com.project200.undabang.common.entity.Picture;
 import com.project200.undabang.configuration.TestQuerydslConfig;
+import com.project200.undabang.exercise.entity.Exercise;
 import com.project200.undabang.exercise.entity.ExerciseType;
 import com.project200.undabang.member.dto.command.SignUpMemberCommand;
 import com.project200.undabang.member.entity.Member;
@@ -353,6 +354,175 @@ class MemberRepositoryTest {
 
             // then
             assertThat(foundMemberOptional).as("삭제된 회원이므로 빈 Optional을 반환해야 합니다.").isEmpty();
+        }
+    }
+
+    // ============== 테스트 헬퍼 메소드 추가 ==============
+    // Exercise 엔티티를 생성하고 저장하는 헬퍼 메소드
+    private Exercise createAndSaveExercise(Member member, LocalDateTime startedAt, boolean isDeleted) {
+        Exercise exercise = Exercise.builder()
+                .member(member)
+                .exerciseTitle("테스트 운동 - " + startedAt.toString())
+                .exerciseStartedAt(startedAt)
+                .exerciseEndedAt(startedAt.plusHours(1))
+                .exerciseDeletedAt(isDeleted ? LocalDateTime.now() : null)
+                .build();
+        em.persist(exercise);
+        return exercise;
+    }
+
+    @Nested
+    @DisplayName("countMemberExerciseInLastDays 메소드는")
+    class CountMemberExerciseInLastDaysTest {
+
+        @Test
+        @DisplayName("지정된 기간 내에 존재하는 운동 기록의 개수를 정확히 반환한다")
+        void should_returnCorrectCount_when_exercisesExistWithinRange() {
+            // given: 테스트를 위한 회원과 최근 7일 내 3개의 운동 기록 생성
+            Member member = createAndSaveMember("user1", "user1@email.com", false);
+            createAndSaveExercise(member, LocalDateTime.now().minusDays(1), false); // 1일 전
+            createAndSaveExercise(member, LocalDateTime.now().minusDays(3), false); // 3일 전
+            createAndSaveExercise(member, LocalDateTime.now().minusDays(6), false); // 6일 전
+            // 범위 밖의 데이터
+            createAndSaveExercise(member, LocalDateTime.now().minusDays(8), false); // 8일 전
+
+            em.flush();
+            em.clear();
+
+            // when: 최근 7일간의 운동 기록 개수를 조회
+            Long exerciseCount = memberRepository.countMemberExerciseInLastDays(member.getMemberId(), 7);
+
+            // then: 3개가 조회되어야 한다
+            assertThat(exerciseCount).isEqualTo(3L);
+        }
+
+        @Test
+        @DisplayName("삭제된 운동 기록은 개수에서 제외한다")
+        void should_excludeDeletedExercises_fromCount() {
+            // given: 테스트를 위한 회원과 삭제된 기록을 포함한 운동 기록 생성
+            Member member = createAndSaveMember("user2", "user2@email.com", false);
+            createAndSaveExercise(member, LocalDateTime.now().minusDays(1), false); // 정상
+            createAndSaveExercise(member, LocalDateTime.now().minusDays(2), true);  // 삭제됨
+            createAndSaveExercise(member, LocalDateTime.now().minusDays(3), false); // 정상
+
+            em.flush();
+            em.clear();
+
+            // when: 최근 7일간의 운동 기록 개수를 조회
+            Long exerciseCount = memberRepository.countMemberExerciseInLastDays(member.getMemberId(), 7);
+
+            // then: 삭제된 기록을 제외한 2개가 조회되어야 한다
+            assertThat(exerciseCount).isEqualTo(2L);
+        }
+
+        @Test
+        @DisplayName("다른 회원의 운동 기록은 개수에 포함하지 않는다")
+        void should_notCountExercises_ofOtherMembers() {
+            // given: 테스트 대상 회원과 다른 회원, 그리고 각자의 운동 기록 생성
+            Member targetMember = createAndSaveMember("targetUser", "target@email.com", false);
+            Member anotherMember = createAndSaveMember("anotherUser", "another@email.com", false);
+
+            createAndSaveExercise(anotherMember, LocalDateTime.now().minusDays(1), false);
+            createAndSaveExercise(targetMember, LocalDateTime.now().minusDays(2), false);
+            createAndSaveExercise(targetMember, LocalDateTime.now().minusDays(3), false);
+
+            em.flush();
+            em.clear();
+
+            // when: targetMember의 최근 7일간 운동 기록 개수를 조회
+            Long exerciseCount = memberRepository.countMemberExerciseInLastDays(targetMember.getMemberId(), 7);
+
+            // then: targetMember의 기록인 2개만 조회되어야 한다
+            assertThat(exerciseCount).isEqualTo(2L);
+        }
+
+        @Test
+        @DisplayName("지정된 기간 내에 운동 기록이 없으면 0을 반환한다")
+        void should_returnZero_when_noExercisesExistWithinRange() {
+            // given: 테스트를 위한 회원과 범위 밖의 운동 기록만 생성
+            Member member = createAndSaveMember("user4", "user4@email.com", false);
+            createAndSaveExercise(member, LocalDateTime.now().minusDays(10), false);
+            createAndSaveExercise(member, LocalDateTime.now().minusDays(15), false);
+
+            em.flush();
+            em.clear();
+
+            // when: 최근 7일간의 운동 기록 개수를 조회
+            Long exerciseCount = memberRepository.countMemberExerciseInLastDays(member.getMemberId(), 7);
+
+            // then: 0이 반환되어야 한다
+            assertThat(exerciseCount).isEqualTo(0L);
+        }
+    }
+
+    @Nested
+    @DisplayName("countMemberExerciseInThisYear 메소드는")
+    class CountMemberExerciseInThisYearTest {
+
+        @Test
+        @DisplayName("올해에 운동한 고유한 날짜의 수를 정확히 반환한다")
+        void should_returnDistinctDayCount_forCurrentYear() {
+            // given: 테스트를 위한 회원과 3일에 걸친 4개의 운동 기록 생성
+            Member member = createAndSaveMember("user5", "user5@email.com", false);
+            LocalDateTime now = LocalDateTime.now();
+            // 오늘 2번
+            createAndSaveExercise(member, now, false);
+            createAndSaveExercise(member, now.minusHours(2), false);
+            // 5일 전 1번
+            createAndSaveExercise(member, now.minusDays(5), false);
+            // 10일 전 1번
+            createAndSaveExercise(member, now.minusDays(10), false);
+            // 작년 데이터 (포함되면 안됨)
+            createAndSaveExercise(member, now.minusYears(1), false);
+
+            em.flush();
+            em.clear();
+
+            // when: 올해 운동한 일수를 조회
+            Long exerciseDays = memberRepository.countMemberExerciseInThisYear(member.getMemberId());
+
+            // then: 오늘, 5일 전, 10일 전. 총 3일이 조회되어야 한다
+            assertThat(exerciseDays).isEqualTo(3L);
+        }
+
+        @Test
+        @DisplayName("삭제된 운동 기록이 있는 날은, 다른 기록이 없다면 일수에서 제외한다")
+        void should_excludeDay_ifAllExercisesOnThatDayAreDeleted() {
+            // given
+            Member member = createAndSaveMember("user6", "user6@email.com", false);
+            LocalDateTime now = LocalDateTime.now();
+            // 오늘 1번 (정상)
+            createAndSaveExercise(member, now, false);
+            // 어제 2번 (모두 삭제)
+            createAndSaveExercise(member, now.minusDays(1), true);
+            createAndSaveExercise(member, now.minusDays(1).minusHours(1), true);
+
+            em.flush();
+            em.clear();
+
+            // when: 올해 운동한 일수를 조회
+            Long exerciseDays = memberRepository.countMemberExerciseInThisYear(member.getMemberId());
+
+            // then: 어제는 모두 삭제되었으므로, 오늘 하루만 카운트되어 1일이 조회되어야 한다
+            assertThat(exerciseDays).isEqualTo(1L);
+        }
+
+        @Test
+        @DisplayName("올해에 운동 기록이 없으면 0을 반환한다")
+        void should_returnZero_when_noExercisesInCurrentYear() {
+            // given: 테스트를 위한 회원과 작년 데이터만 생성
+            Member member = createAndSaveMember("user7", "user7@email.com", false);
+            createAndSaveExercise(member, LocalDateTime.now().minusYears(1), false);
+            createAndSaveExercise(member, LocalDateTime.now().minusYears(2), false);
+
+            em.flush();
+            em.clear();
+
+            // when: 올해 운동한 일수를 조회
+            Long exerciseDays = memberRepository.countMemberExerciseInThisYear(member.getMemberId());
+
+            // then: 0이 반환되어야 한다
+            assertThat(exerciseDays).isEqualTo(0L);
         }
     }
 }

--- a/src/test/java/com/project200/undabang/member/service/impl/MemberQueryServiceImplTest.java
+++ b/src/test/java/com/project200/undabang/member/service/impl/MemberQueryServiceImplTest.java
@@ -324,5 +324,55 @@ class MemberQueryServiceImplTest {
                         .hasFieldOrPropertyWithValue("errorCode", ErrorCode.MEMBER_NOT_FOUND);
             }
         }
+
+        @Test
+        @DisplayName("운동 기록 횟수가 정확히 포함된 프로필 정보를 반환한다")
+        void getMemberProfile_withExerciseCounts_Success() {
+            // given: 테스트에 필요한 mock 데이터 설정
+            UUID testUserId = UUID.randomUUID();
+            Member mockMember = createMember();
+            // Mocking할 때 일관성을 유지하기 위해 Member의 ID를 testUserId로 설정합니다.
+            ReflectionTestUtils.setField(mockMember, "memberId", testUserId);
+
+            // Repository 메서드들이 반환할 값들을 미리 정의합니다.
+            long expectedYearlyCount = 15L;
+            long expectedMonthlyCount = 5L;
+
+            try (MockedStatic<UserContextHolder> ignored = BDDMockito.mockStatic(UserContextHolder.class)) {
+                // 1. UserContextHolder가 testUserId를 반환하도록 설정
+                BDDMockito.given(UserContextHolder.getUserId()).willReturn(testUserId);
+
+                // 2. 기본 프로필 조회 시 mockMember를 반환하도록 설정
+                BDDMockito.given(memberRepository.findMemberProfileByMemberIdAndMemberDeletedAtNull(testUserId))
+                        .willReturn(Optional.of(mockMember));
+
+                // 3. 올해 운동 일수 조회 시 expectedYearlyCount를 반환하도록 설정
+                BDDMockito.given(memberRepository.countMemberExerciseInThisYear(testUserId))
+                        .willReturn(expectedYearlyCount);
+
+                // 4. 최근 30일 운동 횟수 조회 시 expectedMonthlyCount를 반환하도록 설정
+                BDDMockito.given(memberRepository.countMemberExerciseInLastDays(testUserId, 30))
+                        .willReturn(expectedMonthlyCount);
+
+                // when: 실제 서비스 메서드 호출
+                MemberProfileResponse response = memberQueryService.getMemberProfile();
+
+                // then: 반환된 DTO의 값이 우리가 Mocking한 값과 일치하는지 검증
+                assertSoftly(softly -> {
+                    softly.assertThat(response).isNotNull();
+                    softly.assertThat(response.getNickname()).isEqualTo("테스트유저"); // 기본 정보 확인
+                    softly.assertThat(response.getExerciseScore()).isEqualTo(50); // 기본 정보 확인
+
+                    // 핵심 검증: 운동 기록 횟수가 정확히 매핑되었는지 확인
+                    softly.assertThat(response.getYearlyExerciseDays()).isEqualTo((int) expectedYearlyCount);
+                    softly.assertThat(response.getExerciseCountInLast30Days()).isEqualTo((int) expectedMonthlyCount);
+                });
+
+                // then: Repository의 메서드들이 정확히 1번씩 호출되었는지 검증 (Verify)
+                then(memberRepository).should(times(1)).findMemberProfileByMemberIdAndMemberDeletedAtNull(testUserId);
+                then(memberRepository).should(times(1)).countMemberExerciseInThisYear(testUserId);
+                then(memberRepository).should(times(1)).countMemberExerciseInLastDays(testUserId, 30);
+            }
+        }
     }
 }


### PR DESCRIPTION
## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

이전 승규님께서 개발하신 코드에 

커밋 **7b29c9c** 를 통해 기능 개발을 완료하였습니다.
커밋 **529b3bf** 을 통해 최근 30일간 누적 운동 횟수 로직을 수정하였습니다.

- 최근 30일간 누적 운동 횟수 
    - 파라미터를 통해 삭제하지 않은 N일간의 누적 운동 횟수를 반환하도록 구현하였습니다. 
    - 기간은 N(현재는 30)일전 00:00:00 ~ 오늘 23:59:59 까지입니다. (정확히는 내일 00:00:00 미만)
- 올해 운동 일수
    - 올해 1월 1일 00:00:00 부터 "오늘" 23:59:59 까지의 운동 기록이 있는 날짜를 countDistinct 하도록 구현하였습니다. (정확히는 내일 00:00:00 미만)
    
데이터를 같이 반환하도록 기능을 추가하였습니다. 
테스트코드도 추가하였습니다.

**API 명세서는 이전과 내용이 같아서 추가하지 않았습니다.**

### 스크린샷 (선택)
**API 응답 사진입니다.**
- **운동을 2일에 걸쳐서 (첫째날 1회, 둘째날 3회) 한 경우의 응답사진입니다.**
<img width="883" height="405" alt="image" src="https://github.com/user-attachments/assets/0ea264d0-f36c-45b0-8cad-cb9b5199db75" />


**테스트코드 사진입니다**
<img width="717" height="206" alt="image" src="https://github.com/user-attachments/assets/4b31154c-78d1-485d-823a-6ebfd789cbd5" />

## 💬리뷰 요구사항(선택)

* 이전 PR에 추가하긴 하였지만, 혹시 몰라서 
* 회원 운동 점수 API 명세서를 수정하였습니다.
* 빌드 버전을 0.3.2로 유지하였습니다.

## #️⃣연관된 이슈

> ex) Closes #261 