### PR TITLE
[Refactor] 프로필 사진 삭제 기능 리팩토링

### DIFF
--- a/src/main/java/com/project200/undabang/member/service/MemberPictureCommandService.java
+++ b/src/main/java/com/project200/undabang/member/service/MemberPictureCommandService.java
@@ -7,6 +7,5 @@ import org.springframework.web.multipart.MultipartFile;
 public interface MemberPictureCommandService {
     CreateProfilePictureResponse createProfilePicture(MultipartFile profilePicture);
     UpdateProfilePictureResponse updateRepresentativeProfileImage(Long pictureId);
-
     void deleteProfilePicture(Long pictureId);
 }

--- a/src/main/java/com/project200/undabang/member/service/impl/MemberPictureCommandServiceImpl.java
+++ b/src/main/java/com/project200/undabang/member/service/impl/MemberPictureCommandServiceImpl.java
@@ -95,17 +95,23 @@ public class MemberPictureCommandServiceImpl implements MemberPictureCommandServ
     @Override
     public void deleteProfilePicture(Long pictureId) {
         Member member = getMember(UserContextHolder.getUserId());
+        Picture picture = getPicture(pictureId);
 
-        Picture picture = pictureRepository.findById(pictureId).orElseThrow(() -> new CustomException(ErrorCode.PICTURE_NOT_FOUND));
-
-        MemberPicture memberPicture = memberPictureRepository.findByMemberAndPicture_IdAndPicture_PictureDeletedAtNull(member, pictureId)
-                .orElseThrow(() -> new CustomException(ErrorCode.AUTHORIZATION_DENIED));
+        MemberPicture memberPicture = validateAndGetMemberPicture(member, picture);
 
         // 썸네일 사진, 프로필 사진 논리적 삭제 및 S3에 저장된 프로필 사진 삭제
-        pictureService.deletePictureFromS3AndDB(picture);
-        memberPicture.deleteMemberPicture();
-
+        deleteProfileAndThumbnailImageFromS3AndDB(picture, memberPicture);
         // 회원 테이블의 대표사진을 제거합니다. 그 후, 가장 최근에 생성된 사진 데이터를 넣어주고 그렇지 않으면 null 을 넣어줘야 합니다.
+        updateRepresentativeProfileImageAfterDelete(member, memberPicture);
+
+        // todo 썸네일 생성 이후 삭제를 진행해야 함 S3에 업로드 및 삭제 과정에 대한 고려 후 개발 진행
+    }
+
+    /**
+     * 특정 프로필 사진을 삭제한 후, 회원의 대표 프로필 사진을 갱신합니다.
+     * 대표 프로필 사진이 삭제된 경우, 남아 있는 사진 중 가장 최신의 사진으로 갱신하거나, 사진이 없는 경우 null로 설정합니다.
+     */
+    private void updateRepresentativeProfileImageAfterDelete(Member member, MemberPicture memberPicture) {
         if (member.getMemberPicture() != null && Objects.equals(member.getMemberPicture().getId(), memberPicture.getId())) {
             memberPictureRepository.findFirstByMemberAndMemberPicturesDeletedAtNullAndPicture_PictureDeletedAtNullOrderByPicture_PictureCreatedAtDesc(member)
                     .ifPresentOrElse(
@@ -113,8 +119,30 @@ public class MemberPictureCommandServiceImpl implements MemberPictureCommandServ
                             () -> member.updateProfilePicture(null)
                     );
         }
+    }
 
-        // todo 썸네일 생성 이후 삭제를 진행해야 함 S3에 업로드 및 삭제 과정에 대한 고려 후 개발 진행
+    /**
+     * 주어진 Picture와 MemberPicture 객체를 사용하여 해당 사진 및 관련 정보를 삭제합니다.
+     */
+    private void deleteProfileAndThumbnailImageFromS3AndDB(Picture picture, MemberPicture memberPicture) {
+        pictureService.deletePictureFromS3AndDB(picture);
+        memberPicture.deleteMemberPicture();
+    }
+
+    /**
+     * 주어진 회원과 사진 정보를 검증하고, 해당 회원과 연관된 MemberPicture 정보를 반환합니다.
+     */
+    private MemberPicture validateAndGetMemberPicture(Member member, Picture picture) {
+        return memberPictureRepository.findByMemberAndPicture_IdAndPicture_PictureDeletedAtNull(member, picture.getId())
+                .orElseThrow(() -> new CustomException(ErrorCode.AUTHORIZATION_DENIED));
+    }
+
+    /**
+     * 주어진 사진 ID를 기반으로 사진 정보를 조회합니다.
+     * 사진 정보를 찾을 수 없는 경우 예외를 발생시킵니다.
+     */
+    private Picture getPicture(Long pictureId) {
+        return pictureRepository.findById(pictureId).orElseThrow(() -> new CustomException(ErrorCode.PICTURE_NOT_FOUND));
     }
 
     /**

--- a/src/test/java/com/project200/undabang/member/repository/impl/MemberRepositoryImplTest.java
+++ b/src/test/java/com/project200/undabang/member/repository/impl/MemberRepositoryImplTest.java
@@ -1,0 +1,193 @@
+package com.project200.undabang.member.repository.impl;
+
+import com.project200.undabang.configuration.TestQuerydslConfig;
+import com.project200.undabang.exercise.entity.Exercise;
+import com.project200.undabang.member.entity.Member;
+import com.project200.undabang.member.enums.MemberGender;
+import com.project200.undabang.member.repository.MemberRepository;
+import jakarta.persistence.EntityManager;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DataJpaTest
+@Import(TestQuerydslConfig.class)
+class MemberRepositoryImplTest {
+    @Autowired
+    private EntityManager em;
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    // Helper Methods
+    private Member createAndSaveMember(String nickname) {
+        Member member = Member.builder()
+                .memberId(UUID.randomUUID())
+                .memberEmail(nickname + "@email.com")
+                .memberNickname(nickname)
+                .memberGender(MemberGender.UNKNOWN)
+                .memberBday(LocalDate.of(2000, 1, 1))
+                .build();
+        em.persist(member);
+        return member;
+    }
+
+    private Exercise createAndSaveExercise(Member member, LocalDateTime startedAt) {
+        Exercise exercise = Exercise.builder()
+                .member(member)
+                .exerciseTitle("testTitle")
+                .exerciseStartedAt(startedAt)
+                .exerciseEndedAt(startedAt.plusHours(1))
+                .build();
+        em.persist(exercise);
+        return exercise;
+    }
+
+    private void flushAndClear() {
+        em.flush();
+        em.clear();
+    }
+
+    @Nested
+    @DisplayName("countMemberExerciseInLastDays 메소드는")
+    class Describe_countMemberExerciseInLastDays {
+
+        @Test
+        @DisplayName("주어진 기간 내의 삭제되지 않은 운동 기록 개수를 정확히 반환한다")
+        void it_returns_correct_count_of_non_deleted_exercises_within_period() {
+            // given
+            Member testMember = createAndSaveMember("testUser");
+            Member anotherMember = createAndSaveMember("anotherUser");
+
+            // 기간 내 운동 기록
+            createAndSaveExercise(testMember, LocalDateTime.now()); // 오늘
+            createAndSaveExercise(testMember, LocalDateTime.now().minusDays(3)); // 3일 전
+            createAndSaveExercise(testMember, LocalDateTime.now().minusDays(6)); // 6일 전
+
+            // 기간 밖 운동 기록
+            createAndSaveExercise(testMember, LocalDateTime.now().minusDays(8)); // 8일 전
+
+            // 삭제된 운동 기록
+            Exercise deletedExercise = createAndSaveExercise(testMember, LocalDateTime.now().minusDays(1));
+            deletedExercise.deleteExercise();
+            em.persist(deletedExercise);
+
+            // 다른 사용자의 운동 기록
+            createAndSaveExercise(anotherMember, LocalDateTime.now().minusDays(2));
+
+            flushAndClear();
+
+            // when
+            Long exerciseCount = memberRepository.countMemberExerciseInLastDays(testMember.getMemberId(), 7);
+
+            // then
+            assertThat(exerciseCount).isEqualTo(3);
+        }
+
+        @Test
+        @DisplayName("기간 내에 운동 기록이 없으면 0을 반환한다")
+        void it_returns_zero_when_no_exercises_in_period() {
+            // given
+            Member testMember = createAndSaveMember("testUser");
+            createAndSaveExercise(testMember, LocalDateTime.now().minusDays(10));
+            flushAndClear();
+
+            // when
+            Long exerciseCount = memberRepository.countMemberExerciseInLastDays(testMember.getMemberId(), 7);
+
+            // then
+            assertThat(exerciseCount).isEqualTo(0);
+        }
+
+        @Test
+        @DisplayName("운동 기록이 전혀 없으면 0을 반환한다")
+        void it_returns_zero_when_no_exercises_at_all() {
+            // given
+            Member testMember = createAndSaveMember("testUser");
+            flushAndClear();
+
+            // when
+            Long exerciseCount = memberRepository.countMemberExerciseInLastDays(testMember.getMemberId(), 30);
+
+            // then
+            assertThat(exerciseCount).isEqualTo(0);
+        }
+    }
+
+    @Nested
+    @DisplayName("countMemberExerciseInThisYear 메소드는")
+    class Describe_countMemberExerciseInThisYear {
+
+        @Test
+        @DisplayName("올해 수행한 운동 일수(중복 제외)를 정확히 반환한다")
+        void it_returns_correct_distinct_day_count_in_this_year() {
+            // given
+            Member testMember = createAndSaveMember("testUser");
+            Member anotherMember = createAndSaveMember("anotherUser");
+            LocalDateTime now = LocalDateTime.now();
+
+            // 올해 운동 기록 (중복된 날짜 포함)
+            createAndSaveExercise(testMember, now); // 오늘
+            createAndSaveExercise(testMember, now.minusHours(1)); // 오늘
+            createAndSaveExercise(testMember, now.minusDays(1)); // 어제
+
+            // 작년 운동 기록
+            createAndSaveExercise(testMember, now.minusYears(1));
+
+            // 삭제된 운동 기록
+            Exercise deletedExercise = createAndSaveExercise(testMember, now.minusDays(2));
+            deletedExercise.deleteExercise();
+            em.persist(deletedExercise);
+
+            // 다른 사용자의 운동 기록
+            createAndSaveExercise(anotherMember, now);
+
+            flushAndClear();
+
+            // when
+            Long exerciseDays = memberRepository.countMemberExerciseInThisYear(testMember.getMemberId());
+
+            // then
+            // 오늘, 어제 -> 2일
+            assertThat(exerciseDays).isEqualTo(2);
+        }
+
+        @Test
+        @DisplayName("올해 운동 기록이 없으면 0을 반환한다")
+        void it_returns_zero_when_no_exercises_in_this_year() {
+            // given
+            Member testMember = createAndSaveMember("testUser");
+            createAndSaveExercise(testMember, LocalDateTime.now().minusYears(1));
+            flushAndClear();
+
+            // when
+            Long exerciseDays = memberRepository.countMemberExerciseInThisYear(testMember.getMemberId());
+
+            // then
+            assertThat(exerciseDays).isEqualTo(0);
+        }
+
+        @Test
+        @DisplayName("운동 기록이 전혀 없으면 0을 반환한다")
+        void it_returns_zero_when_no_exercises_at_all() {
+            // given
+            Member testMember = createAndSaveMember("testUser");
+            flushAndClear();
+
+            // when
+            Long exerciseDays = memberRepository.countMemberExerciseInThisYear(testMember.getMemberId());
+
+            // then
+            assertThat(exerciseDays).isEqualTo(0);
+        }
+    }
+}

--- a/src/test/java/com/project200/undabang/member/service/impl/MemberPictureCommandServiceImplTest.java
+++ b/src/test/java/com/project200/undabang/member/service/impl/MemberPictureCommandServiceImplTest.java
@@ -18,7 +18,6 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.BDDMockito;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -97,9 +96,9 @@ class MemberPictureCommandServiceImplTest {
                 assertThat(testMember.getMemberPicture()).as("Member 객체의 프로필 사진이 업데이트되어야 함").isEqualTo(savedMemberPicture);
 
                 // Mock 객체들의 상호작용 검증
-                then(memberRepository).should(BDDMockito.times(1)).findById(testUserId);
-                then(pictureService).should(BDDMockito.times(1)).uploadPictureToS3AndDB(mockFile, FileType.PROFILE);
-                then(memberPictureRepository).should(BDDMockito.times(1)).save(any(MemberPicture.class));
+                then(memberRepository).should(times(1)).findById(testUserId);
+                then(pictureService).should(times(1)).uploadPictureToS3AndDB(mockFile, FileType.PROFILE);
+                then(memberPictureRepository).should(times(1)).save(any(MemberPicture.class));
             }
         }
     }
@@ -126,9 +125,9 @@ class MemberPictureCommandServiceImplTest {
                         .hasFieldOrPropertyWithValue("errorCode", ErrorCode.MEMBER_NOT_FOUND);
 
                 // 실패했으므로 PictureService나 MemberPictureRepository는 호출되지 않아야 함
-                then(pictureService).should(BDDMockito.never()).uploadPictureToS3AndDB(any(MultipartFile.class), any(FileType.class));
-                then(pictureService).should(BDDMockito.never()).uploadPictureToS3AndDB(any(MultipartFile.class), any(String.class));
-                then(memberPictureRepository).should(BDDMockito.never()).save(any());
+                then(pictureService).should(never()).uploadPictureToS3AndDB(any(MultipartFile.class), any(FileType.class));
+                then(pictureService).should(never()).uploadPictureToS3AndDB(any(MultipartFile.class), any(String.class));
+                then(memberPictureRepository).should(never()).save(any());
             }
         }
 
@@ -154,7 +153,7 @@ class MemberPictureCommandServiceImplTest {
                         .hasFieldOrPropertyWithValue("errorCode", ErrorCode.PICTURE_UPLOAD_FAILED);
 
                 // 실패했으므로 MemberPictureRepository는 호출되지 않아야 함
-                then(memberPictureRepository).should(BDDMockito.never()).save(any());
+                then(memberPictureRepository).should(never()).save(any());
             }
         }
 
@@ -182,8 +181,8 @@ class MemberPictureCommandServiceImplTest {
                         .hasMessage("Database save error");
 
                 // 상위 로직들이 정상적으로 1번씩 호출되었는지 검증
-                then(memberRepository).should(BDDMockito.times(1)).findById(testUserId);
-                then(pictureService).should(BDDMockito.times(1)).uploadPictureToS3AndDB(mockFile, FileType.PROFILE);
+                then(memberRepository).should(times(1)).findById(testUserId);
+                then(pictureService).should(times(1)).uploadPictureToS3AndDB(mockFile, FileType.PROFILE);
             }
         }
     }
@@ -269,8 +268,8 @@ class MemberPictureCommandServiceImplTest {
                         .hasFieldOrPropertyWithValue("errorCode", ErrorCode.MEMBER_NOT_FOUND);
 
                 // 이후 로직이 호출되지 않았는지 검증
-                then(pictureRepository).should(BDDMockito.never()).existsByIdAndPictureDeletedAtNull(any());
-                then(memberPictureRepository).should(BDDMockito.never()).findByMemberAndPicture_IdAndPicture_PictureDeletedAtNull(any(), any());
+                then(pictureRepository).should(never()).existsByIdAndPictureDeletedAtNull(any());
+                then(memberPictureRepository).should(never()).findByMemberAndPicture_IdAndPicture_PictureDeletedAtNull(any(), any());
             }
         }
 
@@ -292,7 +291,7 @@ class MemberPictureCommandServiceImplTest {
                         .isInstanceOf(CustomException.class)
                         .hasFieldOrPropertyWithValue("errorCode", ErrorCode.PICTURE_NOT_FOUND);
 
-                then(memberPictureRepository).should(BDDMockito.never()).findByMemberAndPicture_IdAndPicture_PictureDeletedAtNull(any(), any());
+                then(memberPictureRepository).should(never()).findByMemberAndPicture_IdAndPicture_PictureDeletedAtNull(any(), any());
             }
         }
 

--- a/src/test/java/com/project200/undabang/member/service/impl/MemberPictureCommandServiceImplTest.java
+++ b/src/test/java/com/project200/undabang/member/service/impl/MemberPictureCommandServiceImplTest.java
@@ -32,7 +32,9 @@ import java.util.UUID;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.BDDMockito.*;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
 class MemberPictureCommandServiceImplTest {
@@ -72,14 +74,14 @@ class MemberPictureCommandServiceImplTest {
 
             MemberPicture savedMemberPicture = MemberPicture.from(testMember, savedPicture);
 
-            try (var ignored = BDDMockito.mockStatic(UserContextHolder.class)) {
+            try (var ignored = mockStatic(UserContextHolder.class)) {
                 // Mocking static method
-                BDDMockito.given(UserContextHolder.getUserId()).willReturn(testUserId);
+                given(UserContextHolder.getUserId()).willReturn(testUserId);
 
                 // Mocking repository and service calls
-                BDDMockito.given(memberRepository.findById(testUserId)).willReturn(Optional.of(testMember));
-                BDDMockito.given(pictureService.uploadPictureToS3AndDB(mockFile, FileType.PROFILE)).willReturn(savedPicture);
-                BDDMockito.given(memberPictureRepository.save(any(MemberPicture.class))).willReturn(savedMemberPicture);
+                given(memberRepository.findById(testUserId)).willReturn(Optional.of(testMember));
+                given(pictureService.uploadPictureToS3AndDB(mockFile, FileType.PROFILE)).willReturn(savedPicture);
+                given(memberPictureRepository.save(any(MemberPicture.class))).willReturn(savedMemberPicture);
 
                 // when
                 CreateProfilePictureResponse result = memberPictureCommandService.createProfilePicture(mockFile);
@@ -95,9 +97,9 @@ class MemberPictureCommandServiceImplTest {
                 assertThat(testMember.getMemberPicture()).as("Member 객체의 프로필 사진이 업데이트되어야 함").isEqualTo(savedMemberPicture);
 
                 // Mock 객체들의 상호작용 검증
-                BDDMockito.then(memberRepository).should(BDDMockito.times(1)).findById(testUserId);
-                BDDMockito.then(pictureService).should(BDDMockito.times(1)).uploadPictureToS3AndDB(mockFile, FileType.PROFILE);
-                BDDMockito.then(memberPictureRepository).should(BDDMockito.times(1)).save(any(MemberPicture.class));
+                then(memberRepository).should(BDDMockito.times(1)).findById(testUserId);
+                then(pictureService).should(BDDMockito.times(1)).uploadPictureToS3AndDB(mockFile, FileType.PROFILE);
+                then(memberPictureRepository).should(BDDMockito.times(1)).save(any(MemberPicture.class));
             }
         }
     }
@@ -113,9 +115,9 @@ class MemberPictureCommandServiceImplTest {
             UUID testUserId = UUID.randomUUID();
             MultipartFile mockFile = createTestMultipartFile();
 
-            try (var ignored = BDDMockito.mockStatic(UserContextHolder.class)) {
-                BDDMockito.given(UserContextHolder.getUserId()).willReturn(testUserId);
-                BDDMockito.given(memberRepository.findById(testUserId)).willReturn(Optional.empty());
+            try (var ignored = mockStatic(UserContextHolder.class)) {
+                given(UserContextHolder.getUserId()).willReturn(testUserId);
+                given(memberRepository.findById(testUserId)).willReturn(Optional.empty());
 
                 // when & then
                 assertThatThrownBy(() -> memberPictureCommandService.createProfilePicture(mockFile))
@@ -124,9 +126,9 @@ class MemberPictureCommandServiceImplTest {
                         .hasFieldOrPropertyWithValue("errorCode", ErrorCode.MEMBER_NOT_FOUND);
 
                 // 실패했으므로 PictureService나 MemberPictureRepository는 호출되지 않아야 함
-                BDDMockito.then(pictureService).should(BDDMockito.never()).uploadPictureToS3AndDB(any(MultipartFile.class), any(FileType.class));
-                BDDMockito.then(pictureService).should(BDDMockito.never()).uploadPictureToS3AndDB(any(MultipartFile.class), any(String.class));
-                BDDMockito.then(memberPictureRepository).should(BDDMockito.never()).save(any());
+                then(pictureService).should(BDDMockito.never()).uploadPictureToS3AndDB(any(MultipartFile.class), any(FileType.class));
+                then(pictureService).should(BDDMockito.never()).uploadPictureToS3AndDB(any(MultipartFile.class), any(String.class));
+                then(memberPictureRepository).should(BDDMockito.never()).save(any());
             }
         }
 
@@ -138,11 +140,11 @@ class MemberPictureCommandServiceImplTest {
             Member testMember = createTestMember(testUserId);
             MultipartFile mockFile = createTestMultipartFile();
 
-            try (var ignored = BDDMockito.mockStatic(UserContextHolder.class)) {
-                BDDMockito.given(UserContextHolder.getUserId()).willReturn(testUserId);
-                BDDMockito.given(memberRepository.findById(testUserId)).willReturn(Optional.of(testMember));
+            try (var ignored = mockStatic(UserContextHolder.class)) {
+                given(UserContextHolder.getUserId()).willReturn(testUserId);
+                given(memberRepository.findById(testUserId)).willReturn(Optional.of(testMember));
                 // PictureService에서 예외 발생 시나리오 Mocking
-                BDDMockito.given(pictureService.uploadPictureToS3AndDB(mockFile, FileType.PROFILE))
+                given(pictureService.uploadPictureToS3AndDB(mockFile, FileType.PROFILE))
                         .willThrow(new CustomException(ErrorCode.PICTURE_UPLOAD_FAILED));
 
                 // when & then
@@ -152,7 +154,7 @@ class MemberPictureCommandServiceImplTest {
                         .hasFieldOrPropertyWithValue("errorCode", ErrorCode.PICTURE_UPLOAD_FAILED);
 
                 // 실패했으므로 MemberPictureRepository는 호출되지 않아야 함
-                BDDMockito.then(memberPictureRepository).should(BDDMockito.never()).save(any());
+                then(memberPictureRepository).should(BDDMockito.never()).save(any());
             }
         }
 
@@ -165,12 +167,12 @@ class MemberPictureCommandServiceImplTest {
             MultipartFile mockFile = createTestMultipartFile();
             Picture savedPicture = Picture.builder().id(1L).build();
 
-            try (var ignored = BDDMockito.mockStatic(UserContextHolder.class)) {
-                BDDMockito.given(UserContextHolder.getUserId()).willReturn(testUserId);
-                BDDMockito.given(memberRepository.findById(testUserId)).willReturn(Optional.of(testMember));
-                BDDMockito.given(pictureService.uploadPictureToS3AndDB(mockFile, FileType.PROFILE)).willReturn(savedPicture);
+            try (var ignored = mockStatic(UserContextHolder.class)) {
+                given(UserContextHolder.getUserId()).willReturn(testUserId);
+                given(memberRepository.findById(testUserId)).willReturn(Optional.of(testMember));
+                given(pictureService.uploadPictureToS3AndDB(mockFile, FileType.PROFILE)).willReturn(savedPicture);
                 // MemberPictureRepository 저장 시 예외 발생 시나리오 Mocking
-                BDDMockito.given(memberPictureRepository.save(any(MemberPicture.class)))
+                given(memberPictureRepository.save(any(MemberPicture.class)))
                         .willThrow(new RuntimeException("Database save error"));
 
                 // when & then
@@ -180,8 +182,8 @@ class MemberPictureCommandServiceImplTest {
                         .hasMessage("Database save error");
 
                 // 상위 로직들이 정상적으로 1번씩 호출되었는지 검증
-                BDDMockito.then(memberRepository).should(BDDMockito.times(1)).findById(testUserId);
-                BDDMockito.then(pictureService).should(BDDMockito.times(1)).uploadPictureToS3AndDB(mockFile, FileType.PROFILE);
+                then(memberRepository).should(BDDMockito.times(1)).findById(testUserId);
+                then(pictureService).should(BDDMockito.times(1)).uploadPictureToS3AndDB(mockFile, FileType.PROFILE);
             }
         }
     }
@@ -225,12 +227,12 @@ class MemberPictureCommandServiceImplTest {
             Picture testPicture = createTestPicture(pictureId);
             MemberPicture testMemberPicture = createTestMemberPicture(testMember, testPicture);
 
-            try (var ignored = BDDMockito.mockStatic(UserContextHolder.class)) {
+            try (var ignored = mockStatic(UserContextHolder.class)) {
                 // Mocking static method and repository calls
-                BDDMockito.given(UserContextHolder.getUserId()).willReturn(testUserId);
-                BDDMockito.given(memberRepository.findById(testUserId)).willReturn(Optional.of(testMember));
-                BDDMockito.given(pictureRepository.existsByIdAndPictureDeletedAtNull(pictureId)).willReturn(true);
-                BDDMockito.given(memberPictureRepository.findByMemberAndPicture_IdAndPicture_PictureDeletedAtNull(testMember, pictureId))
+                given(UserContextHolder.getUserId()).willReturn(testUserId);
+                given(memberRepository.findById(testUserId)).willReturn(Optional.of(testMember));
+                given(pictureRepository.existsByIdAndPictureDeletedAtNull(pictureId)).willReturn(true);
+                given(memberPictureRepository.findByMemberAndPicture_IdAndPicture_PictureDeletedAtNull(testMember, pictureId))
                         .willReturn(Optional.of(testMemberPicture));
 
                 // when
@@ -244,9 +246,9 @@ class MemberPictureCommandServiceImplTest {
                 assertThat(testMember.getMemberPicture()).isEqualTo(testMemberPicture);
 
                 // Mock 객체 상호작용 검증
-                BDDMockito.then(memberRepository).should().findById(testUserId);
-                BDDMockito.then(pictureRepository).should().existsByIdAndPictureDeletedAtNull(pictureId);
-                BDDMockito.then(memberPictureRepository).should().findByMemberAndPicture_IdAndPicture_PictureDeletedAtNull(testMember, pictureId);
+                then(memberRepository).should().findById(testUserId);
+                then(pictureRepository).should().existsByIdAndPictureDeletedAtNull(pictureId);
+                then(memberPictureRepository).should().findByMemberAndPicture_IdAndPicture_PictureDeletedAtNull(testMember, pictureId);
             }
         }
 
@@ -257,9 +259,9 @@ class MemberPictureCommandServiceImplTest {
             UUID testUserId = UUID.randomUUID();
             Long pictureId = 100L;
 
-            try (var ignored = BDDMockito.mockStatic(UserContextHolder.class)) {
-                BDDMockito.given(UserContextHolder.getUserId()).willReturn(testUserId);
-                BDDMockito.given(memberRepository.findById(testUserId)).willReturn(Optional.empty());
+            try (var ignored = mockStatic(UserContextHolder.class)) {
+                given(UserContextHolder.getUserId()).willReturn(testUserId);
+                given(memberRepository.findById(testUserId)).willReturn(Optional.empty());
 
                 // when & then
                 assertThatThrownBy(() -> memberPictureCommandService.updateRepresentativeProfileImage(pictureId))
@@ -267,8 +269,8 @@ class MemberPictureCommandServiceImplTest {
                         .hasFieldOrPropertyWithValue("errorCode", ErrorCode.MEMBER_NOT_FOUND);
 
                 // 이후 로직이 호출되지 않았는지 검증
-                BDDMockito.then(pictureRepository).should(BDDMockito.never()).existsByIdAndPictureDeletedAtNull(any());
-                BDDMockito.then(memberPictureRepository).should(BDDMockito.never()).findByMemberAndPicture_IdAndPicture_PictureDeletedAtNull(any(), any());
+                then(pictureRepository).should(BDDMockito.never()).existsByIdAndPictureDeletedAtNull(any());
+                then(memberPictureRepository).should(BDDMockito.never()).findByMemberAndPicture_IdAndPicture_PictureDeletedAtNull(any(), any());
             }
         }
 
@@ -280,17 +282,17 @@ class MemberPictureCommandServiceImplTest {
             Long pictureId = 100L;
             Member testMember = createTestMember(testUserId);
 
-            try (var ignored = BDDMockito.mockStatic(UserContextHolder.class)) {
-                BDDMockito.given(UserContextHolder.getUserId()).willReturn(testUserId);
-                BDDMockito.given(memberRepository.findById(testUserId)).willReturn(Optional.of(testMember));
-                BDDMockito.given(pictureRepository.existsByIdAndPictureDeletedAtNull(pictureId)).willReturn(false);
+            try (var ignored = mockStatic(UserContextHolder.class)) {
+                given(UserContextHolder.getUserId()).willReturn(testUserId);
+                given(memberRepository.findById(testUserId)).willReturn(Optional.of(testMember));
+                given(pictureRepository.existsByIdAndPictureDeletedAtNull(pictureId)).willReturn(false);
 
                 // when & then
                 assertThatThrownBy(() -> memberPictureCommandService.updateRepresentativeProfileImage(pictureId))
                         .isInstanceOf(CustomException.class)
                         .hasFieldOrPropertyWithValue("errorCode", ErrorCode.PICTURE_NOT_FOUND);
 
-                BDDMockito.then(memberPictureRepository).should(BDDMockito.never()).findByMemberAndPicture_IdAndPicture_PictureDeletedAtNull(any(), any());
+                then(memberPictureRepository).should(BDDMockito.never()).findByMemberAndPicture_IdAndPicture_PictureDeletedAtNull(any(), any());
             }
         }
 
@@ -302,12 +304,12 @@ class MemberPictureCommandServiceImplTest {
             Long pictureId = 100L;
             Member testMember = createTestMember(testUserId);
 
-            try (var ignored = BDDMockito.mockStatic(UserContextHolder.class)) {
-                BDDMockito.given(UserContextHolder.getUserId()).willReturn(testUserId);
-                BDDMockito.given(memberRepository.findById(testUserId)).willReturn(Optional.of(testMember));
-                BDDMockito.given(pictureRepository.existsByIdAndPictureDeletedAtNull(pictureId)).willReturn(true);
+            try (var ignored = mockStatic(UserContextHolder.class)) {
+                given(UserContextHolder.getUserId()).willReturn(testUserId);
+                given(memberRepository.findById(testUserId)).willReturn(Optional.of(testMember));
+                given(pictureRepository.existsByIdAndPictureDeletedAtNull(pictureId)).willReturn(true);
                 // 사용자의 사진이 아니므로 empty Optional 반환
-                BDDMockito.given(memberPictureRepository.findByMemberAndPicture_IdAndPicture_PictureDeletedAtNull(testMember, pictureId))
+                given(memberPictureRepository.findByMemberAndPicture_IdAndPicture_PictureDeletedAtNull(testMember, pictureId))
                         .willReturn(Optional.empty());
 
                 // when & then
@@ -332,9 +334,9 @@ class MemberPictureCommandServiceImplTest {
 
             Member testMember = createTestMember(testUserId);
             Picture pictureToDelete = createTestPicture(pictureToDeleteId);
-            MemberPicture memberPictureToDelete = createTestMemberPicture(testMember, pictureToDelete);
+            // memberPictureToDelete 객체를 spy로 생성하여 deleteMemberPicture 메서드 호출을 추적
+            MemberPicture memberPictureToDelete = spy(createTestMemberPicture(testMember, pictureToDelete));
 
-            // 현재 대표 사진은 다른 사진으로 설정
             Picture representativePicture = createTestPicture(representativePictureId);
             MemberPicture representativeMemberPicture = createTestMemberPicture(testMember, representativePicture);
             testMember.updateProfilePicture(representativeMemberPicture);
@@ -344,18 +346,17 @@ class MemberPictureCommandServiceImplTest {
                 given(UserContextHolder.getUserId()).willReturn(testUserId);
                 given(memberRepository.findById(testUserId)).willReturn(Optional.of(testMember));
                 given(pictureRepository.findById(pictureToDeleteId)).willReturn(Optional.of(pictureToDelete));
-                given(memberPictureRepository.findByMemberAndPicture_IdAndPicture_PictureDeletedAtNull(testMember, pictureToDeleteId))
+                given(memberPictureRepository.findByMemberAndPicture_IdAndPicture_PictureDeletedAtNull(testMember, pictureToDelete.getId()))
                         .willReturn(Optional.of(memberPictureToDelete));
-
-                // pictureService의 삭제 메서드는 void이므로 doNothing() 처리
                 doNothing().when(pictureService).deletePictureFromS3AndDB(pictureToDelete);
 
                 // when
                 memberPictureCommandService.deleteProfilePicture(pictureToDeleteId);
 
                 // then
-                // 1. 서비스/레포지토리 호출 검증
+                // 1. 서비스/레포지토리/객체 메서드 호출 검증
                 then(pictureService).should(times(1)).deletePictureFromS3AndDB(pictureToDelete);
+                then(memberPictureToDelete).should(times(1)).deleteMemberPicture(); // spy 객체의 메서드 호출 검증
                 // 대표 사진이 아니므로, 새 대표 사진을 찾는 로직은 호출되지 않아야 함
                 then(memberPictureRepository).should(never()).findFirstByMemberAndMemberPicturesDeletedAtNullAndPicture_PictureDeletedAtNullOrderByPicture_PictureCreatedAtDesc(any(Member.class));
 
@@ -373,12 +374,10 @@ class MemberPictureCommandServiceImplTest {
 
             Member testMember = createTestMember(testUserId);
             Picture pictureToDelete = createTestPicture(pictureToDeleteId);
-            MemberPicture memberPictureToDelete = createTestMemberPicture(testMember, pictureToDelete);
+            MemberPicture memberPictureToDelete = spy(createTestMemberPicture(testMember, pictureToDelete));
 
-            // 삭제할 사진을 현재 대표 사진으로 설정
             testMember.updateProfilePicture(memberPictureToDelete);
 
-            // 새로 대표 사진이 될 후보 사진 설정
             Picture newRepresentativePicture = createTestPicture(200L);
             MemberPicture newRepresentativeMemberPicture = createTestMemberPicture(testMember, newRepresentativePicture);
 
@@ -387,13 +386,10 @@ class MemberPictureCommandServiceImplTest {
                 given(UserContextHolder.getUserId()).willReturn(testUserId);
                 given(memberRepository.findById(testUserId)).willReturn(Optional.of(testMember));
                 given(pictureRepository.findById(pictureToDeleteId)).willReturn(Optional.of(pictureToDelete));
-                given(memberPictureRepository.findByMemberAndPicture_IdAndPicture_PictureDeletedAtNull(testMember, pictureToDeleteId))
+                given(memberPictureRepository.findByMemberAndPicture_IdAndPicture_PictureDeletedAtNull(testMember, pictureToDelete.getId()))
                         .willReturn(Optional.of(memberPictureToDelete));
-
-                // 새 대표 사진을 찾는 쿼리가 newRepresentativeMemberPicture를 반환하도록 설정
                 given(memberPictureRepository.findFirstByMemberAndMemberPicturesDeletedAtNullAndPicture_PictureDeletedAtNullOrderByPicture_PictureCreatedAtDesc(testMember))
                         .willReturn(Optional.of(newRepresentativeMemberPicture));
-
                 doNothing().when(pictureService).deletePictureFromS3AndDB(pictureToDelete);
 
                 // when
@@ -401,9 +397,9 @@ class MemberPictureCommandServiceImplTest {
 
                 // then
                 then(pictureService).should(times(1)).deletePictureFromS3AndDB(pictureToDelete);
+                then(memberPictureToDelete).should(times(1)).deleteMemberPicture();
                 then(memberPictureRepository).should(times(1)).findFirstByMemberAndMemberPicturesDeletedAtNullAndPicture_PictureDeletedAtNullOrderByPicture_PictureCreatedAtDesc(testMember);
 
-                // Member의 대표 사진이 새로운 사진으로 교체되었는지 검증
                 assertThat(testMember.getMemberPicture()).isEqualTo(newRepresentativeMemberPicture);
             }
         }
@@ -417,7 +413,7 @@ class MemberPictureCommandServiceImplTest {
 
             Member testMember = createTestMember(testUserId);
             Picture pictureToDelete = createTestPicture(pictureToDeleteId);
-            MemberPicture memberPictureToDelete = createTestMemberPicture(testMember, pictureToDelete);
+            MemberPicture memberPictureToDelete = spy(createTestMemberPicture(testMember, pictureToDelete));
             testMember.updateProfilePicture(memberPictureToDelete);
 
             try (var ignored = mockStatic(UserContextHolder.class)) {
@@ -425,13 +421,10 @@ class MemberPictureCommandServiceImplTest {
                 given(UserContextHolder.getUserId()).willReturn(testUserId);
                 given(memberRepository.findById(testUserId)).willReturn(Optional.of(testMember));
                 given(pictureRepository.findById(pictureToDeleteId)).willReturn(Optional.of(pictureToDelete));
-                given(memberPictureRepository.findByMemberAndPicture_IdAndPicture_PictureDeletedAtNull(testMember, pictureToDeleteId))
+                given(memberPictureRepository.findByMemberAndPicture_IdAndPicture_PictureDeletedAtNull(testMember, pictureToDelete.getId()))
                         .willReturn(Optional.of(memberPictureToDelete));
-
-                // 새 대표 사진을 찾는 쿼리가 빈 Optional을 반환하도록 설정 (다른 사진 없음)
                 given(memberPictureRepository.findFirstByMemberAndMemberPicturesDeletedAtNullAndPicture_PictureDeletedAtNullOrderByPicture_PictureCreatedAtDesc(testMember))
                         .willReturn(Optional.empty());
-
                 doNothing().when(pictureService).deletePictureFromS3AndDB(pictureToDelete);
 
                 // when
@@ -439,9 +432,9 @@ class MemberPictureCommandServiceImplTest {
 
                 // then
                 then(pictureService).should(times(1)).deletePictureFromS3AndDB(pictureToDelete);
+                then(memberPictureToDelete).should(times(1)).deleteMemberPicture();
                 then(memberPictureRepository).should(times(1)).findFirstByMemberAndMemberPicturesDeletedAtNullAndPicture_PictureDeletedAtNullOrderByPicture_PictureCreatedAtDesc(testMember);
 
-                // Member의 대표 사진이 null로 설정되었는지 검증
                 assertThat(testMember.getMemberPicture()).isNull();
             }
         }
@@ -457,7 +450,6 @@ class MemberPictureCommandServiceImplTest {
             try (var ignored = mockStatic(UserContextHolder.class)) {
                 given(UserContextHolder.getUserId()).willReturn(testUserId);
                 given(memberRepository.findById(testUserId)).willReturn(Optional.of(testMember));
-                // PictureRepository가 빈 Optional을 반환하도록 설정
                 given(pictureRepository.findById(pictureId)).willReturn(Optional.empty());
 
                 // when & then
@@ -484,8 +476,7 @@ class MemberPictureCommandServiceImplTest {
                 given(UserContextHolder.getUserId()).willReturn(testUserId);
                 given(memberRepository.findById(testUserId)).willReturn(Optional.of(testMember));
                 given(pictureRepository.findById(pictureId)).willReturn(Optional.of(testPicture));
-                // MemberPictureRepository가 빈 Optional을 반환하도록 설정 (권한 없음 케이스)
-                given(memberPictureRepository.findByMemberAndPicture_IdAndPicture_PictureDeletedAtNull(testMember, pictureId))
+                given(memberPictureRepository.findByMemberAndPicture_IdAndPicture_PictureDeletedAtNull(testMember, testPicture.getId()))
                         .willReturn(Optional.empty());
 
                 // when & then
@@ -497,4 +488,5 @@ class MemberPictureCommandServiceImplTest {
             }
         }
     }
+
 }


### PR DESCRIPTION
## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

이전에 작업한 프로필 삭제 기능을 헬퍼 메소드 기반으로 리팩토링 하였습니다.

테스트 코드는 100%를 유지하였습니다.

### 스크린샷 (선택)
<img width="721" height="295" alt="image" src="https://github.com/user-attachments/assets/00788bd2-f9bb-4f9d-bc44-dfcbf28b4e9b" />


Closes #263 