### PR TITLE
[Feat] 닉네임 중복 검사 기능 개발

### DIFF
--- a/src/docs/asciidoc/auth/닉네임-중복-검사-API.adoc
+++ b/src/docs/asciidoc/auth/닉네임-중복-검사-API.adoc
@@ -1,0 +1,34 @@
+== 닉네임 중복 검사 API
+
+=== 설명
+
+- #GET# `/open/v1/nicknames/check?nickname={nickname}`
+- 중복 닉네임을 검사하는 API입니다.
+- 이 API는 입력받은 닉네임에 대해 다른 회원이 사용중인 닉네임인지 여부를 반환합니다. +
+만약 사용중이지 않은 닉네임이라면 `true` 를 반환하고, 사용중이라면 `false` 를 반환 합니다.
+
+=== 개발 이력
+
+- Sprint 11 (2025-09-06): 기능 개발이 완료되었습니다.
+
+=== 개발 참고 사항
+
+- <<공통-개발-참고-사항,공통 개발 참고 사항>>을 참고하세요.
+
+=== 코드 샘플
+
+operation::check-nickname-duplicate/check-nickname_-available_-success[snippets="curl-request,http-request,http-response"]
+
+=== 매개 변수
+
+operation::check-nickname-duplicate/check-nickname_-available_-success[snippets="query-parameters,response-fields"]
+
+==== 응답 상태 코드
+
+|===
+|상태 코드|설명
+|200|요청이 성공적으로 처리되었습니다. +
+회원이 입력한 닉네임의 사용 여부를 반환합니다.
+|400|입력값 검증에 실패했습니다.
+|===
+

--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -101,6 +101,8 @@ include::overview/공통-개발-참고-사항.adoc[]
 
 - 로그아웃 API #POST# `/api/v1/logout`
 
+- 닉네임 중복검사 API #GET# `/open/v1/nicknames/check?nickname={nickname}`
+
 === xref:회원-API.html[회원 API]
 
 - 회원 운동 점수 조회 API #GET# `/api/v1/members/score`

--- a/src/docs/asciidoc/member/회원-점수-조회-API.adoc
+++ b/src/docs/asciidoc/member/회원-점수-조회-API.adoc
@@ -15,10 +15,12 @@
 - <<공통-개발-참고-사항,공통 개발 참고 사항>>을 참고하세요.
 
 === 코드 샘플
-operation::member-rest-controller-test/get-member-score_success[snippets="curl-request,http-request,http-response"]
+
+operation::get-member-score/get-member-score_success[snippets="curl-request,http-request,http-response"]
 
 === 매개 변수
-operation::member-rest-controller-test/get-member-score_success[snippets="request-headers,response-fields"]
+
+operation::get-member-score/get-member-score_success[snippets="request-headers,response-fields"]
 
 ==== 응답 상태 코드
 |===

--- a/src/docs/asciidoc/인증-API.adoc
+++ b/src/docs/asciidoc/인증-API.adoc
@@ -25,3 +25,5 @@ include::auth/회원-등록-상태-조회-API.adoc[]
 include::auth/로그인-API.adoc[]
 
 include::auth/로그아웃-API.adoc[]
+
+include::auth/닉네임-중복-검사-API.adoc[]

--- a/src/main/java/com/project200/undabang/member/controller/PublicMemberQueryController.java
+++ b/src/main/java/com/project200/undabang/member/controller/PublicMemberQueryController.java
@@ -1,0 +1,33 @@
+package com.project200.undabang.member.controller;
+
+import com.project200.undabang.common.web.response.CommonResponse;
+import com.project200.undabang.member.dto.response.CheckNicknameDuplicateResponse;
+import com.project200.undabang.member.service.MemberQueryService;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/open")
+public class PublicMemberQueryController {
+    private final MemberQueryService memberQueryService;
+
+
+    @GetMapping("/v1/nicknames/check")
+    public ResponseEntity<CommonResponse<CheckNicknameDuplicateResponse>> checkDuplicateNickname(
+            @RequestParam
+            @NotBlank(message = "닉네임을 설정해주세요")
+            @Size(min = 1, max = 30, message = "닉네임은 30자 이내로 설정해주세요")
+            @Pattern(regexp = "^[가-힣a-zA-Z0-9]{1,30}$", message = "닉네임은 한글, 영문, 숫자만 사용 가능합니다")
+            String nickname) {
+
+        return ResponseEntity.ok(CommonResponse.success(memberQueryService.checkDuplicateNickname(nickname)));
+    }
+}

--- a/src/main/java/com/project200/undabang/member/dto/response/CheckNicknameDuplicateResponse.java
+++ b/src/main/java/com/project200/undabang/member/dto/response/CheckNicknameDuplicateResponse.java
@@ -1,0 +1,16 @@
+package com.project200.undabang.member.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class CheckNicknameDuplicateResponse {
+    private boolean available;
+
+    public static CheckNicknameDuplicateResponse of(boolean available) {
+        return new CheckNicknameDuplicateResponse(available);
+    }
+}

--- a/src/main/java/com/project200/undabang/member/service/MemberQueryService.java
+++ b/src/main/java/com/project200/undabang/member/service/MemberQueryService.java
@@ -1,5 +1,6 @@
 package com.project200.undabang.member.service;
 
+import com.project200.undabang.member.dto.response.CheckNicknameDuplicateResponse;
 import com.project200.undabang.member.dto.response.MemberProfileResponse;
 import com.project200.undabang.member.dto.response.MemberRegistrationStatusResponseDto;
 import com.project200.undabang.member.dto.response.MemberScoreResponseDto;
@@ -14,4 +15,6 @@ public interface MemberQueryService {
      * @return 회원 프로필 정보를 담고 있는 MemberProfileResponse 객체
      */
     MemberProfileResponse getMemberProfile();
+
+    CheckNicknameDuplicateResponse checkDuplicateNickname(String nickname);
 }

--- a/src/main/java/com/project200/undabang/member/service/impl/MemberQueryServiceImpl.java
+++ b/src/main/java/com/project200/undabang/member/service/impl/MemberQueryServiceImpl.java
@@ -3,6 +3,7 @@ package com.project200.undabang.member.service.impl;
 import com.project200.undabang.common.context.UserContextHolder;
 import com.project200.undabang.common.web.exception.CustomException;
 import com.project200.undabang.common.web.exception.ErrorCode;
+import com.project200.undabang.member.dto.response.CheckNicknameDuplicateResponse;
 import com.project200.undabang.member.dto.response.MemberProfileResponse;
 import com.project200.undabang.member.dto.response.MemberRegistrationStatusResponseDto;
 import com.project200.undabang.member.dto.response.MemberScoreResponseDto;
@@ -26,6 +27,11 @@ public class MemberQueryServiceImpl implements MemberQueryService {
 
     private final PolicyService policyService;
 
+    /**
+     * 현재 사용자가 시스템에 등록되어 있는지의 여부를 확인합니다.
+     *
+     * @return MemberRegistrationStatusResponseDto 객체로, 사용자의 회원 ID와 등록 여부를 포함합니다.
+     */
     @Override
     public MemberRegistrationStatusResponseDto getRegistrationStatus() {
         UUID userId = UserContextHolder.getUserId();
@@ -39,6 +45,12 @@ public class MemberQueryServiceImpl implements MemberQueryService {
 
     }
 
+    /**
+     * 현재 사용자의 멤버 점수를 조회합니다.
+     * 점수는 정책에서 정의된 최대 점수 및 최소 점수와 함께 반환됩니다.
+     *
+     * @return MemberScoreResponseDto 객체로, 멤버 ID, 현재 점수, 정책 기준 최대 점수, 정책 기준 최소 점수를 포함합니다.
+     */
     @Override
     public MemberScoreResponseDto getMemberScore() {
         Member member = findMemberById();
@@ -53,16 +65,36 @@ public class MemberQueryServiceImpl implements MemberQueryService {
                 .build();
     }
 
-    private Member findMemberById(){
-        return memberRepository.findByMemberIdAndMemberDeletedAtNull(UserContextHolder.getUserId())
-                .orElseThrow(() -> new CustomException(ErrorCode.MEMBER_NOT_FOUND));
-    }
-
+    /**
+     * 현재 사용자와 관련된 멤버 프로필 정보를 조회합니다.
+     * 삭제된 멤버는 조회 대상에서 제외되며, 해당 사용자의 프로필 정보가 존재하지 않을 경우 예외가 발생합니다.
+     *
+     * @return MemberProfileResponse 객체로, 현재 사용자와 연결된 멤버의 프로필 정보를 포함합니다.
+     */
     @Override
     public MemberProfileResponse getMemberProfile() {
         Member member = memberRepository.findMemberProfileByMemberIdAndMemberDeletedAtNull(UserContextHolder.getUserId())
                 .orElseThrow(() -> new CustomException(ErrorCode.MEMBER_NOT_FOUND));
 
         return MemberProfileResponse.of(member, 0, 0);
+    }
+
+    /**
+     * 주어진 닉네임이 시스템에서 이미 사용 중인지 확인합니다.
+     */
+    @Override
+    public CheckNicknameDuplicateResponse checkDuplicateNickname(String nickname) {
+
+        return CheckNicknameDuplicateResponse.of(!memberRepository.existsByMemberNickname(nickname));
+    }
+
+
+    /**
+     * 주어진 사용자 ID를 기반으로 멤버 정보를 조회합니다.
+     * 삭제된 멤버는 조회 대상에서 제외되며, 조회 결과가 없을 경우 예외가 발생합니다.
+     */
+    private Member findMemberById() {
+        return memberRepository.findByMemberIdAndMemberDeletedAtNull(UserContextHolder.getUserId())
+                .orElseThrow(() -> new CustomException(ErrorCode.MEMBER_NOT_FOUND));
     }
 }

--- a/src/test/java/com/project200/undabang/member/controller/PublicMemberQueryControllerTest.java
+++ b/src/test/java/com/project200/undabang/member/controller/PublicMemberQueryControllerTest.java
@@ -1,0 +1,143 @@
+package com.project200.undabang.member.controller;
+
+import com.project200.undabang.common.web.response.CommonResponse;
+import com.project200.undabang.configuration.AbstractRestDocSupport;
+import com.project200.undabang.member.dto.response.CheckNicknameDuplicateResponse;
+import com.project200.undabang.member.service.MemberQueryService;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.mockito.BDDMockito;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.http.MediaType;
+import org.springframework.restdocs.payload.JsonFieldType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+
+import static com.project200.undabang.configuration.DocumentFormatGenerator.getTypeFormat;
+import static com.project200.undabang.configuration.RestDocsUtils.commonResponseFields;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
+import static org.springframework.restdocs.request.RequestDocumentation.queryParameters;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(PublicMemberQueryController.class)
+@DisplayName("PublicMemberQueryController 테스트")
+class PublicMemberQueryControllerTest extends AbstractRestDocSupport {
+
+    @MockitoBean
+    private MemberQueryService memberQueryService;
+
+    @Nested
+    @DisplayName("닉네임 중복 검사 API")
+    class CheckNicknameDuplicate {
+
+        @Test
+        @DisplayName("성공 - 사용 가능한 닉네임으로 요청 시 200 OK와 available true를 반환하고 API 문서를 생성한다")
+        void checkNickname_Available_Success() throws Exception {
+            // given
+            String nickname = "availableNickname123";
+            CheckNicknameDuplicateResponse responseDto = CheckNicknameDuplicateResponse.of(true);
+            BDDMockito.given(memberQueryService.checkDuplicateNickname(nickname)).willReturn(responseDto);
+
+            // when & then
+            mockMvc.perform(MockMvcRequestBuilders.get("/open/v1/nicknames/check")
+                            .param("nickname", nickname)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .accept(MediaType.APPLICATION_JSON)
+                    )
+                    .andExpect(status().isOk())
+                    .andDo(document.document(
+                            queryParameters(
+                                    parameterWithName("nickname").attributes(getTypeFormat(JsonFieldType.STRING))
+                                            .description("중복 검사를 위해 사용자가 입력한 닉네임입니다. 1~30자의 영문,숫자,한글로 이루어진 문자열이어야 합니다.")
+                            ),
+                            responseFields(commonResponseFields(
+                                    fieldWithPath("data.available").type(JsonFieldType.BOOLEAN).description("요청받은 닉네임의 사용 가능 여부를 나타냅니다.")
+                            ))
+                    ));
+        }
+
+        @Test
+        @DisplayName("실패하는 경우 - 이미 사용 중인 닉네임으로 요청 시 200 OK와 available false를 반환한다")
+        void checkNickname_Duplicated_ReturnsOkWithFalse() throws Exception {
+            // given
+            String nickname = "existingUser";
+            CheckNicknameDuplicateResponse responseDto = CheckNicknameDuplicateResponse.of(false);
+            BDDMockito.given(memberQueryService.checkDuplicateNickname(nickname)).willReturn(responseDto);
+
+            // when
+            String response = mockMvc.perform(MockMvcRequestBuilders.get("/open/v1/nicknames/check")
+                            .param("nickname", nickname)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .accept(MediaType.APPLICATION_JSON)
+                    )
+                    .andExpect(status().isOk())
+                    .andReturn().getResponse().getContentAsString();
+
+            // then
+            CommonResponse<CheckNicknameDuplicateResponse> expectedData = CommonResponse.success(responseDto);
+            String expected = objectMapper.writeValueAsString(expectedData);
+            Assertions.assertThat(response).as("응답 본문 검증").isEqualTo(expected);
+        }
+
+
+        @Test
+        @DisplayName("닉네임이 비어있을 경우(@NotBlank) 400 Bad Request를 반환한다")
+        void checkNickname_Failed_BlankNickname() throws Exception {
+            // given
+            String blankNickname = " ";
+
+            // when & then
+            mockMvc.perform(MockMvcRequestBuilders.get("/open/v1/nicknames/check")
+                            .param("nickname", blankNickname)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .accept(MediaType.APPLICATION_JSON)
+                    )
+                    .andExpect(status().isBadRequest())
+                    .andDo(print());
+
+            BDDMockito.then(memberQueryService).should(BDDMockito.never()).checkDuplicateNickname(BDDMockito.anyString());
+        }
+
+
+        @Test
+        @DisplayName("닉네임 길이가 유효하지 않을 경우(@Size) 400 Bad Request를 반환한다")
+        void checkNickname_Failed_InvalidLength() throws Exception {
+            // given
+            String longNickname = "a".repeat(31);
+
+            // when & then
+            mockMvc.perform(MockMvcRequestBuilders.get("/open/v1/nicknames/check")
+                            .param("nickname", longNickname)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .accept(MediaType.APPLICATION_JSON)
+                    )
+                    .andExpect(status().isBadRequest())
+                    .andDo(print());
+
+            BDDMockito.then(memberQueryService).should(BDDMockito.never()).checkDuplicateNickname(BDDMockito.anyString());
+        }
+
+        @Test
+        @DisplayName("닉네임 형식이 유효하지 않을 경우(@Pattern) 400 Bad Request를 반환한다")
+        void checkNickname_Failed_InvalidPattern() throws Exception {
+            // given
+            String invalidNickname = "invalid-nickname!";
+
+            // when & then
+            mockMvc.perform(MockMvcRequestBuilders.get("/open/v1/nicknames/check")
+                            .param("nickname", invalidNickname)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .accept(MediaType.APPLICATION_JSON)
+                    )
+                    .andExpect(status().isBadRequest())
+                    .andDo(print());
+
+            BDDMockito.then(memberQueryService).should(BDDMockito.never()).checkDuplicateNickname(BDDMockito.anyString());
+        }
+    }
+}

--- a/src/test/java/com/project200/undabang/member/service/impl/MemberQueryServiceImplTest.java
+++ b/src/test/java/com/project200/undabang/member/service/impl/MemberQueryServiceImplTest.java
@@ -5,6 +5,7 @@ import com.project200.undabang.common.entity.Picture;
 import com.project200.undabang.common.web.exception.CustomException;
 import com.project200.undabang.common.web.exception.ErrorCode;
 import com.project200.undabang.exercise.entity.ExerciseType;
+import com.project200.undabang.member.dto.response.CheckNicknameDuplicateResponse;
 import com.project200.undabang.member.dto.response.MemberProfileResponse;
 import com.project200.undabang.member.dto.response.MemberRegistrationStatusResponseDto;
 import com.project200.undabang.member.dto.response.MemberScoreResponseDto;
@@ -323,6 +324,42 @@ class MemberQueryServiceImplTest {
                         .isInstanceOf(CustomException.class)
                         .hasFieldOrPropertyWithValue("errorCode", ErrorCode.MEMBER_NOT_FOUND);
             }
+        }
+    }
+
+
+    @Nested
+    @DisplayName("닉네임 중복 검사")
+    class CheckDuplicateNickname {
+
+        @Test
+        @DisplayName("이미 존재하는 닉네임일 경우 available false를 반환한다")
+        void checkDuplicateNickname_ExistingNickname_ReturnsFalse() {
+            // given
+            String existingNickname = "이미존재하는닉네임";
+            given(memberRepository.existsByMemberNickname(existingNickname)).willReturn(true);
+
+            // when
+            CheckNicknameDuplicateResponse response = memberQueryService.checkDuplicateNickname(existingNickname);
+
+            // then
+            assertThat(response.isAvailable()).isFalse();
+            then(memberRepository).should().existsByMemberNickname(existingNickname);
+        }
+
+        @Test
+        @DisplayName("사용 가능한 닉네임일 경우 available true를 반환한다")
+        void checkDuplicateNickname_AvailableNickname_ReturnsTrue() {
+            // given
+            String availableNickname = "새로운닉네임";
+            given(memberRepository.existsByMemberNickname(availableNickname)).willReturn(false);
+
+            // when
+            CheckNicknameDuplicateResponse response = memberQueryService.checkDuplicateNickname(availableNickname);
+
+            // then
+            assertThat(response.isAvailable()).isTrue();
+            then(memberRepository).should().existsByMemberNickname(availableNickname);
         }
     }
 }


### PR DESCRIPTION
## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

닉네임 중복 검사 기능을 개발하였습니다.

이 기능은 회원이 회원가입 하기 전 닉네임 중복검사 시에도 사용되어야 하므로 API 를 **"/open"** 으로 개발하였습니다.

테스트케이스는 이전과 마찬가지로 100%를 유지하였습니다.

쿼리 파라미터로 한글을 입력받을 시, 인코딩 문제가 있을 수 있다는 글을 보았습니다.
하지만 로컬에서 동작시 문제 없음을 확인하였습니다. 
(명세서에서는 한글 넣을시 퍼센트 인코딩이 되어서 영어로 테스트 닉네임을 작성하였습니다.)

### 스크린샷 (선택)
API 응답 사진입니다.
<img width="1563" height="745" alt="image" src="https://github.com/user-attachments/assets/9a0c5fb6-98a7-438a-9fae-8f4b7dccb76a" />


API 명세서 사진입니다.
<img width="682" height="309" alt="image" src="https://github.com/user-attachments/assets/1721c5a5-ef58-4d43-802e-cecbee2b7b10" />
<img width="997" height="717" alt="image" src="https://github.com/user-attachments/assets/b90f72af-6a10-44f1-a9ff-82f8787a45b7" />
<img width="999" height="793" alt="image" src="https://github.com/user-attachments/assets/4089dd41-67ab-4434-9c34-c7279ffea8c5" />
<img width="1007" height="827" alt="image" src="https://github.com/user-attachments/assets/2fe3316e-0e42-4049-85f3-2ac4e396d456" />
<img width="1006" height="261" alt="image" src="https://github.com/user-attachments/assets/1b699b93-b537-415b-8d39-d404a8674842" />


테스트 케이스 입니다.
<img width="713" height="191" alt="image" src="https://github.com/user-attachments/assets/f707ae87-ad60-405b-8346-d55ee199ee03" />



## #️⃣연관된 이슈

> ex) Closes #289 