### PR TITLE
[Feat] 오픈채팅방 생성 기능 개발 [0.4.7] -> [0.4.8]

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ plugins {
 }
 
 group = 'com.project200'
-version = '0.4.5-SNAPSHOT'
+version = '0.4.8-SNAPSHOT'
 
 java {
     toolchain {

--- a/documents/Undabang SQL/Undabang Database DDL.sql
+++ b/documents/Undabang SQL/Undabang Database DDL.sql
@@ -591,15 +591,27 @@ CREATE TABLE exercise_locations
 
 CREATE TABLE open_chatrooms
 (
-    open_chatroom_id         BIGINT       NOT NULL AUTO_INCREMENT,
-    member_id                CHAR(36)     NOT NULL COMMENT 'UUID_SELF',
-    open_chatroom_url        VARCHAR(255) NULL COMMENT '유효성 검증 필요',
-    open_chatroom_created_at DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    open_chatroom_updated_at DATETIME     NULL,
-    open_chatroom_deleted_at DATETIME     NULL,
+    open_chatroom_id             BIGINT       NOT NULL AUTO_INCREMENT COMMENT 'AUTO_INCREMENT',
+    member_id                    CHAR(36)     NOT NULL COMMENT 'UUID_SELF',
+    open_chatroom_url            VARCHAR(255) NULL COMMENT '유효성 검증 필요',
+    open_chatroom_created_at     DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    open_chatroom_updated_at     DATETIME     NULL,
+    open_chatroom_deleted_at     DATETIME     NULL,
+    member_id_unique_key         BIGINT       NOT NULL DEFAULT 0 COMMENT '활성 레코드의 member_id 유일성 보장을 위한 키. 기본값 0, 삭제 시 자신의 PK 값으로 변경됨',
+    open_chatroom_url_unique_key BIGINT       NOT NULL DEFAULT 0 COMMENT '활성 레코드의 url 유일성 보장을 위한 키. 기본값 0, 삭제 시 자신의 PK 값으로 변경됨',
+
+    -- 기본 키
     CONSTRAINT PK_OPEN_CHATROOMS PRIMARY KEY (open_chatroom_id),
+
+    -- 외래 키
     CONSTRAINT FK_members_TO_open_chatrooms_1 FOREIGN KEY (member_id)
-        REFERENCES members (member_id)
+        REFERENCES members (member_id),
+
+    -- 조건부 UNIQUE 제약조건 1: 활성 상태의 member_id는 유일해야 함
+    CONSTRAINT UK_active_member_id UNIQUE (member_id, member_id_unique_key),
+
+    -- 조건부 UNIQUE 제약조건 2: 활성 상태의 open_chatroom_url은 유일해야 함
+    CONSTRAINT UK_active_url UNIQUE (open_chatroom_url, open_chatroom_url_unique_key)
 );
 
 CREATE TABLE matches

--- a/src/main/java/com/project200/undabang/common/web/exception/ErrorCode.java
+++ b/src/main/java/com/project200/undabang/common/web/exception/ErrorCode.java
@@ -61,7 +61,11 @@ public enum ErrorCode {
     // 운동 주소 관련 에러
     EXERCISE_LOCATION_MAX_COUNT_VIOLATION(409, "EXERCISE_LOCATION_MAX_COUNT_VIOLATION", "최대 운동 장소 저장 갯수(10개)를 초과했습니다."),
     EXERCISE_LOCATION_NAME_DUPLICATED(409, "EXERCISE_LOCATION_NAME_DUPLICATED", "이미 사용중인 운동 장소 명 입니다."),
-    EXERCISE_LOCATION_NOT_FOUND(404, "EXERCISE_LOCATION_NOT_FOUND", "존재하지 않는 운동장소 입니다");
+    EXERCISE_LOCATION_NOT_FOUND(404, "EXERCISE_LOCATION_NOT_FOUND", "존재하지 않는 운동장소 입니다"),
+
+    // 오픈 채팅 관련 에러
+    OPEN_CHAT_ROOM_ALREADY_EXIST(409, "OPEN_CHAT_ROOM_ALREADY_EXIST", "이미 오픈 채팅방을 보유한 회원입니다."),
+    OPEN_CHAT_ROOM_URL_DUPLICATED(409, "OPEN_CHAT_ROOM_URL_DUPLICATED", "이미 사용중인 오픈 채팅 링크입니다");
 
     private final HttpStatusCode status;
     private final String code;

--- a/src/main/java/com/project200/undabang/member/entity/Member.java
+++ b/src/main/java/com/project200/undabang/member/entity/Member.java
@@ -4,6 +4,7 @@ import com.project200.undabang.common.web.exception.CustomException;
 import com.project200.undabang.common.web.exception.ErrorCode;
 import com.project200.undabang.member.dto.command.SignUpMemberCommand;
 import com.project200.undabang.member.enums.MemberGender;
+import com.project200.undabang.openchat.entity.OpenChatRoom;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
@@ -88,6 +89,10 @@ public class Member {
 
     @OneToMany(mappedBy = "member")
     private List<ExerciseLocation> exerciseLocations = new ArrayList<>();
+
+    @OneToOne(mappedBy = "member", fetch = FetchType.LAZY)
+    private OpenChatRoom openChatRoom;
+
 
     /**
      * 회원의 점수를 증가시킵니다. 점수는 정책에 정의된 최소/최대 값을 벗어나지 않습니다.

--- a/src/main/java/com/project200/undabang/openchat/controller/OpenChatRoomCommandController.java
+++ b/src/main/java/com/project200/undabang/openchat/controller/OpenChatRoomCommandController.java
@@ -1,0 +1,28 @@
+package com.project200.undabang.openchat.controller;
+
+import com.project200.undabang.common.web.response.CommonResponse;
+import com.project200.undabang.openchat.dto.request.CreateOpenChatRoomRequest;
+import com.project200.undabang.openchat.dto.response.CreateOpenChatRoomResponse;
+import com.project200.undabang.openchat.service.OpenChatRoomCommandService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api")
+public class OpenChatRoomCommandController {
+
+    private final OpenChatRoomCommandService openChatRoomCommandService;
+
+    @PostMapping("/v1/open-chats")
+    public ResponseEntity<CommonResponse<CreateOpenChatRoomResponse>> createOpenChatRoom(@Valid @RequestBody CreateOpenChatRoomRequest request) {
+
+        return ResponseEntity.status(HttpStatus.CREATED).body(CommonResponse.create(openChatRoomCommandService.createOpenChatRoom(request)));
+    }
+}

--- a/src/main/java/com/project200/undabang/openchat/dto/request/CreateOpenChatRoomRequest.java
+++ b/src/main/java/com/project200/undabang/openchat/dto/request/CreateOpenChatRoomRequest.java
@@ -1,0 +1,18 @@
+package com.project200.undabang.openchat.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class CreateOpenChatRoomRequest {
+
+    @NotBlank(message = "오픈채팅 URL을 입력해주세요.")
+    @Pattern(regexp = "^https?://open\\.kakao\\.com/o/[a-zA-Z0-9]+$",
+            message = "유효하지 않은 카카오 오픈채팅 URL 형식입니다.")
+    private String openChatroomUrl;
+}

--- a/src/main/java/com/project200/undabang/openchat/dto/response/CreateOpenChatRoomResponse.java
+++ b/src/main/java/com/project200/undabang/openchat/dto/response/CreateOpenChatRoomResponse.java
@@ -1,0 +1,16 @@
+package com.project200.undabang.openchat.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class CreateOpenChatRoomResponse {
+    private Long openChatroomId;
+
+    public static CreateOpenChatRoomResponse of(Long openChatroomId) {
+        return new CreateOpenChatRoomResponse(openChatroomId);
+    }
+}

--- a/src/main/java/com/project200/undabang/openchat/entity/OpenChatRoom.java
+++ b/src/main/java/com/project200/undabang/openchat/entity/OpenChatRoom.java
@@ -1,0 +1,66 @@
+package com.project200.undabang.openchat.entity;
+
+import com.project200.undabang.member.entity.Member;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Entity
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Table(name = "open_chatrooms",
+        uniqueConstraints = {
+                @UniqueConstraint(name = "UK_active_member_id", columnNames = {"member_id", "member_id_unique_key"}),
+                @UniqueConstraint(name = "UK_active_url", columnNames = {"open_chatroom_url", "open_chatroom_url_unique_key"})
+        }
+)
+public class OpenChatRoom {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "open_chatroom_id")
+    private Long id;
+
+    @OneToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "member_id", nullable = false)
+    private Member member;
+
+    @Column(name = "open_chatroom_url", length = 255)
+    private String url;
+
+    @Column(name = "open_chatroom_created_at", nullable = false, updatable = false)
+    @Builder.Default
+    private LocalDateTime createdAt = LocalDateTime.now();
+
+    @Column(name = "open_chatroom_updated_at")
+    private LocalDateTime updatedAt;
+
+    @Column(name = "open_chatroom_deleted_at")
+    private LocalDateTime deletedAt;
+
+    @Column(name = "member_id_unique_key", nullable = false)
+    @Builder.Default
+    private Long memberIdUniqueKey = 0L;
+
+    @Column(name = "open_chatroom_url_unique_key", nullable = false)
+    @Builder.Default
+    private Long urlUniqueKey = 0L;
+
+    /**
+     * 주어진 멤버와 오픈 채팅방 URL을 기반으로 OpenChatRoom 객체를 생성합니다.
+     */
+    public static OpenChatRoom of(Member member, String openChatroomUrl) {
+        return OpenChatRoom.builder()
+                .member(member)
+                .url(openChatroomUrl)
+                .createdAt(LocalDateTime.now())
+                .memberIdUniqueKey(0L)
+                .urlUniqueKey(0L)
+                .build();
+    }
+
+    // Todo : 논리적 삭제 구현시 두개의 UNIQUE에 모두 PK 값을 넣어주어야 한다. 그래서 회원은 새로운 채팅방을 만들 수 있고, 다른 회원은 URL을 재사용 할 수 있음(혹시 재사용 하게 된다면)
+}

--- a/src/main/java/com/project200/undabang/openchat/repository/OpenChatRoomRepository.java
+++ b/src/main/java/com/project200/undabang/openchat/repository/OpenChatRoomRepository.java
@@ -1,4 +1,4 @@
-package com.project200.undabang.openchat.respository;
+package com.project200.undabang.openchat.repository;
 
 import com.project200.undabang.member.entity.Member;
 import com.project200.undabang.openchat.entity.OpenChatRoom;

--- a/src/main/java/com/project200/undabang/openchat/respository/OpenChatRoomRepository.java
+++ b/src/main/java/com/project200/undabang/openchat/respository/OpenChatRoomRepository.java
@@ -1,0 +1,11 @@
+package com.project200.undabang.openchat.respository;
+
+import com.project200.undabang.member.entity.Member;
+import com.project200.undabang.openchat.entity.OpenChatRoom;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface OpenChatRoomRepository extends JpaRepository<OpenChatRoom, Long> {
+    boolean existsByMemberAndDeletedAtNull(Member member);
+
+    boolean existsByUrlAndDeletedAtNull(String url);
+}

--- a/src/main/java/com/project200/undabang/openchat/service/OpenChatRoomCommandService.java
+++ b/src/main/java/com/project200/undabang/openchat/service/OpenChatRoomCommandService.java
@@ -1,0 +1,8 @@
+package com.project200.undabang.openchat.service;
+
+import com.project200.undabang.openchat.dto.request.CreateOpenChatRoomRequest;
+import com.project200.undabang.openchat.dto.response.CreateOpenChatRoomResponse;
+
+public interface OpenChatRoomCommandService {
+    CreateOpenChatRoomResponse createOpenChatRoom(CreateOpenChatRoomRequest request);
+}

--- a/src/main/java/com/project200/undabang/openchat/service/impl/OpenChatRoomCommandServiceImpl.java
+++ b/src/main/java/com/project200/undabang/openchat/service/impl/OpenChatRoomCommandServiceImpl.java
@@ -1,0 +1,68 @@
+package com.project200.undabang.openchat.service.impl;
+
+import com.project200.undabang.common.context.UserContextHolder;
+import com.project200.undabang.common.web.exception.CustomException;
+import com.project200.undabang.common.web.exception.ErrorCode;
+import com.project200.undabang.member.entity.Member;
+import com.project200.undabang.member.repository.MemberRepository;
+import com.project200.undabang.openchat.dto.request.CreateOpenChatRoomRequest;
+import com.project200.undabang.openchat.dto.response.CreateOpenChatRoomResponse;
+import com.project200.undabang.openchat.entity.OpenChatRoom;
+import com.project200.undabang.openchat.respository.OpenChatRoomRepository;
+import com.project200.undabang.openchat.service.OpenChatRoomCommandService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.UUID;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class OpenChatRoomCommandServiceImpl implements OpenChatRoomCommandService {
+    private final MemberRepository memberRepository;
+    private final OpenChatRoomRepository openChatRoomRepository;
+
+    /**
+     * 새로운 오픈채팅방을 생성합니다.
+     *
+     * @param request 오픈채팅방 생성 요청 정보를 담고 있는 객체
+     * @return 생성된 오픈채팅방의 ID를 포함한 응답 객체
+     * @throws CustomException 오픈채팅방 URL 중복, 회원 정보 미존재, 또는 이미 존재하는 오픈채팅방이 있는 경우 발생
+     */
+    @Override
+    @Transactional
+    public CreateOpenChatRoomResponse createOpenChatRoom(CreateOpenChatRoomRequest request) {
+        Member member = getMember(UserContextHolder.getUserId());
+
+        String openChatroomUrl = request.getOpenChatroomUrl();
+
+        // 이미 등록한 오픈카톡 ID가 있는지 우선 검사
+        if (openChatRoomRepository.existsByMemberAndDeletedAtNull(member)) {
+            throw new CustomException(ErrorCode.OPEN_CHAT_ROOM_ALREADY_EXIST);
+        }
+
+        OpenChatRoom openChatRoom = OpenChatRoom.of(member, openChatroomUrl);
+
+        try {
+            OpenChatRoom savedOpenChatRoom = openChatRoomRepository.save(openChatRoom);
+            return CreateOpenChatRoomResponse.of(savedOpenChatRoom.getId());
+
+        } catch (DataIntegrityViolationException e) {
+
+            log.warn("생성시 DB Race Condition 발생으로 인한 오류 발생");
+            // 다른 사람이 사용중인 오픈카톡 URL로 생성 시도시 오류 반환
+            throw new CustomException(ErrorCode.OPEN_CHAT_ROOM_URL_DUPLICATED);
+        }
+    }
+
+
+    /**
+     * 지정된 회원 ID에 해당하는 회원 정보를 조회합니다.
+     */
+    private Member getMember(UUID memberId) {
+        return memberRepository.findById(memberId).orElseThrow(() -> new CustomException(ErrorCode.MEMBER_NOT_FOUND));
+    }
+}

--- a/src/main/java/com/project200/undabang/openchat/service/impl/OpenChatRoomCommandServiceImpl.java
+++ b/src/main/java/com/project200/undabang/openchat/service/impl/OpenChatRoomCommandServiceImpl.java
@@ -37,7 +37,7 @@ public class OpenChatRoomCommandServiceImpl implements OpenChatRoomCommandServic
     public CreateOpenChatRoomResponse createOpenChatRoom(CreateOpenChatRoomRequest request) {
         Member member = getMember(UserContextHolder.getUserId());
 
-        String openChatroomUrl = request.getOpenChatroomUrl();
+        String openChatroomUrl = normalizeUrl(request.getOpenChatroomUrl());
 
         // 이미 등록한 오픈카톡 ID가 있는지 우선 검사
         if (openChatRoomRepository.existsByMemberAndDeletedAtNull(member)) {
@@ -58,6 +58,16 @@ public class OpenChatRoomCommandServiceImpl implements OpenChatRoomCommandServic
         }
     }
 
+    /**
+     * 주어진 URL을 정규화합니다. URL이 "http://"로 시작하는 경우 "https://"로 변경합니다.
+     */
+    private String normalizeUrl(String url) {
+        if (url.startsWith("http://")) {
+            return url.replace("http://", "https://");
+        }
+
+        return url;
+    }
 
     /**
      * 지정된 회원 ID에 해당하는 회원 정보를 조회합니다.

--- a/src/main/java/com/project200/undabang/openchat/service/impl/OpenChatRoomCommandServiceImpl.java
+++ b/src/main/java/com/project200/undabang/openchat/service/impl/OpenChatRoomCommandServiceImpl.java
@@ -36,13 +36,9 @@ public class OpenChatRoomCommandServiceImpl implements OpenChatRoomCommandServic
     @Transactional
     public CreateOpenChatRoomResponse createOpenChatRoom(CreateOpenChatRoomRequest request) {
         Member member = getMember(UserContextHolder.getUserId());
-
         String openChatroomUrl = normalizeUrl(request.getOpenChatroomUrl());
 
-        // 이미 등록한 오픈카톡 ID가 있는지 우선 검사
-        if (openChatRoomRepository.existsByMemberAndDeletedAtNull(member)) {
-            throw new CustomException(ErrorCode.OPEN_CHAT_ROOM_ALREADY_EXIST);
-        }
+        validateForOpenChatRoomCreation(member, openChatroomUrl);
 
         OpenChatRoom openChatRoom = OpenChatRoom.of(member, openChatroomUrl);
 
@@ -54,6 +50,23 @@ public class OpenChatRoomCommandServiceImpl implements OpenChatRoomCommandServic
 
             log.warn("생성시 DB Race Condition 발생으로 인한 오류 발생");
             // 다른 사람이 사용중인 오픈카톡 URL로 생성 시도시 오류 반환
+            throw new CustomException(ErrorCode.OPEN_CHAT_ROOM_URL_DUPLICATED);
+        }
+    }
+
+    /**
+     * 오픈채팅방 생성을 위한 유효성 검사를 수행합니다.
+     * <p>
+     * 검사 대상
+     * 1. 회원이 이미 오픈 채팅방을 보유중인지 확인
+     * 2. 생성하려는 URL이 다른 사용자가 사용중인 URL인지 확인
+     */
+    private void validateForOpenChatRoomCreation(Member member, String openChatUrl) {
+        if (openChatRoomRepository.existsByMemberAndDeletedAtNull(member)) {
+            throw new CustomException(ErrorCode.OPEN_CHAT_ROOM_ALREADY_EXIST);
+        }
+
+        if (openChatRoomRepository.existsByUrlAndDeletedAtNull(openChatUrl)) {
             throw new CustomException(ErrorCode.OPEN_CHAT_ROOM_URL_DUPLICATED);
         }
     }

--- a/src/main/java/com/project200/undabang/openchat/service/impl/OpenChatRoomCommandServiceImpl.java
+++ b/src/main/java/com/project200/undabang/openchat/service/impl/OpenChatRoomCommandServiceImpl.java
@@ -8,7 +8,7 @@ import com.project200.undabang.member.repository.MemberRepository;
 import com.project200.undabang.openchat.dto.request.CreateOpenChatRoomRequest;
 import com.project200.undabang.openchat.dto.response.CreateOpenChatRoomResponse;
 import com.project200.undabang.openchat.entity.OpenChatRoom;
-import com.project200.undabang.openchat.respository.OpenChatRoomRepository;
+import com.project200.undabang.openchat.repository.OpenChatRoomRepository;
 import com.project200.undabang.openchat.service.OpenChatRoomCommandService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -63,7 +63,8 @@ public class OpenChatRoomCommandServiceImpl implements OpenChatRoomCommandServic
      */
     private String normalizeUrl(String url) {
         if (url.startsWith("http://")) {
-            return url.replace("http://", "https://");
+            // 혹시 쿼리 파라미터로 redirect?=http:// 가 있을 수 있으므로 프로토콜 부분만 검사
+            return url.replaceFirst("http://", "https://");
         }
 
         return url;


### PR DESCRIPTION
## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

오픈 채팅방 생성 기능을 개발하였습니다.

- 회원은 단 하나의 오픈 카톡 URL을 생성할 수 있게 하기 위해서 복합 유니크 키를 설정하였습니다. 
    - (member_id(fk), member_id_unique_key(int))

- 회원이 보유한 오픈 카톡 URL은 모든 회원 가운데 유일해야 합니다. (사용중인 URL은 등록 불가) 
    - (open_chatroom_url(String), open_chatroom_url_unique_key(int))

- 또한 RequestBody에서 카카오톡에서 사용하는 오픈 채팅 URL 형식에 맞춰 정규 표현식으로 검사를 하도록 하였습니다.

- 혹시 http:// 로 요청을 보낸 사용자에 대해서는 Https:// 로 저장되도록 정규화 기능을 추가하였습니다.

- 추후 논리적 삭제 구현시 ~~unique_key에 pk를 넣으면 되도록 구현하였습니다.

또한 예외처리로

1) 회원이 없는 경우 : MEMBER_NOT_FOUND (404)
2) 회원이 이미 채팅방을 보유한 경우 : OPEN_CHAT_ROOM_ALREADY_EXIST (409)
3) URL이 중복된 경우 : OPEN_CHAT_ROOM_URL_DUPLICATED (409)

를 사용하였습니다.

### 스크린샷 (선택)
**API 응답 사진입니다**
<img width="1151" height="374" alt="image" src="https://github.com/user-attachments/assets/9d91e474-0595-4493-a14f-48d5559ff5ad" />
<img width="394" height="241" alt="image" src="https://github.com/user-attachments/assets/d45c6711-c4f9-4e8c-b221-df1f1e38ad6a" />

성공 케이스에서 생성 시도시 응답
<img width="446" height="192" alt="image" src="https://github.com/user-attachments/assets/1679f5e6-260c-4539-849b-5b5f68327684" />

다른 회원 식별자로 생성 시도시
<img width="414" height="203" alt="image" src="https://github.com/user-attachments/assets/3f14f2e6-5323-4079-bf4e-f24df69fe22e" />

해커라 가정하고, 스미싱 페이지를 심으려는 시도시
<img width="1164" height="355" alt="image" src="https://github.com/user-attachments/assets/210d98a6-8309-4232-8e32-79af123af0e6" />
<img width="580" height="273" alt="image" src="https://github.com/user-attachments/assets/d5f5ac73-a193-43b6-beee-7de1103a108e" />

Closes #319