### PR TITLE
[Feat] 프로필 사진 삭제기능 개발 [0.3.5] -> [0.3.6]

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ plugins {
 }
 
 group = 'com.project200'
-version = '0.3.5-SNAPSHOT'
+version = '0.3.6-SNAPSHOT'
 
 java {
     toolchain {

--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -173,3 +173,5 @@ include::overview/공통-개발-참고-사항.adoc[]
 - 프로필 사진 조회 API #GET# `/api/v1/profile-pictures`
 
 - 프로필 사진 생성 API #POST# `/api/v1/profile-pictures`
+
+- 프로필 사진 삭제 API #DELETE# `/api/v1/profile-pictures/{profileId}`

--- a/src/docs/asciidoc/profile-picture/프로필-사진-삭제-API.adoc
+++ b/src/docs/asciidoc/profile-picture/프로필-사진-삭제-API.adoc
@@ -1,0 +1,34 @@
+== 프로필 사진 삭제 API
+
+=== 설명
+
+- #DELETE# `/api/v1/profile-pictures/{pictureId}`
+- 마이페이지에서 프로필 사진 및 썸네일을 삭제하는 API 입니다.
+
+=== 개발 이력
+
+- Sprint 11 (2025-09-12): 기능 개발을 완료하였습니다.
+
+=== 개발 참고 사항
+
+- <<공통-개발-참고-사항,공통 개발 참고 사항>>을 참고하세요.
+
+=== 코드 샘플
+
+operation::delete-profile-picture/delete-profile-picture_-success[snippets="curl-request,http-request,http-response"]
+
+=== 매개 변수
+
+operation::delete-profile-picture/delete-profile-picture_-success[snippets="request-headers,path-parameters,response-fields"]
+
+==== 응답 상태 코드
+
+|===
+|상태 코드|설명
+|200|리소스가 성공적으로 삭제되었습니다.
+|403|접근 권한이 없습니다.
+|404|존재하지 않는 회원입니다. +
+존재하지 않는 사진입니다.
+|500|이미지 업로드에 실패하였습니다. +
+이미지 삭제에 실패했습니다. +
+|===

--- a/src/docs/asciidoc/프로필-사진-API.adoc
+++ b/src/docs/asciidoc/프로필-사진-API.adoc
@@ -22,3 +22,5 @@ include::overview/공통-개발-참고-사항.adoc[]
 include::profile-picture/프로필-사진-조회-API.adoc[]
 
 include::profile-picture/프로필-사진-생성-API.adoc[]
+
+include::profile-picture/프로필-사진-삭제-API.adoc[]

--- a/src/main/java/com/project200/undabang/common/service/PictureService.java
+++ b/src/main/java/com/project200/undabang/common/service/PictureService.java
@@ -151,6 +151,18 @@ public class PictureService {
     }
 
     /**
+     * 단일 Picture 엔티티를 기반으로 S3에서 이미지를 삭제하고,
+     * 데이터베이스에서 해당 데이터를 논리적으로 삭제(soft delete)합니다.
+     * 내부적으로 리스트 처리 메소드를 재사용합니다.
+     *
+     * @param picture 삭제할 Picture 엔티티
+     */
+    @Transactional
+    public void deletePictureFromS3AndDB(@NotNull Picture picture) {
+        this.deletePictureFromS3AndDB(List.of(picture));
+    }
+
+    /**
      * 주어진 Picture 리스트를 기반으로 S3에서 이미지를 삭제하고,
      * 데이터베이스에 해당 데이터를 논리적으로 삭제(soft delete)합니다.
      * 예외 상황 발생 시 S3 삭제나 DB 처리의 롤백을 수행합니다.

--- a/src/main/java/com/project200/undabang/common/service/S3Service.java
+++ b/src/main/java/com/project200/undabang/common/service/S3Service.java
@@ -173,11 +173,21 @@ public class S3Service {
     }
 
     /**
-     * 주어진 S3 객체를 "휴지통" 디렉터리로 이동시키는 메서드입니다.
+     * 주어진 S3 객체를 휴지통 경로로 이동합니다.
+     * 원본 객체를 휴지통 경로로 복사한 후, 원본 객체를 삭제합니다.
+     *
+     * @param objectKey 이동하려는 S3 객체의 고유 키. null이거나 비어있는 값은 허용되지 않습니다.
+     * @throws S3UploadFailedException S3 객체 복사 또는 삭제 작업 중 실패가 발생한 경우 예외를 던집니다.
      */
     public void moveImageToTrash(String objectKey) throws S3UploadFailedException {
         if (objectKey == null || objectKey.isBlank()) {
             log.warn("moveToTrash: objectKey가 null이거나 비어있습니다.");
+            return;
+        }
+
+        // DB에는 데이터가 있는데 S3에 객체가 없을경우 체크
+        if (!isFileExists(objectKey)) {
+            log.warn("휴지통으로 이동할 원본 S3 객체가 존재하지 않습니다. Key: {}", objectKey);
             return;
         }
 

--- a/src/main/java/com/project200/undabang/member/controller/MemberPictureCommandController.java
+++ b/src/main/java/com/project200/undabang/member/controller/MemberPictureCommandController.java
@@ -35,9 +35,17 @@ public class MemberPictureCommandController {
         return ResponseEntity.status(HttpStatus.CREATED).body(CommonResponse.create(memberPictureCommandService.createProfilePicture(profilePicture)));
     }
 
+    /**
+     * 사용자의 프로필 사진을 삭제합니다.
+     *
+     * @param pictureId 삭제할 프로필 사진의 고유 ID
+     * @return 삭제 결과를 포함하는 ResponseEntity 객체를 반환합니다.
+     * 반환 데이터는 CommonResponse<Void> 형태입니다.
+     */
     @DeleteMapping("/v1/profile-pictures/{pictureId}")
     public ResponseEntity<CommonResponse<Void>> deleteProfilePicture(@PathVariable Long pictureId) {
 
+        memberPictureCommandService.deleteProfilePicture(pictureId);
         return ResponseEntity.ok(CommonResponse.delete(null));
     }
 

--- a/src/main/java/com/project200/undabang/member/entity/MemberPicture.java
+++ b/src/main/java/com/project200/undabang/member/entity/MemberPicture.java
@@ -61,4 +61,12 @@ public class MemberPicture {
                 .memberPicturesCreatedAt(LocalDateTime.now())
                 .build();
     }
+
+    /**
+     * 회원 사진이 삭제된 시간(memberPicturesDeletedAt)을 현재 시간으로 설정합니다.
+     * 이를 통해 회원 사진이 삭제되었음을 나타냅니다.
+     */
+    public void deleteMemberPicture() {
+        this.memberPicturesDeletedAt = LocalDateTime.now();
+    }
 }

--- a/src/main/java/com/project200/undabang/member/repository/MemberPictureRepository.java
+++ b/src/main/java/com/project200/undabang/member/repository/MemberPictureRepository.java
@@ -14,4 +14,6 @@ public interface MemberPictureRepository extends JpaRepository<MemberPicture, Lo
     List<MemberPicture> findByMemberAndPicture_PictureDeletedAtNull(Member member);
 
     Optional<MemberPicture> findByMemberAndPicture_IdAndPicture_PictureDeletedAtNull(Member member, Long id);
+
+    Optional<MemberPicture> findFirstByMemberAndMemberPicturesDeletedAtNullAndPicture_PictureDeletedAtNullOrderByPicture_PictureCreatedAtDesc(Member member);
 }

--- a/src/main/java/com/project200/undabang/member/service/MemberPictureCommandService.java
+++ b/src/main/java/com/project200/undabang/member/service/MemberPictureCommandService.java
@@ -6,6 +6,7 @@ import org.springframework.web.multipart.MultipartFile;
 
 public interface MemberPictureCommandService {
     CreateProfilePictureResponse createProfilePicture(MultipartFile profilePicture);
-
     UpdateProfilePictureResponse updateRepresentativeProfileImage(Long pictureId);
+
+    void deleteProfilePicture(Long pictureId);
 }

--- a/src/main/java/com/project200/undabang/member/service/impl/MemberPictureCommandServiceImpl.java
+++ b/src/main/java/com/project200/undabang/member/service/impl/MemberPictureCommandServiceImpl.java
@@ -102,11 +102,11 @@ public class MemberPictureCommandServiceImpl implements MemberPictureCommandServ
                 .orElseThrow(() -> new CustomException(ErrorCode.AUTHORIZATION_DENIED));
 
         // 썸네일 사진, 프로필 사진 논리적 삭제 및 S3에 저장된 프로필 사진 삭제
-        memberPicture.deleteMemberPicture();
         pictureService.deletePictureFromS3AndDB(picture);
+        memberPicture.deleteMemberPicture();
 
         // 만약 회원의 fk 를 지우는 경우, 가장 최근에 생성된 사진 데이터를 넣어주고 그렇지 않으면 null 을 넣어줘야 함
-        if (Objects.equals(member.getMemberPicture(), memberPicture)) {
+        if (member.getMemberPicture() != null && Objects.equals(member.getMemberPicture().getId(), memberPicture.getId())) {
             memberPictureRepository.findFirstByMemberAndMemberPicturesDeletedAtNullAndPicture_PictureDeletedAtNullOrderByPicture_PictureCreatedAtDesc(member)
                     .ifPresentOrElse(
                             member::updateProfilePicture,

--- a/src/main/java/com/project200/undabang/member/service/impl/MemberPictureCommandServiceImpl.java
+++ b/src/main/java/com/project200/undabang/member/service/impl/MemberPictureCommandServiceImpl.java
@@ -105,7 +105,7 @@ public class MemberPictureCommandServiceImpl implements MemberPictureCommandServ
         pictureService.deletePictureFromS3AndDB(picture);
         memberPicture.deleteMemberPicture();
 
-        // 만약 회원의 fk 를 지우는 경우, 가장 최근에 생성된 사진 데이터를 넣어주고 그렇지 않으면 null 을 넣어줘야 함
+        // 회원 테이블의 대표사진을 제거합니다. 그 후, 가장 최근에 생성된 사진 데이터를 넣어주고 그렇지 않으면 null 을 넣어줘야 합니다.
         if (member.getMemberPicture() != null && Objects.equals(member.getMemberPicture().getId(), memberPicture.getId())) {
             memberPictureRepository.findFirstByMemberAndMemberPicturesDeletedAtNullAndPicture_PictureDeletedAtNullOrderByPicture_PictureCreatedAtDesc(member)
                     .ifPresentOrElse(

--- a/src/main/java/com/project200/undabang/member/service/impl/MemberPictureCommandServiceImpl.java
+++ b/src/main/java/com/project200/undabang/member/service/impl/MemberPictureCommandServiceImpl.java
@@ -21,6 +21,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
+import java.util.Objects;
 import java.util.UUID;
 
 @Slf4j
@@ -81,6 +82,39 @@ public class MemberPictureCommandServiceImpl implements MemberPictureCommandServ
         member.updateProfilePicture(memberPicture);
 
         return UpdateProfilePictureResponse.from(member);
+    }
+
+    /**
+     * 주어진 사진 ID에 해당하는 프로필 사진을 삭제합니다.
+     * 사진이 존재하지 않거나 사용 권한이 없는 경우 예외가 발생합니다.
+     * 기존 대표 프로필 사진을 삭제한 경우, 삭제 후 가장 최신 사진으로 대표 프로필 사진을 갱신하거나 null로 업데이트합니다.
+     *
+     * @param pictureId 삭제할 프로필 사진의 ID
+     * @throws CustomException 사진이 존재하지 않거나 사용 권한이 없는 경우 발생
+     */
+    @Override
+    public void deleteProfilePicture(Long pictureId) {
+        Member member = getMember(UserContextHolder.getUserId());
+
+        Picture picture = pictureRepository.findById(pictureId).orElseThrow(() -> new CustomException(ErrorCode.PICTURE_NOT_FOUND));
+
+        MemberPicture memberPicture = memberPictureRepository.findByMemberAndPicture_IdAndPicture_PictureDeletedAtNull(member, pictureId)
+                .orElseThrow(() -> new CustomException(ErrorCode.AUTHORIZATION_DENIED));
+
+        // 썸네일 사진, 프로필 사진 논리적 삭제 및 S3에 저장된 프로필 사진 삭제
+        memberPicture.deleteMemberPicture();
+        pictureService.deletePictureFromS3AndDB(picture);
+
+        // 만약 회원의 fk 를 지우는 경우, 가장 최근에 생성된 사진 데이터를 넣어주고 그렇지 않으면 null 을 넣어줘야 함
+        if (Objects.equals(member.getMemberPicture(), memberPicture)) {
+            memberPictureRepository.findFirstByMemberAndMemberPicturesDeletedAtNullAndPicture_PictureDeletedAtNullOrderByPicture_PictureCreatedAtDesc(member)
+                    .ifPresentOrElse(
+                            member::updateProfilePicture,
+                            () -> member.updateProfilePicture(null)
+                    );
+        }
+
+        // todo 썸네일 생성 이후 삭제를 진행해야 함 S3에 업로드 및 삭제 과정에 대한 고려 후 개발 진행
     }
 
     /**

--- a/src/test/java/com/project200/undabang/common/service/PictureServiceIntegrationTest.java
+++ b/src/test/java/com/project200/undabang/common/service/PictureServiceIntegrationTest.java
@@ -296,5 +296,28 @@ public class PictureServiceIntegrationTest {
             assertThat(s3Service.isFileExists("trash/uploads/rollback1.jpg")).isFalse();
             assertThat(s3Service.isFileExists("uploads/fail-on-this.png")).isTrue();
         }
+
+        @Test
+        @DisplayName("성공[단일 삭제]: 단일 Picture 객체 삭제 시 S3 파일이 휴지통으로 이동하고 DB가 soft-delete 된다")
+        void delete_SinglePicture_Success_Integration() {
+            // given
+            // 1. DB에 Picture 엔티티 저장
+            Picture pic = pictureRepository.save(Picture.builder().pictureUrl("http://s3.com/uploads/single-delete.gif").build());
+            // 2. LocalStack S3에 실제 파일 업로드
+            s3Service.uploadImage(new MockMultipartFile("f", "single.gif", "image/gif", "c".getBytes()), "uploads/single-delete.gif");
+
+            // when
+            pictureService.deletePictureFromS3AndDB(pic);
+
+            // then
+            // 1. DB 검증: deleted_at 컬럼 확인
+            entityManager.clear(); // 영속성 컨텍스트를 비워 DB에서 직접 다시 조회하도록 강제
+            Picture deletedPic = pictureRepository.findById(pic.getId()).get();
+            assertThat(deletedPic.getPictureDeletedAt()).isNotNull();
+
+            // 2. S3 검증: 원본 파일 삭제 및 휴지통으로 이동 확인
+            assertThat(s3Service.isFileExists("uploads/single-delete.gif")).isFalse();
+            assertThat(s3Service.isFileExists("trash/uploads/single-delete.gif")).isTrue();
+        }
     }
 }

--- a/src/test/java/com/project200/undabang/common/service/PictureServiceUnitTest.java
+++ b/src/test/java/com/project200/undabang/common/service/PictureServiceUnitTest.java
@@ -11,6 +11,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -431,6 +432,60 @@ class PictureServiceUnitTest {
                     .isInstanceOf(CustomException.class)
                     .extracting("errorCode")
                     .isEqualTo(ErrorCode.PICTURE_UPLOAD_FAILED);
+        }
+
+        @Test
+        @DisplayName("성공[단일 삭제]: 단일 Picture 객체 삭제 시 내부 리스트 처리 메서드를 정상적으로 호출한다")
+        void delete_SinglePicture_Success() {
+            // given
+            // PictureService의 실제 객체를 Spy하여 실제 메서드 호출을 추적
+            PictureService spiedPictureService = spy(new PictureService(s3Service, pictureRepository));
+
+            // 내부적으로 호출될 List<Picture> 버전의 메서드가 아무것도 하지 않도록 설정
+            // 이렇게 함으로써 우리는 단일 버전 메서드가 List 버전을 '호출했는지' 여부만 검증할 수 있음
+            doNothing().when(spiedPictureService).deletePictureFromS3AndDB(anyList());
+
+            // when
+            spiedPictureService.deletePictureFromS3AndDB(picture1);
+
+            // then
+            // deletePictureFromS3AndDB(List<Picture>) 메서드가 정확히 한 번 호출되었는지,
+            // 그리고 그 인자가 List.of(picture1)과 같은지 검증
+            ArgumentCaptor<List<Picture>> listArgumentCaptor = ArgumentCaptor.forClass(List.class);
+            verify(spiedPictureService, times(1)).deletePictureFromS3AndDB(listArgumentCaptor.capture());
+
+            List<Picture> capturedList = listArgumentCaptor.getValue();
+            assertThat(capturedList).hasSize(1);
+            assertThat(capturedList.get(0)).isEqualTo(picture1);
+        }
+
+        // --- ✨ 추가된 테스트 코드 2: 롤백 실패 시 동작 검증 ---
+        @Test
+        @DisplayName("롤백 중 S3 복원 실패 시, 에러를 로깅하고 계속 진행한다")
+        void delete_Rollback_Continues_On_S3RestoreFailure() {
+            // given: S3 이동은 성공, DB 저장은 실패, S3 롤백(복원) 중에도 실패
+            when(s3Service.extractObjectKeyFromUrl(anyString()))
+                    .thenAnswer(inv -> {
+                        String url = inv.getArgument(0).toString();
+                        int idx = url.indexOf("uploads/");
+                        return idx >= 0 ? url.substring(idx) : url;
+                    });
+            doNothing().when(s3Service).moveImageToTrash(anyString());
+            when(pictureRepository.save(any(Picture.class))).thenThrow(new RuntimeException("DB 강제 에러"));
+
+            // 롤백 시, 첫 번째 파일 복원에서 예외를 던지도록 설정
+            doThrow(new S3UploadFailedException("S3 복원 강제 에러")).when(s3Service).restoreImageFromTrash("uploads/pic1.jpg");
+            // 두 번째 파일 복원은 성공
+            doNothing().when(s3Service).restoreImageFromTrash("uploads/pic2.png");
+
+            // when & then: 최종적으로는 CustomException이 발생해야 함
+            assertThatThrownBy(() -> pictureService.deletePictureFromS3AndDB(pictureList))
+                    .isInstanceOf(CustomException.class);
+
+            // then: 롤백 로직 검증
+            // 두 파일 모두에 대해 restoreImageFromTrash가 호출되었는지 확인 (첫 번째는 실패, 두 번째는 성공)
+            verify(s3Service, times(1)).restoreImageFromTrash("uploads/pic1.jpg");
+            verify(s3Service, times(1)).restoreImageFromTrash("uploads/pic2.png");
         }
     }
 }

--- a/src/test/java/com/project200/undabang/member/controller/MemberPictureCommandControllerTest.java
+++ b/src/test/java/com/project200/undabang/member/controller/MemberPictureCommandControllerTest.java
@@ -24,7 +24,10 @@ import java.util.UUID;
 import static com.project200.undabang.configuration.DocumentFormatGenerator.getTypeFormat;
 import static com.project200.undabang.configuration.HeadersGenerator.getCommonApiHeaders;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.times;
 import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.delete;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.put;
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
 import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
@@ -57,7 +60,7 @@ class MemberPictureCommandControllerTest extends AbstractRestDocSupport {
                     1L, "https://s3.com/images/my-profile.jpg"
             );
 
-            BDDMockito.given(memberPictureCommandService.createProfilePicture(BDDMockito.any(MockMultipartFile.class)))
+            BDDMockito.given(memberPictureCommandService.createProfilePicture(any(MockMultipartFile.class)))
                     .willReturn(responseDto);
 
             // when
@@ -84,7 +87,7 @@ class MemberPictureCommandControllerTest extends AbstractRestDocSupport {
 
             // then
             assertThat(response).isEqualTo(objectMapper.writeValueAsString(CommonResponse.create(responseDto)));
-            BDDMockito.then(memberPictureCommandService).should(BDDMockito.times(1)).createProfilePicture(BDDMockito.any(MockMultipartFile.class));
+            BDDMockito.then(memberPictureCommandService).should(times(1)).createProfilePicture(any(MockMultipartFile.class));
             BDDMockito.then(memberPictureCommandService).shouldHaveNoMoreInteractions();
         }
 
@@ -106,7 +109,7 @@ class MemberPictureCommandControllerTest extends AbstractRestDocSupport {
                     .andExpect(jsonPath("$.succeed").value(false))
                     .andExpect(jsonPath("$.message").value("요청 파라미터 유효성 검증에 실패했습니다."));
 
-            BDDMockito.then(memberPictureCommandService).should(BDDMockito.never()).createProfilePicture(BDDMockito.any(MockMultipartFile.class));
+            BDDMockito.then(memberPictureCommandService).should(BDDMockito.never()).createProfilePicture(any(MockMultipartFile.class));
         }
 
         @Test
@@ -127,7 +130,7 @@ class MemberPictureCommandControllerTest extends AbstractRestDocSupport {
                     .andExpect(jsonPath("$.succeed").value(false))
                     .andExpect(jsonPath("$.message").value("Required part 'profilePicture' is not present."));
 
-            BDDMockito.then(memberPictureCommandService).should(BDDMockito.never()).createProfilePicture(BDDMockito.any(MockMultipartFile.class));
+            BDDMockito.then(memberPictureCommandService).should(BDDMockito.never()).createProfilePicture(any(MockMultipartFile.class));
         }
 
         @Test
@@ -137,7 +140,7 @@ class MemberPictureCommandControllerTest extends AbstractRestDocSupport {
             UUID testMemberId = UUID.randomUUID();
             MockMultipartFile profilePictureFile = new MockMultipartFile("profilePicture", "my-profile.jpg", MediaType.IMAGE_JPEG_VALUE, "dummy-image-content".getBytes());
 
-            BDDMockito.given(memberPictureCommandService.createProfilePicture(BDDMockito.any(MockMultipartFile.class)))
+            BDDMockito.given(memberPictureCommandService.createProfilePicture(any(MockMultipartFile.class)))
                     .willThrow(new CustomException(ErrorCode.MEMBER_NOT_FOUND));
 
             // when & then
@@ -152,7 +155,7 @@ class MemberPictureCommandControllerTest extends AbstractRestDocSupport {
                     .andExpect(jsonPath("$.code").value(ErrorCode.MEMBER_NOT_FOUND.getCode()))
                     .andExpect(jsonPath("$.message").value(ErrorCode.MEMBER_NOT_FOUND.getMessage()));
 
-            BDDMockito.then(memberPictureCommandService).should(BDDMockito.times(1)).createProfilePicture(BDDMockito.any(MockMultipartFile.class));
+            BDDMockito.then(memberPictureCommandService).should(times(1)).createProfilePicture(any(MockMultipartFile.class));
         }
     }
 
@@ -239,6 +242,123 @@ class MemberPictureCommandControllerTest extends AbstractRestDocSupport {
                     .andExpect(jsonPath("$.message").value(ErrorCode.AUTHORIZATION_DENIED.getMessage()));
 
             BDDMockito.then(memberPictureCommandService).should().updateRepresentativeProfileImage(pictureId);
+        }
+    }
+
+    @Nested
+    @DisplayName("프로필 사진 삭제")
+    class DeleteProfilePicture {
+
+        @Test
+        @DisplayName("성공: 유효한 사진 ID로 요청 시 200 OK와 성공 응답을 반환한다")
+        void deleteProfilePicture_Success() throws Exception {
+            // given
+            UUID testMemberId = UUID.randomUUID();
+            Long pictureId = 1L;
+
+            // deleteProfilePicture는 void를 반환하므로, doNothing()으로 설정
+            BDDMockito.doNothing().when(memberPictureCommandService).deleteProfilePicture(pictureId);
+
+            // when
+            String response = mockMvc.perform(delete("/api/v1/profile-pictures/{pictureId}", pictureId)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .accept(MediaType.APPLICATION_JSON)
+                            .headers(getCommonApiHeaders(testMemberId)))
+                    .andExpectAll(status().isOk())
+                    .andDo(document.document(
+                            requestHeaders(RestDocsUtils.HEADER_ACCESS_TOKEN),
+                            pathParameters(
+                                    parameterWithName("pictureId").attributes(getTypeFormat("NUMBER")).description("삭제할 프로필 사진의 식별자입니다.")
+                            ),
+                            responseFields(RestDocsUtils.commonResponseFields(
+                                    fieldWithPath("data").type(JsonFieldType.NULL).description("삭제 성공 시 데이터는 null 을 반환합니다")
+                            ))
+                    ))
+                    .andReturn().getResponse().getContentAsString();
+
+            // then
+            assertThat(response).isEqualTo(objectMapper.writeValueAsString(CommonResponse.delete(null)));
+            BDDMockito.then(memberPictureCommandService).should(times(1)).deleteProfilePicture(pictureId);
+            BDDMockito.then(memberPictureCommandService).shouldHaveNoMoreInteractions();
+        }
+
+        @Test
+        @DisplayName("실패: 사진이 존재하지 않을 때 서비스에서 예외 발생 시 404 Not Found를 반환한다")
+        void deleteProfilePicture_Fail_PictureNotFound() throws Exception {
+            // given
+            UUID testMemberId = UUID.randomUUID();
+            Long nonExistentPictureId = 999L;
+
+            // 서비스 레이어에서 PICTURE_NOT_FOUND 예외를 던지도록 Mocking
+            BDDMockito.willThrow(new CustomException(ErrorCode.PICTURE_NOT_FOUND))
+                    .given(memberPictureCommandService).deleteProfilePicture(nonExistentPictureId);
+
+            // when & then
+            mockMvc.perform(delete("/api/v1/profile-pictures/{pictureId}", nonExistentPictureId)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .accept(MediaType.APPLICATION_JSON)
+                            .headers(getCommonApiHeaders(testMemberId)))
+                    .andExpectAll(status().isNotFound())
+                    .andExpect(jsonPath("$.succeed").value(false))
+                    .andExpect(jsonPath("$.code").value(ErrorCode.PICTURE_NOT_FOUND.getCode()))
+                    .andExpect(jsonPath("$.message").value(ErrorCode.PICTURE_NOT_FOUND.getMessage()));
+
+            BDDMockito.then(memberPictureCommandService).should(times(1)).deleteProfilePicture(nonExistentPictureId);
+        }
+
+        @Test
+        @DisplayName("실패: 사진이 사용자의 소유가 아닐 때 서비스에서 예외 발생 시 403 Forbidden을 반환한다")
+        void deleteProfilePicture_Fail_AuthorizationDenied() throws Exception {
+            // given
+            UUID testMemberId = UUID.randomUUID();
+            Long othersPictureId = 2L;
+
+            // 서비스 레이어에서 AUTHORIZATION_DENIED 예외를 던지도록 Mocking
+            BDDMockito.willThrow(new CustomException(ErrorCode.AUTHORIZATION_DENIED))
+                    .given(memberPictureCommandService).deleteProfilePicture(othersPictureId);
+
+            // when & then
+            mockMvc.perform(delete("/api/v1/profile-pictures/{pictureId}", othersPictureId)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .accept(MediaType.APPLICATION_JSON)
+                            .headers(getCommonApiHeaders(testMemberId)))
+                    .andExpectAll(status().isForbidden())
+                    .andExpect(jsonPath("$.succeed").value(false))
+                    .andExpect(jsonPath("$.code").value(ErrorCode.AUTHORIZATION_DENIED.getCode()))
+                    .andExpect(jsonPath("$.message").value(ErrorCode.AUTHORIZATION_DENIED.getMessage()));
+
+            BDDMockito.then(memberPictureCommandService).should(times(1)).deleteProfilePicture(othersPictureId);
+        }
+
+        @Test
+        @DisplayName("실패: 사진 업로드 중 서버 내부 오류 발생 시 500 Internal Server Error를 반환한다")
+        void createProfilePicture_Fail_InternalServerError() throws Exception {
+            // given
+            UUID testMemberId = UUID.randomUUID();
+            MockMultipartFile profilePictureFile = new MockMultipartFile(
+                    "profilePicture",
+                    "my-profile.jpg",
+                    MediaType.IMAGE_JPEG_VALUE,
+                    "dummy-image-content".getBytes()
+            );
+
+            // 서비스 레이어에서 PICTURE_UPLOAD_FAILED 예외를 던지도록 Mocking
+            BDDMockito.given(memberPictureCommandService.createProfilePicture(any(MockMultipartFile.class)))
+                    .willThrow(new CustomException(ErrorCode.PICTURE_UPLOAD_FAILED));
+
+            // when & then
+            mockMvc.perform(MockMvcRequestBuilders
+                            .multipart("/api/v1/profile-pictures")
+                            .file(profilePictureFile)
+                            .contentType(MediaType.MULTIPART_FORM_DATA_VALUE)
+                            .accept(MediaType.APPLICATION_JSON)
+                            .headers(getCommonApiHeaders(testMemberId)))
+                    .andExpectAll(status().isInternalServerError()) // 500 상태 코드 검증
+                    .andExpect(jsonPath("$.succeed").value(false))
+                    .andExpect(jsonPath("$.code").value(ErrorCode.PICTURE_UPLOAD_FAILED.getCode()))
+                    .andExpect(jsonPath("$.message").value(ErrorCode.PICTURE_UPLOAD_FAILED.getMessage()));
+
+            BDDMockito.then(memberPictureCommandService).should(times(1)).createProfilePicture(any(MockMultipartFile.class));
         }
     }
 }

--- a/src/test/java/com/project200/undabang/member/repository/MemberPictureRepositoryTest.java
+++ b/src/test/java/com/project200/undabang/member/repository/MemberPictureRepositoryTest.java
@@ -14,6 +14,7 @@ import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.context.annotation.Import;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
@@ -29,47 +30,6 @@ class MemberPictureRepositoryTest {
 
     @Autowired
     private MemberPictureRepository memberPictureRepository;
-
-    private Member createAndSaveMember(String nickname) {
-        Member member = Member.builder()
-                .memberId(UUID.randomUUID())
-                .memberEmail(nickname + "@email.com")
-                .memberNickname(nickname)
-                .memberGender(MemberGender.UNKNOWN) // Enum이 있다면 실제 값으로
-                .memberBday(LocalDate.of(2000, 1, 1))
-                .build();
-        em.persist(member);
-        return member;
-    }
-
-    private Picture createAndSavePicture(String pictureName) {
-        Picture picture = Picture.builder()
-                .pictureName(pictureName)
-                .pictureUrl("/test/" + pictureName)
-                .pictureExtension(".jpg")
-                .pictureSize(1024)
-                .build();
-        em.persist(picture);
-        return picture;
-    }
-
-    private MemberPicture createAndSaveMemberPicture(Member member) {
-        // Picture를 먼저 생성하고 저장
-        Picture picture = createAndSavePicture(UUID.randomUUID().toString());
-
-        // MemberPicture 생성 및 저장
-        MemberPicture memberPicture = MemberPicture.builder()
-                .member(member)
-                .picture(picture)
-                .build();
-        em.persist(memberPicture);
-        return memberPicture;
-    }
-
-    private void flushAndClear() {
-        em.flush();
-        em.clear();
-    }
 
     @Nested
     @DisplayName("findByMemberAndPicture_PictureDeletedAtNull 메소드는")
@@ -193,6 +153,147 @@ class MemberPictureRepositoryTest {
 
             // then
             assertThat(result).isEmpty();
+        }
+    }
+
+    private Member createAndSaveMember(String nickname) {
+        Member member = Member.builder()
+                .memberId(UUID.randomUUID())
+                .memberEmail(nickname + "@email.com")
+                .memberNickname(nickname)
+                .memberGender(MemberGender.UNKNOWN)
+                .memberBday(LocalDate.of(2000, 1, 1))
+                .build();
+        em.persist(member);
+        return member;
+    }
+
+    private Picture createAndSavePicture(String pictureName, LocalDateTime createdAt) {
+        Picture picture = Picture.builder()
+                .pictureName(pictureName)
+                .pictureUrl("/test/" + pictureName)
+                .pictureExtension(".jpg")
+                .pictureSize(1024)
+                .pictureCreatedAt(createdAt) // 생성 시간 제어를 위해 파라미터 추가
+                .build();
+        em.persist(picture);
+        return picture;
+    }
+
+    private MemberPicture createAndSaveMemberPicture(Member member) {
+        return createAndSaveMemberPicture(member, LocalDateTime.now());
+    }
+
+    private MemberPicture createAndSaveMemberPicture(Member member, LocalDateTime pictureCreatedAt) {
+        Picture picture = createAndSavePicture(UUID.randomUUID().toString(), pictureCreatedAt);
+        MemberPicture memberPicture = MemberPicture.builder()
+                .member(member)
+                .picture(picture)
+                .build();
+        em.persist(memberPicture);
+        return memberPicture;
+    }
+
+    private void flushAndClear() {
+        em.flush();
+        em.clear();
+    }
+
+    @Nested
+    @DisplayName("findFirstByMemberAndMemberPicturesDeletedAtNullAndPicture_PictureDeletedAtNullOrderByPicture_PictureCreatedAtDesc 메소드는")
+    class Describe_findFirstByMember {
+
+        @Test
+        @DisplayName("삭제되지 않은 사진들 중 가장 최근에 생성된 사진 하나를 Optional에 담아 반환한다")
+        void it_returns_the_most_recently_created_picture() throws InterruptedException {
+            // given
+            Member member = createAndSaveMember("testMember");
+
+            // 생성 시간 순서를 보장하기 위해 시간 간격을 둠
+            createAndSaveMemberPicture(member, LocalDateTime.now().minusDays(2)); // 가장 오래된 사진
+            MemberPicture middlePicture = createAndSaveMemberPicture(member, LocalDateTime.now().minusDays(1)); // 중간
+            MemberPicture latestPicture = createAndSaveMemberPicture(member, LocalDateTime.now()); // 가장 최신
+
+            flushAndClear();
+
+            // when
+            Optional<MemberPicture> foundOpt = memberPictureRepository.findFirstByMemberAndMemberPicturesDeletedAtNullAndPicture_PictureDeletedAtNullOrderByPicture_PictureCreatedAtDesc(member);
+
+            // then
+            assertThat(foundOpt).isPresent();
+            assertThat(foundOpt.get().getId()).isEqualTo(latestPicture.getId());
+            assertThat(foundOpt.get().getPicture().getId()).isEqualTo(latestPicture.getPicture().getId());
+        }
+
+        @Test
+        @DisplayName("가장 최신 사진의 Picture가 soft-delete된 경우, 그 다음으로 최신인 사진을 반환한다")
+        void it_returns_the_next_latest_picture_if_the_latest_one_is_deleted() {
+            // given
+            Member member = createAndSaveMember("testMember");
+
+            createAndSaveMemberPicture(member, LocalDateTime.now().minusDays(2));
+            MemberPicture expectedPicture = createAndSaveMemberPicture(member, LocalDateTime.now().minusDays(1)); // 차순위 최신
+            MemberPicture latestButDeleted = createAndSaveMemberPicture(member, LocalDateTime.now()); // 가장 최신이지만 삭제될 사진
+
+            // 가장 최신 Picture를 soft-delete
+            latestButDeleted.getPicture().softDelete();
+            em.persist(latestButDeleted.getPicture());
+
+            flushAndClear();
+
+            // when
+            Optional<MemberPicture> foundOpt = memberPictureRepository.findFirstByMemberAndMemberPicturesDeletedAtNullAndPicture_PictureDeletedAtNullOrderByPicture_PictureCreatedAtDesc(member);
+
+            // then
+            assertThat(foundOpt).isPresent();
+            assertThat(foundOpt.get().getId()).isEqualTo(expectedPicture.getId());
+        }
+
+        @Test
+        @DisplayName("가장 최신 사진의 MemberPicture가 soft-delete된 경우, 그 다음으로 최신인 사진을 반환한다")
+        void it_returns_the_next_latest_picture_if_the_latest_member_picture_is_deleted() {
+            // given
+            Member member = createAndSaveMember("testMember");
+
+            createAndSaveMemberPicture(member, LocalDateTime.now().minusDays(2));
+            MemberPicture expectedPicture = createAndSaveMemberPicture(member, LocalDateTime.now().minusDays(1));
+            MemberPicture latestButDeleted = createAndSaveMemberPicture(member, LocalDateTime.now());
+
+            // 가장 최신 MemberPicture를 soft-delete
+            latestButDeleted.deleteMemberPicture();
+            em.persist(latestButDeleted);
+
+            flushAndClear();
+
+            // when
+            Optional<MemberPicture> foundOpt = memberPictureRepository.findFirstByMemberAndMemberPicturesDeletedAtNullAndPicture_PictureDeletedAtNullOrderByPicture_PictureCreatedAtDesc(member);
+
+            // then
+            assertThat(foundOpt).isPresent();
+            assertThat(foundOpt.get().getId()).isEqualTo(expectedPicture.getId());
+        }
+
+        @Test
+        @DisplayName("삭제되지 않은 사진이 하나도 없는 경우 빈 Optional을 반환한다")
+        void it_returns_empty_optional_when_no_active_pictures_exist() {
+            // given
+            Member member = createAndSaveMember("testMember");
+            MemberPicture mp1 = createAndSaveMemberPicture(member);
+            MemberPicture mp2 = createAndSaveMemberPicture(member);
+
+            // 모든 사진을 삭제 처리
+            mp1.getPicture().softDelete();
+            em.persist(mp1.getPicture());
+            mp2.deleteMemberPicture();
+            em.persist(mp2);
+
+            flushAndClear();
+
+            // when
+            Optional<MemberPicture> foundOpt = memberPictureRepository.findFirstByMemberAndMemberPicturesDeletedAtNullAndPicture_PictureDeletedAtNullOrderByPicture_PictureCreatedAtDesc(member);
+
+            // then
+            assertThat(foundOpt).isEmpty();
         }
     }
 }

--- a/src/test/java/com/project200/undabang/member/service/impl/MemberPictureCommandServiceImplTest.java
+++ b/src/test/java/com/project200/undabang/member/service/impl/MemberPictureCommandServiceImplTest.java
@@ -32,6 +32,7 @@ import java.util.UUID;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.*;
 
 @ExtendWith(MockitoExtension.class)
 class MemberPictureCommandServiceImplTest {
@@ -317,4 +318,183 @@ class MemberPictureCommandServiceImplTest {
         }
     }
 
+    @Nested
+    @DisplayName("프로필 사진 삭제 테스트")
+    class DeleteProfilePictureTests {
+
+        @Test
+        @DisplayName("성공: 삭제하려는 사진이 대표 사진이 아닐 경우, 해당 사진만 논리적으로 삭제한다")
+        void deleteProfilePicture_Success_WhenNotRepresentative() {
+            // given
+            UUID testUserId = UUID.randomUUID();
+            Long pictureToDeleteId = 100L;
+            Long representativePictureId = 200L;
+
+            Member testMember = createTestMember(testUserId);
+            Picture pictureToDelete = createTestPicture(pictureToDeleteId);
+            MemberPicture memberPictureToDelete = createTestMemberPicture(testMember, pictureToDelete);
+
+            // 현재 대표 사진은 다른 사진으로 설정
+            Picture representativePicture = createTestPicture(representativePictureId);
+            MemberPicture representativeMemberPicture = createTestMemberPicture(testMember, representativePicture);
+            testMember.updateProfilePicture(representativeMemberPicture);
+
+            try (var ignored = mockStatic(UserContextHolder.class)) {
+                // Mocking
+                given(UserContextHolder.getUserId()).willReturn(testUserId);
+                given(memberRepository.findById(testUserId)).willReturn(Optional.of(testMember));
+                given(pictureRepository.findById(pictureToDeleteId)).willReturn(Optional.of(pictureToDelete));
+                given(memberPictureRepository.findByMemberAndPicture_IdAndPicture_PictureDeletedAtNull(testMember, pictureToDeleteId))
+                        .willReturn(Optional.of(memberPictureToDelete));
+
+                // pictureService의 삭제 메서드는 void이므로 doNothing() 처리
+                doNothing().when(pictureService).deletePictureFromS3AndDB(pictureToDelete);
+
+                // when
+                memberPictureCommandService.deleteProfilePicture(pictureToDeleteId);
+
+                // then
+                // 1. 서비스/레포지토리 호출 검증
+                then(pictureService).should(times(1)).deletePictureFromS3AndDB(pictureToDelete);
+                // 대표 사진이 아니므로, 새 대표 사진을 찾는 로직은 호출되지 않아야 함
+                then(memberPictureRepository).should(never()).findFirstByMemberAndMemberPicturesDeletedAtNullAndPicture_PictureDeletedAtNullOrderByPicture_PictureCreatedAtDesc(any(Member.class));
+
+                // 2. Member의 대표 사진은 변경되지 않았는지 검증
+                assertThat(testMember.getMemberPicture()).isEqualTo(representativeMemberPicture);
+            }
+        }
+
+        @Test
+        @DisplayName("성공: 삭제하려는 사진이 대표 사진이고 다른 사진이 있을 경우, 가장 최신 사진으로 대표 사진을 교체한다")
+        void deleteProfilePicture_Success_WhenIsRepresentative_AndOtherPicturesExist() {
+            // given
+            UUID testUserId = UUID.randomUUID();
+            Long pictureToDeleteId = 100L;
+
+            Member testMember = createTestMember(testUserId);
+            Picture pictureToDelete = createTestPicture(pictureToDeleteId);
+            MemberPicture memberPictureToDelete = createTestMemberPicture(testMember, pictureToDelete);
+
+            // 삭제할 사진을 현재 대표 사진으로 설정
+            testMember.updateProfilePicture(memberPictureToDelete);
+
+            // 새로 대표 사진이 될 후보 사진 설정
+            Picture newRepresentativePicture = createTestPicture(200L);
+            MemberPicture newRepresentativeMemberPicture = createTestMemberPicture(testMember, newRepresentativePicture);
+
+            try (var ignored = mockStatic(UserContextHolder.class)) {
+                // Mocking
+                given(UserContextHolder.getUserId()).willReturn(testUserId);
+                given(memberRepository.findById(testUserId)).willReturn(Optional.of(testMember));
+                given(pictureRepository.findById(pictureToDeleteId)).willReturn(Optional.of(pictureToDelete));
+                given(memberPictureRepository.findByMemberAndPicture_IdAndPicture_PictureDeletedAtNull(testMember, pictureToDeleteId))
+                        .willReturn(Optional.of(memberPictureToDelete));
+
+                // 새 대표 사진을 찾는 쿼리가 newRepresentativeMemberPicture를 반환하도록 설정
+                given(memberPictureRepository.findFirstByMemberAndMemberPicturesDeletedAtNullAndPicture_PictureDeletedAtNullOrderByPicture_PictureCreatedAtDesc(testMember))
+                        .willReturn(Optional.of(newRepresentativeMemberPicture));
+
+                doNothing().when(pictureService).deletePictureFromS3AndDB(pictureToDelete);
+
+                // when
+                memberPictureCommandService.deleteProfilePicture(pictureToDeleteId);
+
+                // then
+                then(pictureService).should(times(1)).deletePictureFromS3AndDB(pictureToDelete);
+                then(memberPictureRepository).should(times(1)).findFirstByMemberAndMemberPicturesDeletedAtNullAndPicture_PictureDeletedAtNullOrderByPicture_PictureCreatedAtDesc(testMember);
+
+                // Member의 대표 사진이 새로운 사진으로 교체되었는지 검증
+                assertThat(testMember.getMemberPicture()).isEqualTo(newRepresentativeMemberPicture);
+            }
+        }
+
+        @Test
+        @DisplayName("성공: 삭제하려는 사진이 대표 사진이고 다른 사진이 없을 경우, 대표 사진을 null로 설정한다")
+        void deleteProfilePicture_Success_WhenIsRepresentative_AndNoOtherPicturesExist() {
+            // given
+            UUID testUserId = UUID.randomUUID();
+            Long pictureToDeleteId = 100L;
+
+            Member testMember = createTestMember(testUserId);
+            Picture pictureToDelete = createTestPicture(pictureToDeleteId);
+            MemberPicture memberPictureToDelete = createTestMemberPicture(testMember, pictureToDelete);
+            testMember.updateProfilePicture(memberPictureToDelete);
+
+            try (var ignored = mockStatic(UserContextHolder.class)) {
+                // Mocking
+                given(UserContextHolder.getUserId()).willReturn(testUserId);
+                given(memberRepository.findById(testUserId)).willReturn(Optional.of(testMember));
+                given(pictureRepository.findById(pictureToDeleteId)).willReturn(Optional.of(pictureToDelete));
+                given(memberPictureRepository.findByMemberAndPicture_IdAndPicture_PictureDeletedAtNull(testMember, pictureToDeleteId))
+                        .willReturn(Optional.of(memberPictureToDelete));
+
+                // 새 대표 사진을 찾는 쿼리가 빈 Optional을 반환하도록 설정 (다른 사진 없음)
+                given(memberPictureRepository.findFirstByMemberAndMemberPicturesDeletedAtNullAndPicture_PictureDeletedAtNullOrderByPicture_PictureCreatedAtDesc(testMember))
+                        .willReturn(Optional.empty());
+
+                doNothing().when(pictureService).deletePictureFromS3AndDB(pictureToDelete);
+
+                // when
+                memberPictureCommandService.deleteProfilePicture(pictureToDeleteId);
+
+                // then
+                then(pictureService).should(times(1)).deletePictureFromS3AndDB(pictureToDelete);
+                then(memberPictureRepository).should(times(1)).findFirstByMemberAndMemberPicturesDeletedAtNullAndPicture_PictureDeletedAtNullOrderByPicture_PictureCreatedAtDesc(testMember);
+
+                // Member의 대표 사진이 null로 설정되었는지 검증
+                assertThat(testMember.getMemberPicture()).isNull();
+            }
+        }
+
+        @Test
+        @DisplayName("실패: 삭제하려는 Picture를 찾을 수 없을 때 CustomException(PICTURE_NOT_FOUND)을 던진다")
+        void deleteProfilePicture_Fails_WhenPictureNotFound() {
+            // given
+            UUID testUserId = UUID.randomUUID();
+            Long pictureId = 100L;
+            Member testMember = createTestMember(testUserId);
+
+            try (var ignored = mockStatic(UserContextHolder.class)) {
+                given(UserContextHolder.getUserId()).willReturn(testUserId);
+                given(memberRepository.findById(testUserId)).willReturn(Optional.of(testMember));
+                // PictureRepository가 빈 Optional을 반환하도록 설정
+                given(pictureRepository.findById(pictureId)).willReturn(Optional.empty());
+
+                // when & then
+                assertThatThrownBy(() -> memberPictureCommandService.deleteProfilePicture(pictureId))
+                        .isInstanceOf(CustomException.class)
+                        .hasFieldOrPropertyWithValue("errorCode", ErrorCode.PICTURE_NOT_FOUND);
+
+                // 실패했으므로 이후 로직은 호출되지 않아야 함
+                then(memberPictureRepository).should(never()).findByMemberAndPicture_IdAndPicture_PictureDeletedAtNull(any(), any());
+                then(pictureService).should(never()).deletePictureFromS3AndDB(any(Picture.class));
+            }
+        }
+
+        @Test
+        @DisplayName("실패: 사진이 현재 사용자의 소유가 아닐 때 CustomException(AUTHORIZATION_DENIED)을 던진다")
+        void deleteProfilePicture_Fails_WhenPictureNotOwnedByUser() {
+            // given
+            UUID testUserId = UUID.randomUUID();
+            Long pictureId = 100L;
+            Member testMember = createTestMember(testUserId);
+            Picture testPicture = createTestPicture(pictureId);
+
+            try (var ignored = mockStatic(UserContextHolder.class)) {
+                given(UserContextHolder.getUserId()).willReturn(testUserId);
+                given(memberRepository.findById(testUserId)).willReturn(Optional.of(testMember));
+                given(pictureRepository.findById(pictureId)).willReturn(Optional.of(testPicture));
+                // MemberPictureRepository가 빈 Optional을 반환하도록 설정 (권한 없음 케이스)
+                given(memberPictureRepository.findByMemberAndPicture_IdAndPicture_PictureDeletedAtNull(testMember, pictureId))
+                        .willReturn(Optional.empty());
+
+                // when & then
+                assertThatThrownBy(() -> memberPictureCommandService.deleteProfilePicture(pictureId))
+                        .isInstanceOf(CustomException.class)
+                        .hasFieldOrPropertyWithValue("errorCode", ErrorCode.AUTHORIZATION_DENIED);
+
+                then(pictureService).should(never()).deletePictureFromS3AndDB(any(Picture.class));
+            }
+        }
+    }
 }


### PR DESCRIPTION
## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
프로필 삭제 기능을 개발하였습니다.

커밋 **3bd2638429b4cd9ecd63d4f430c0bb81f11c431c** 을 통해 기능 개발을 완료하였습니다.
프로필 생성과 마찬가지로, 썸네일 사진 S3에서 삭제 기능은 개발하지 않았습니다.

향후 썸네일 생성시 같이 개발하려 합니다.
현재 PictureService의 구조가 썸네일 등록과는 맞지 않아서 썸네일 등록/삭제 용 사진 클래스를 개발하려 합니다.

++ 사진 삭제시 S3 버킷에서는 이미 삭제된 사진인데 디비에 사진 데이터가 남아있는 경우 해당 예외처리가 미흡했던 부분을 확인하여 해당 부분에 분기를 만들어 디비에서만 삭제되도록 처리하였습니다. (S3에서는 이미 삭제된 데이터라 재차 삭제하려할시 에러가 발생하기 때문입니다)

그리고 프로필 사진 삭제시 대표사진인 경우

1) 가장 최근 추가한 프로필 사진을 대표사진으로 설정
2) 사진이 없으면 Null 입력

으로 구현하였습니다.

이전 코드들과 마찬가지로 테스트케이스는 100%를 유지하였습니다.

### 스크린샷 (선택)
**API 응답 사진입니다**
<img width="425" height="237" alt="image" src="https://github.com/user-attachments/assets/2a8eeeb7-46c5-4caf-a6bb-de3967a5555c" />

**API 명세서 사진입니다.**
<img width="674" height="185" alt="image" src="https://github.com/user-attachments/assets/eae091cf-9d9c-4e58-9463-11674d33d46c" />
<img width="529" height="461" alt="image" src="https://github.com/user-attachments/assets/8efb092e-7604-4be6-828e-a0bbdd0db120" />
<img width="992" height="792" alt="image" src="https://github.com/user-attachments/assets/1a92a6a2-3644-41e8-95c9-c8bb762575db" />
<img width="982" height="833" alt="image" src="https://github.com/user-attachments/assets/6b9d2204-c36d-4068-9208-e3c14f47d75d" />
<img width="1030" height="444" alt="image" src="https://github.com/user-attachments/assets/2008ad1c-2669-4886-a693-525b35bc5627" />

**테스트코드 사진입니다.**
<img width="724" height="239" alt="image" src="https://github.com/user-attachments/assets/16820dab-2ec7-4e05-9f73-905bdd06cdf8" />


Closes #263 