### PR TITLE
[Feat] 운동 장소 이름 변경 API

### DIFF
--- a/src/docs/asciidoc/exercise-location/운동-장소-이름-수정-API.adoc
+++ b/src/docs/asciidoc/exercise-location/운동-장소-이름-수정-API.adoc
@@ -1,0 +1,36 @@
+== 운동 장소 이름 수정 API
+
+=== 설명
+
+- #PATCH# `/api/v1/exercise-locations/{locationId}`
+- 회원이 자신이 등록한 운동 장소의 이름을 수정하는 API 입니다.
+- 회원은 이미 보유하고 있는 운동 장소명으로 새로운 운동 장소 이름을 설정할 수 없습니다.
+- 운동 장소 명은 최소 1글자 최대 100글자 이내 여야 합니다.
+
+=== 개발 이력
+
+- Sprint 12 (2025-09-25): 기능 개발이 완료되었습니다.
+
+=== 개발 참고 사항
+
+- <<공통-개발-참고-사항,공통 개발 참고 사항>>을 참고하세요.
+
+=== 코드 샘플
+
+operation::update-exercise-location/update-exercise-location_-success[snippets="curl-request,http-request,http-response"]
+
+=== 매개 변수
+
+operation::update-exercise-location/update-exercise-location_-success[snippets="request-headers,path-parameters,request-fields,response-fields"]
+
+==== 응답 상태 코드
+
+|===
+|상태 코드|설명
+|201|리소스가 성공적으로 생성되었습니다.
+|401|인증되지 않은 요청입니다. Access Token이 없거나 유효하지 않습니다
+|404|존재하지 않는 회원입니다. +
+존재하지 않는 운동 장소 입니다.
+|409|이미 사용중인 운동 장소 이름 입니다
+|===
+

--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -185,3 +185,5 @@ include::overview/공통-개발-참고-사항.adoc[]
 - 운동 장소 목록 조회 API #GET# `/api/v1/exercise-locations`
 
 - 운동 장소 생성 API #POST# `/api/v1/exercise-locations`
+
+- 운동 장소 이름 수정 API #PATCH# `/api/v1/exercise-locations/{locationId}`

--- a/src/docs/asciidoc/운동-장소-API.adoc
+++ b/src/docs/asciidoc/운동-장소-API.adoc
@@ -22,3 +22,5 @@ include::overview/공통-개발-참고-사항.adoc[]
 include::exercise-location/운동-장소-목록-조회-API.adoc[]
 
 include::exercise-location/운동-장소-생성-API.adoc[]
+
+include::exercise-location/운동-장소-이름-수정-API.adoc[]

--- a/src/main/java/com/project200/undabang/common/web/exception/ErrorCode.java
+++ b/src/main/java/com/project200/undabang/common/web/exception/ErrorCode.java
@@ -60,7 +60,8 @@ public enum ErrorCode {
 
     // 운동 주소 관련 에러
     EXERCISE_LOCATION_MAX_COUNT_VIOLATION(409, "EXERCISE_LOCATION_MAX_COUNT_VIOLATION", "최대 운동 장소 저장 갯수(10개)를 초과했습니다."),
-    EXERCISE_LOCATION_NAME_DUPLICATED(409, "EXERCISE_LOCATION_NAME_DUPLICATED", "이미 사용중인 운동 장소 명 입니다.");
+    EXERCISE_LOCATION_NAME_DUPLICATED(409, "EXERCISE_LOCATION_NAME_DUPLICATED", "이미 사용중인 운동 장소 명 입니다."),
+    EXERCISE_LOCATION_NOT_FOUND(404, "EXERCISE_LOCATION_NOT_FOUND", "존재하지 않는 운동장소 입니다");
 
     private final HttpStatusCode status;
     private final String code;

--- a/src/main/java/com/project200/undabang/member/controller/location/ExerciseLocationCommandController.java
+++ b/src/main/java/com/project200/undabang/member/controller/location/ExerciseLocationCommandController.java
@@ -2,16 +2,15 @@ package com.project200.undabang.member.controller.location;
 
 import com.project200.undabang.common.web.response.CommonResponse;
 import com.project200.undabang.member.dto.request.CreateExerciseLocationRequest;
+import com.project200.undabang.member.dto.request.UpdateExerciseLocationRequest;
 import com.project200.undabang.member.dto.response.CreateExerciseLocationResponse;
+import com.project200.undabang.member.dto.response.UpdateExerciseLocationResponse;
 import com.project200.undabang.member.service.ExerciseLocationCommandService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
@@ -23,5 +22,12 @@ public class ExerciseLocationCommandController {
     public ResponseEntity<CommonResponse<CreateExerciseLocationResponse>> createExerciseLocation(@Valid @RequestBody CreateExerciseLocationRequest request) {
 
         return ResponseEntity.status(HttpStatus.CREATED).body(CommonResponse.create(exerciseLocationCommandService.createExerciseLocation(request)));
+    }
+
+    @PatchMapping("/v1/exercise-locations/{locationId}")
+    public ResponseEntity<CommonResponse<UpdateExerciseLocationResponse>> updateExerciseLocation(@PathVariable Long locationId,
+                                                                                                 @RequestBody UpdateExerciseLocationRequest request) {
+
+        return ResponseEntity.ok(CommonResponse.update(exerciseLocationCommandService.updateExerciseLocation(locationId, request)));
     }
 }

--- a/src/main/java/com/project200/undabang/member/dto/request/UpdateExerciseLocationRequest.java
+++ b/src/main/java/com/project200/undabang/member/dto/request/UpdateExerciseLocationRequest.java
@@ -1,0 +1,16 @@
+package com.project200.undabang.member.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class UpdateExerciseLocationRequest {
+    @NotBlank
+    @Size(min = 1, max = 100, message = "운동 장소명은 최대 100글자 입력 가능합니다.")
+    private String exerciseLocationName;
+}

--- a/src/main/java/com/project200/undabang/member/dto/response/UpdateExerciseLocationResponse.java
+++ b/src/main/java/com/project200/undabang/member/dto/response/UpdateExerciseLocationResponse.java
@@ -1,0 +1,17 @@
+package com.project200.undabang.member.dto.response;
+
+import com.project200.undabang.member.entity.ExerciseLocation;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class UpdateExerciseLocationResponse {
+    private long id;
+
+    public static UpdateExerciseLocationResponse from(ExerciseLocation exerciseLocation) {
+        return new UpdateExerciseLocationResponse(exerciseLocation.getExerciseLocationId());
+    }
+}

--- a/src/main/java/com/project200/undabang/member/entity/ExerciseLocation.java
+++ b/src/main/java/com/project200/undabang/member/entity/ExerciseLocation.java
@@ -47,4 +47,9 @@ public class ExerciseLocation {
 
     @Comment("운동 장소 삭제 일시 기록")
     private LocalDateTime exerciseLocationDeletedAt;
+
+    public void updateExerciseLocationName(String exerciseLocationName) {
+        this.exerciseLocationName = exerciseLocationName;
+        this.exerciseLocationUpdatedAt = LocalDateTime.now();
+    }
 }

--- a/src/main/java/com/project200/undabang/member/repository/ExerciseLocationRepository.java
+++ b/src/main/java/com/project200/undabang/member/repository/ExerciseLocationRepository.java
@@ -5,6 +5,7 @@ import com.project200.undabang.member.entity.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface ExerciseLocationRepository extends JpaRepository<ExerciseLocation, Long>, ExerciseLocationRepositoryCustom {
     List<ExerciseLocation> findByMemberAndExerciseLocationDeletedAtNull(Member member);
@@ -12,4 +13,6 @@ public interface ExerciseLocationRepository extends JpaRepository<ExerciseLocati
     boolean existsByExerciseLocationNameAndExerciseLocationDeletedAtNull(String exerciseLocationName);
 
     long countByMemberAndExerciseLocationDeletedAtNull(Member member);
+
+    Optional<ExerciseLocation> findByMemberAndExerciseLocationIdAndExerciseLocationDeletedAtNull(Member member, Long exerciseLocationId);
 }

--- a/src/main/java/com/project200/undabang/member/service/ExerciseLocationCommandService.java
+++ b/src/main/java/com/project200/undabang/member/service/ExerciseLocationCommandService.java
@@ -1,8 +1,12 @@
 package com.project200.undabang.member.service;
 
 import com.project200.undabang.member.dto.request.CreateExerciseLocationRequest;
+import com.project200.undabang.member.dto.request.UpdateExerciseLocationRequest;
 import com.project200.undabang.member.dto.response.CreateExerciseLocationResponse;
+import com.project200.undabang.member.dto.response.UpdateExerciseLocationResponse;
 
 public interface ExerciseLocationCommandService {
     CreateExerciseLocationResponse createExerciseLocation(CreateExerciseLocationRequest request);
+
+    UpdateExerciseLocationResponse updateExerciseLocation(Long locationId, UpdateExerciseLocationRequest request);
 }

--- a/src/main/java/com/project200/undabang/member/service/ExerciseLocationCommandService.java
+++ b/src/main/java/com/project200/undabang/member/service/ExerciseLocationCommandService.java
@@ -7,6 +7,5 @@ import com.project200.undabang.member.dto.response.UpdateExerciseLocationRespons
 
 public interface ExerciseLocationCommandService {
     CreateExerciseLocationResponse createExerciseLocation(CreateExerciseLocationRequest request);
-
     UpdateExerciseLocationResponse updateExerciseLocation(Long locationId, UpdateExerciseLocationRequest request);
 }

--- a/src/main/java/com/project200/undabang/member/service/ExerciseLocationQueryService.java
+++ b/src/main/java/com/project200/undabang/member/service/ExerciseLocationQueryService.java
@@ -7,6 +7,5 @@ import java.util.List;
 
 public interface ExerciseLocationQueryService {
     List<GetMembersExerciseLocationsResponse> getMembersExerciseLocations();
-
     List<GetExerciseLocationsResponse> getExerciseLocations();
 }

--- a/src/main/java/com/project200/undabang/member/service/impl/ExerciseLocationCommandServiceImpl.java
+++ b/src/main/java/com/project200/undabang/member/service/impl/ExerciseLocationCommandServiceImpl.java
@@ -4,7 +4,9 @@ import com.project200.undabang.common.context.UserContextHolder;
 import com.project200.undabang.common.web.exception.CustomException;
 import com.project200.undabang.common.web.exception.ErrorCode;
 import com.project200.undabang.member.dto.request.CreateExerciseLocationRequest;
+import com.project200.undabang.member.dto.request.UpdateExerciseLocationRequest;
 import com.project200.undabang.member.dto.response.CreateExerciseLocationResponse;
+import com.project200.undabang.member.dto.response.UpdateExerciseLocationResponse;
 import com.project200.undabang.member.entity.ExerciseLocation;
 import com.project200.undabang.member.entity.Member;
 import com.project200.undabang.member.repository.ExerciseLocationRepository;
@@ -41,6 +43,20 @@ public class ExerciseLocationCommandServiceImpl implements ExerciseLocationComma
         ExerciseLocation savedExerciseLocation = exerciseLocationRepository.save(exerciseLocation);
 
         return CreateExerciseLocationResponse.from(savedExerciseLocation);
+    }
+
+    @Transactional
+    @Override
+    public UpdateExerciseLocationResponse updateExerciseLocation(Long locationId, UpdateExerciseLocationRequest request) {
+        Member member = getMember(UserContextHolder.getUserId());
+
+        ExerciseLocation exerciseLocation = exerciseLocationRepository.findByMemberAndExerciseLocationIdAndExerciseLocationDeletedAtNull(member, locationId).orElseThrow(
+                () -> new CustomException(ErrorCode.EXERCISE_LOCATION_NOT_FOUND)
+        );
+
+        exerciseLocation.updateExerciseLocationName(request.getExerciseLocationName());
+
+        return UpdateExerciseLocationResponse.from(exerciseLocation);
     }
 
     /**

--- a/src/main/java/com/project200/undabang/member/service/impl/ExerciseLocationCommandServiceImpl.java
+++ b/src/main/java/com/project200/undabang/member/service/impl/ExerciseLocationCommandServiceImpl.java
@@ -45,6 +45,10 @@ public class ExerciseLocationCommandServiceImpl implements ExerciseLocationComma
         return CreateExerciseLocationResponse.from(savedExerciseLocation);
     }
 
+    /**
+     * 전달받은 운동 위치 ID와 회원 식별자를 이용하여 운동 위치 정보를 업데이트하는 메서드.
+     * 해당 회원이 소유한 운동 위치가 존재하지 않거나 삭제된 경우 예외를 발생시킵니다.
+     */
     @Transactional
     @Override
     public UpdateExerciseLocationResponse updateExerciseLocation(Long locationId, UpdateExerciseLocationRequest request) {

--- a/src/test/java/com/project200/undabang/member/controller/ExerciseLocationCommandControllerTest.java
+++ b/src/test/java/com/project200/undabang/member/controller/ExerciseLocationCommandControllerTest.java
@@ -1,11 +1,15 @@
-package com.project200.undabang.member.controller.location;
+package com.project200.undabang.member.controller;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.project200.undabang.common.web.exception.CustomException;
 import com.project200.undabang.common.web.exception.ErrorCode;
 import com.project200.undabang.configuration.AbstractRestDocSupport;
+import com.project200.undabang.configuration.RestDocsUtils;
+import com.project200.undabang.member.controller.location.ExerciseLocationCommandController;
 import com.project200.undabang.member.dto.request.CreateExerciseLocationRequest;
+import com.project200.undabang.member.dto.request.UpdateExerciseLocationRequest;
 import com.project200.undabang.member.dto.response.CreateExerciseLocationResponse;
+import com.project200.undabang.member.dto.response.UpdateExerciseLocationResponse;
 import com.project200.undabang.member.service.ExerciseLocationCommandService;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -13,22 +17,29 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.http.MediaType;
+import org.springframework.restdocs.payload.JsonFieldType;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
 import java.util.UUID;
 
+import static com.project200.undabang.configuration.DocumentFormatGenerator.getTypeFormat;
 import static com.project200.undabang.configuration.HeadersGenerator.getCommonApiHeaders;
 import static com.project200.undabang.configuration.RestDocsUtils.HEADER_ACCESS_TOKEN;
 import static com.project200.undabang.configuration.RestDocsUtils.commonResponseFields;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
 import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
 import static org.springframework.restdocs.payload.PayloadDocumentation.*;
+import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
+import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
 
 @WebMvcTest(ExerciseLocationCommandController.class)
 class ExerciseLocationCommandControllerTest extends AbstractRestDocSupport {
@@ -145,6 +156,82 @@ class ExerciseLocationCommandControllerTest extends AbstractRestDocSupport {
 
             // 예외는 발생했지만, 서비스 메소드 자체는 호출되었음을 검증
             then(exerciseLocationCommandService).should().createExerciseLocation(any(CreateExerciseLocationRequest.class));
+        }
+    }
+
+    @Nested
+    @DisplayName("운동 위치 수정 API")
+    class UpdateExerciseLocation {
+
+        @Test
+        @DisplayName("정상적으로 운동 위치 이름을 수정한다")
+        void updateExerciseLocation_Success() throws Exception {
+            // given
+            UUID memberId = UUID.randomUUID();
+            Long locationId = 1L;
+            String newName = "수정된 헬스장";
+            UpdateExerciseLocationRequest request = new UpdateExerciseLocationRequest(newName);
+            UpdateExerciseLocationResponse expectedResponse = new UpdateExerciseLocationResponse(locationId);
+
+            given(exerciseLocationCommandService.updateExerciseLocation(eq(locationId), any(UpdateExerciseLocationRequest.class)))
+                    .willReturn(expectedResponse);
+
+            // when & then
+            mockMvc.perform(patch("/api/v1/exercise-locations/{locationId}", locationId)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .accept(MediaType.APPLICATION_JSON)
+                            .headers(getCommonApiHeaders(memberId))
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andExpectAll(
+                            status().isOk(),
+                            jsonPath("$.succeed").value(true),
+                            jsonPath("$.code").value("UPDATED"),
+                            jsonPath("$.message").value("리소스가 성공적으로 수정되었습니다."),
+                            jsonPath("$.data.id").value(locationId)
+                    ).andDo(document.document(
+                            requestHeaders(
+                                    RestDocsUtils.HEADER_ACCESS_TOKEN
+                            ),
+                            pathParameters(
+                                    parameterWithName("locationId").attributes(getTypeFormat(JsonFieldType.NUMBER))
+                                            .description("수정할 운동 장소의 고유 식별자 정보를 나타냅니다.")
+                            ),
+                            requestFields(
+                                    fieldWithPath("exerciseLocationName").description("수정할 운동 장소의 상호명 혹은 본인이 설정한 이름 입니다.")
+                            ),
+                            responseFields(commonResponseFields(
+                                    fieldWithPath("data.id").description("수정된 운동 장소의 고유 식별자 입니다.")
+                            ))
+                    ));
+
+
+            then(exerciseLocationCommandService).should().updateExerciseLocation(eq(locationId), any(UpdateExerciseLocationRequest.class));
+            then(exerciseLocationCommandService).shouldHaveNoMoreInteractions();
+        }
+
+        @Test
+        @DisplayName("운동 위치가 존재하지 않으면 404 Not Found를 반환한다")
+        void updateExerciseLocation_NotFound() throws Exception {
+            // given
+            UUID memberId = UUID.randomUUID();
+            Long locationId = 999L;
+            UpdateExerciseLocationRequest request = new UpdateExerciseLocationRequest("없는 헬스장");
+
+            given(exerciseLocationCommandService.updateExerciseLocation(eq(locationId), any(UpdateExerciseLocationRequest.class)))
+                    .willThrow(new CustomException(ErrorCode.EXERCISE_LOCATION_NOT_FOUND));
+
+            // when & then
+            mockMvc.perform(patch("/api/v1/exercise-locations/{locationId}", locationId)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .headers(getCommonApiHeaders(memberId))
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andExpectAll(
+                            status().isNotFound(),
+                            jsonPath("$.succeed").value(false),
+                            jsonPath("$.code").value(ErrorCode.EXERCISE_LOCATION_NOT_FOUND.name())
+                    );
+
+            then(exerciseLocationCommandService).should().updateExerciseLocation(eq(locationId), any(UpdateExerciseLocationRequest.class));
         }
     }
 }

--- a/src/test/java/com/project200/undabang/member/repository/impl/ExerciseLocationRepositoryImplTest.java
+++ b/src/test/java/com/project200/undabang/member/repository/impl/ExerciseLocationRepositoryImplTest.java
@@ -22,6 +22,7 @@ import org.springframework.context.annotation.Import;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -333,6 +334,58 @@ class ExerciseLocationRepositoryImplTest {
 
             // then
             assertThat(result).isFalse();
+        }
+    }
+
+    @Nested
+    @DisplayName("findByMemberAndExerciseLocationIdAndExerciseLocationDeletedAtNull 메소드는")
+    class Describe_findByMemberAndExerciseLocationIdAndExerciseLocationDeletedAtNull {
+
+        @Test
+        @DisplayName("해당 회원의 삭제되지 않은 운동 장소를 ID로 조회하면 Optional에 담아 반환한다")
+        void it_returns_location_when_exists_and_not_deleted() {
+            // given
+            Member member = createAndSaveMember("user");
+            ExerciseLocation location = createAndSaveExerciseLocation(member, "헬스장", false);
+            flushAndClear();
+
+            // when
+            Optional<ExerciseLocation> result = exerciseLocationRepository.findByMemberAndExerciseLocationIdAndExerciseLocationDeletedAtNull(member, location.getExerciseLocationId());
+
+            // then
+            assertThat(result).isPresent();
+            assertThat(result.get().getExerciseLocationId()).isEqualTo(location.getExerciseLocationId());
+        }
+
+        @Test
+        @DisplayName("해당 회원의 운동 장소가 삭제된 경우 Optional.empty를 반환한다")
+        void it_returns_empty_when_location_is_deleted() {
+            // given
+            Member member = createAndSaveMember("user");
+            ExerciseLocation location = createAndSaveExerciseLocation(member, "헬스장", true);
+            flushAndClear();
+
+            // when
+            Optional<ExerciseLocation> result = exerciseLocationRepository.findByMemberAndExerciseLocationIdAndExerciseLocationDeletedAtNull(member, location.getExerciseLocationId());
+
+            // then
+            assertThat(result).isEmpty();
+        }
+
+        @Test
+        @DisplayName("해당 회원이 가진 운동 장소가 아닌 경우 Optional.empty를 반환한다")
+        void it_returns_empty_when_location_does_not_belong_to_member() {
+            // given
+            Member member1 = createAndSaveMember("user1");
+            Member member2 = createAndSaveMember("user2");
+            ExerciseLocation location = createAndSaveExerciseLocation(member1, "헬스장", false);
+            flushAndClear();
+
+            // when
+            Optional<ExerciseLocation> result = exerciseLocationRepository.findByMemberAndExerciseLocationIdAndExerciseLocationDeletedAtNull(member2, location.getExerciseLocationId());
+
+            // then
+            assertThat(result).isEmpty();
         }
     }
 }

--- a/src/test/java/com/project200/undabang/member/service/impl/ExerciseLocationCommandServiceImplTest.java
+++ b/src/test/java/com/project200/undabang/member/service/impl/ExerciseLocationCommandServiceImplTest.java
@@ -4,7 +4,9 @@ import com.project200.undabang.common.context.UserContextHolder;
 import com.project200.undabang.common.web.exception.CustomException;
 import com.project200.undabang.common.web.exception.ErrorCode;
 import com.project200.undabang.member.dto.request.CreateExerciseLocationRequest;
+import com.project200.undabang.member.dto.request.UpdateExerciseLocationRequest;
 import com.project200.undabang.member.dto.response.CreateExerciseLocationResponse;
+import com.project200.undabang.member.dto.response.UpdateExerciseLocationResponse;
 import com.project200.undabang.member.entity.ExerciseLocation;
 import com.project200.undabang.member.entity.Member;
 import com.project200.undabang.member.repository.ExerciseLocationRepository;
@@ -172,6 +174,78 @@ class ExerciseLocationCommandServiceImplTest {
                     verify(exerciseLocationRepository, never()).save(any());
                 }
             }
+        }
+    }
+
+    @Nested
+    @DisplayName("updateExerciseLocation 메소드는")
+    class Describe_updateExerciseLocation {
+
+        @Test
+        @DisplayName("해당 회원의 삭제되지 않은 운동장소가 존재하면 이름을 수정하고 응답을 반환한다")
+        void it_updates_location_name_and_returns_response() {
+            // given
+            final UUID MEMBER_ID = UUID.randomUUID();
+            final Long LOCATION_ID = 1L;
+            final String OLD_NAME = "기존 헬스장";
+            final String NEW_NAME = "수정된 헬스장";
+            Member member = createMember(MEMBER_ID, "testUser");
+            ExerciseLocation location = ExerciseLocation.builder()
+                    .exerciseLocationId(LOCATION_ID)
+                    .member(member)
+                    .exerciseLocationName(OLD_NAME)
+                    .build();
+
+            try (MockedStatic<UserContextHolder> mockedUserContext = mockStatic(UserContextHolder.class)) {
+                mockedUserContext.when(UserContextHolder::getUserId).thenReturn(MEMBER_ID);
+                when(memberRepository.findById(MEMBER_ID)).thenReturn(Optional.of(member));
+                when(exerciseLocationRepository.findByMemberAndExerciseLocationIdAndExerciseLocationDeletedAtNull(member, LOCATION_ID))
+                        .thenReturn(Optional.of(location));
+
+                UpdateExerciseLocationRequest request = updateRequest(NEW_NAME);
+
+                // when
+                UpdateExerciseLocationResponse response = exerciseLocationCommandService.updateExerciseLocation(LOCATION_ID, request);
+
+                // then
+                assertThat(response).isNotNull();
+                assertThat(response.getId()).isEqualTo(LOCATION_ID);
+                assertThat(location.getExerciseLocationName()).isEqualTo(NEW_NAME);
+            }
+        }
+
+        @Test
+        @DisplayName("운동장소가 없거나 삭제된 경우 CustomException을 던진다")
+        void it_throws_exception_when_location_not_found() {
+            // given
+            final UUID MEMBER_ID = UUID.randomUUID();
+            final Long LOCATION_ID = 1L;
+            Member member = createMember(MEMBER_ID, "testUser");
+
+            try (MockedStatic<UserContextHolder> mockedUserContext = mockStatic(UserContextHolder.class)) {
+                mockedUserContext.when(UserContextHolder::getUserId).thenReturn(MEMBER_ID);
+                when(memberRepository.findById(MEMBER_ID)).thenReturn(Optional.of(member));
+                when(exerciseLocationRepository.findByMemberAndExerciseLocationIdAndExerciseLocationDeletedAtNull(member, LOCATION_ID))
+                        .thenReturn(Optional.empty());
+
+                UpdateExerciseLocationRequest request = updateRequest("새 이름");
+
+                // when & then
+                assertThatThrownBy(() -> exerciseLocationCommandService.updateExerciseLocation(LOCATION_ID, request))
+                        .isInstanceOf(CustomException.class)
+                        .hasFieldOrPropertyWithValue("errorCode", ErrorCode.EXERCISE_LOCATION_NOT_FOUND);
+            }
+        }
+
+        private UpdateExerciseLocationRequest updateRequest(String newName) {
+            return new UpdateExerciseLocationRequest(newName);
+        }
+
+        private Member createMember(UUID memberId, String nickname) {
+            return Member.builder()
+                    .memberId(memberId)
+                    .memberNickname(nickname)
+                    .build();
         }
     }
 }


### PR DESCRIPTION
## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

운동 장소 이름을 변경하는 기능을 개발하였습니다.

변경감지를 사용하여 운동 장소 이름을 업데이트 하도록 하였으며, 업데이트 뒤에는 업데이트한 엔티티의 식별자를 반환하였습니다.

업데이트시 지금 사용중인 운동 장소 이름일 경우 200 ok를 반환하며, 회원이 등록한 운동장소 이름 목록에 없는 이름일 경우 200 ok를 반환합니다.

에러는 세가지 종류를 반환합니다.

403 : 타인의 운동장소를 조회/수정 하려는 경우
404 : 존재하지 않는 회원이거나, 존재하지 않는 운동기록의 경우(삭제한 경우)
409 : 이미 사용중인 이름으로 변경하려는 경우

### 스크린샷 (선택)
**API 응답 사진입니다.**
<img width="418" height="244" alt="image" src="https://github.com/user-attachments/assets/9b800b8d-91ba-412c-9a35-b0676095f322" />

**API 명세서 사진입니다.**
<img width="978" height="622" alt="image" src="https://github.com/user-attachments/assets/3d3582ef-108b-4885-ae0d-e44236a39874" />
<img width="977" height="635" alt="image" src="https://github.com/user-attachments/assets/cf216f8c-814c-4b46-83b1-5228780a97c3" />
<img width="987" height="778" alt="image" src="https://github.com/user-attachments/assets/227381c8-ebff-4eb3-bf1c-e67c46a52235" />
<img width="984" height="765" alt="image" src="https://github.com/user-attachments/assets/9c7ce3f1-9dfc-407a-8495-e07d790fd937" />
<img width="1006" height="373" alt="image" src="https://github.com/user-attachments/assets/bfb2c38a-61f5-446d-87b5-17f7b0aea09e" />


**테스트코드 사진입니다.**
<img width="720" height="341" alt="image" src="https://github.com/user-attachments/assets/d92077df-c81e-4bd6-978f-ae99daba6e3b" />

Closes #315