### PR TITLE
[Feat] 오픈 채팅 수정 기능 개발 [0.4.8] -> [0.4.9]

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ plugins {
 }
 
 group = 'com.project200'
-version = '0.4.8-SNAPSHOT'
+version = '0.4.9-SNAPSHOT'
 
 java {
     toolchain {

--- a/src/main/java/com/project200/undabang/common/web/exception/ErrorCode.java
+++ b/src/main/java/com/project200/undabang/common/web/exception/ErrorCode.java
@@ -65,7 +65,8 @@ public enum ErrorCode {
 
     // 오픈 채팅 관련 에러
     OPEN_CHAT_ROOM_ALREADY_EXIST(409, "OPEN_CHAT_ROOM_ALREADY_EXIST", "이미 오픈 채팅방을 보유한 회원입니다."),
-    OPEN_CHAT_ROOM_URL_DUPLICATED(409, "OPEN_CHAT_ROOM_URL_DUPLICATED", "이미 사용중인 오픈 채팅 링크입니다");
+    OPEN_CHAT_ROOM_URL_DUPLICATED(409, "OPEN_CHAT_ROOM_URL_DUPLICATED", "이미 사용중인 오픈 채팅 링크입니다"),
+    OPEN_CHAT_ROOM_NOT_FOUND(404, "OPEN_CHAT_ROOM_NOT_FOUND", "존재하지 않는 오픈 채팅방 입니다.");
 
     private final HttpStatusCode status;
     private final String code;

--- a/src/main/java/com/project200/undabang/openchat/controller/OpenChatRoomCommandController.java
+++ b/src/main/java/com/project200/undabang/openchat/controller/OpenChatRoomCommandController.java
@@ -2,16 +2,15 @@ package com.project200.undabang.openchat.controller;
 
 import com.project200.undabang.common.web.response.CommonResponse;
 import com.project200.undabang.openchat.dto.request.CreateOpenChatRoomRequest;
+import com.project200.undabang.openchat.dto.request.UpdateOpenChatRoomRequest;
 import com.project200.undabang.openchat.dto.response.CreateOpenChatRoomResponse;
+import com.project200.undabang.openchat.dto.response.UpdateOpenChatRoomResponse;
 import com.project200.undabang.openchat.service.OpenChatRoomCommandService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
@@ -24,5 +23,12 @@ public class OpenChatRoomCommandController {
     public ResponseEntity<CommonResponse<CreateOpenChatRoomResponse>> createOpenChatRoom(@Valid @RequestBody CreateOpenChatRoomRequest request) {
 
         return ResponseEntity.status(HttpStatus.CREATED).body(CommonResponse.create(openChatRoomCommandService.createOpenChatRoom(request)));
+    }
+
+    @PatchMapping("/v1/open-chats/{openChatId}")
+    public ResponseEntity<CommonResponse<UpdateOpenChatRoomResponse>> updateOpenChatRoom(@PathVariable long openChatId,
+                                                                                         @Valid @RequestBody UpdateOpenChatRoomRequest request) {
+
+        return ResponseEntity.ok(CommonResponse.success(openChatRoomCommandService.updateOpenChatRoom(openChatId, request)));
     }
 }

--- a/src/main/java/com/project200/undabang/openchat/dto/request/UpdateOpenChatRoomRequest.java
+++ b/src/main/java/com/project200/undabang/openchat/dto/request/UpdateOpenChatRoomRequest.java
@@ -1,0 +1,18 @@
+package com.project200.undabang.openchat.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class UpdateOpenChatRoomRequest {
+
+    @NotBlank(message = "오픈채팅 URL을 입력해주세요.")
+    @Pattern(regexp = "^https?://open\\.kakao\\.com/o/[a-zA-Z0-9]+$",
+            message = "유효하지 않은 카카오 오픈채팅 URL 형식입니다.")
+    private String openChatroomUrl;
+}

--- a/src/main/java/com/project200/undabang/openchat/dto/response/UpdateOpenChatRoomResponse.java
+++ b/src/main/java/com/project200/undabang/openchat/dto/response/UpdateOpenChatRoomResponse.java
@@ -1,0 +1,16 @@
+package com.project200.undabang.openchat.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class UpdateOpenChatRoomResponse {
+    private Long openChatroomId;
+
+    public static UpdateOpenChatRoomResponse of(Long openChatroomId) {
+        return new UpdateOpenChatRoomResponse(openChatroomId);
+    }
+}

--- a/src/main/java/com/project200/undabang/openchat/entity/OpenChatRoom.java
+++ b/src/main/java/com/project200/undabang/openchat/entity/OpenChatRoom.java
@@ -62,5 +62,13 @@ public class OpenChatRoom {
                 .build();
     }
 
+    public void updateOpenChatUrl(String openChatUrl) {
+        this.url = openChatUrl;
+        this.updatedAt = LocalDateTime.now();
+    }
+
+    public boolean isSameUrl(String urlToCompare) {
+        return this.url.equals(urlToCompare);
+    }
     // Todo : 논리적 삭제 구현시 두개의 UNIQUE에 모두 PK 값을 넣어주어야 한다. 그래서 회원은 새로운 채팅방을 만들 수 있고, 다른 회원은 URL을 재사용 할 수 있음(혹시 재사용 하게 된다면)
 }

--- a/src/main/java/com/project200/undabang/openchat/entity/OpenChatRoom.java
+++ b/src/main/java/com/project200/undabang/openchat/entity/OpenChatRoom.java
@@ -56,6 +56,9 @@ public class OpenChatRoom {
         return OpenChatRoom.builder()
                 .member(member)
                 .url(openChatroomUrl)
+                .createdAt(LocalDateTime.now())
+                .memberIdUniqueKey(0L)
+                .urlUniqueKey(0L)
                 .build();
     }
 

--- a/src/main/java/com/project200/undabang/openchat/entity/OpenChatRoom.java
+++ b/src/main/java/com/project200/undabang/openchat/entity/OpenChatRoom.java
@@ -56,9 +56,6 @@ public class OpenChatRoom {
         return OpenChatRoom.builder()
                 .member(member)
                 .url(openChatroomUrl)
-                .createdAt(LocalDateTime.now())
-                .memberIdUniqueKey(0L)
-                .urlUniqueKey(0L)
                 .build();
     }
 
@@ -70,5 +67,6 @@ public class OpenChatRoom {
     public boolean isSameUrl(String urlToCompare) {
         return this.url.equals(urlToCompare);
     }
+
     // Todo : 논리적 삭제 구현시 두개의 UNIQUE에 모두 PK 값을 넣어주어야 한다. 그래서 회원은 새로운 채팅방을 만들 수 있고, 다른 회원은 URL을 재사용 할 수 있음(혹시 재사용 하게 된다면)
 }

--- a/src/main/java/com/project200/undabang/openchat/repository/OpenChatRoomRepository.java
+++ b/src/main/java/com/project200/undabang/openchat/repository/OpenChatRoomRepository.java
@@ -9,7 +9,8 @@ import java.util.Optional;
 public interface OpenChatRoomRepository extends JpaRepository<OpenChatRoom, Long> {
     boolean existsByMemberAndDeletedAtNull(Member member);
 
-    Optional<OpenChatRoom> findByIdAndDeletedAtNull(Long id);
-
     boolean existsByUrlAndIdNotAndDeletedAtNull(String url, Long id);
+
+    boolean existsByUrlAndDeletedAtNull(String url);
+    Optional<OpenChatRoom> findByIdAndDeletedAtNull(Long id);
 }

--- a/src/main/java/com/project200/undabang/openchat/repository/OpenChatRoomRepository.java
+++ b/src/main/java/com/project200/undabang/openchat/repository/OpenChatRoomRepository.java
@@ -4,8 +4,12 @@ import com.project200.undabang.member.entity.Member;
 import com.project200.undabang.openchat.entity.OpenChatRoom;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface OpenChatRoomRepository extends JpaRepository<OpenChatRoom, Long> {
     boolean existsByMemberAndDeletedAtNull(Member member);
 
-    boolean existsByUrlAndDeletedAtNull(String url);
+    Optional<OpenChatRoom> findByIdAndDeletedAtNull(Long id);
+
+    boolean existsByUrlAndIdNotAndDeletedAtNull(String url, Long id);
 }

--- a/src/main/java/com/project200/undabang/openchat/service/OpenChatRoomCommandService.java
+++ b/src/main/java/com/project200/undabang/openchat/service/OpenChatRoomCommandService.java
@@ -1,8 +1,12 @@
 package com.project200.undabang.openchat.service;
 
 import com.project200.undabang.openchat.dto.request.CreateOpenChatRoomRequest;
+import com.project200.undabang.openchat.dto.request.UpdateOpenChatRoomRequest;
 import com.project200.undabang.openchat.dto.response.CreateOpenChatRoomResponse;
+import com.project200.undabang.openchat.dto.response.UpdateOpenChatRoomResponse;
 
 public interface OpenChatRoomCommandService {
     CreateOpenChatRoomResponse createOpenChatRoom(CreateOpenChatRoomRequest request);
+
+    UpdateOpenChatRoomResponse updateOpenChatRoom(Long openChatRoomId, UpdateOpenChatRoomRequest request);
 }

--- a/src/main/java/com/project200/undabang/openchat/service/impl/OpenChatRoomCommandServiceImpl.java
+++ b/src/main/java/com/project200/undabang/openchat/service/impl/OpenChatRoomCommandServiceImpl.java
@@ -6,7 +6,9 @@ import com.project200.undabang.common.web.exception.ErrorCode;
 import com.project200.undabang.member.entity.Member;
 import com.project200.undabang.member.repository.MemberRepository;
 import com.project200.undabang.openchat.dto.request.CreateOpenChatRoomRequest;
+import com.project200.undabang.openchat.dto.request.UpdateOpenChatRoomRequest;
 import com.project200.undabang.openchat.dto.response.CreateOpenChatRoomResponse;
+import com.project200.undabang.openchat.dto.response.UpdateOpenChatRoomResponse;
 import com.project200.undabang.openchat.entity.OpenChatRoom;
 import com.project200.undabang.openchat.repository.OpenChatRoomRepository;
 import com.project200.undabang.openchat.service.OpenChatRoomCommandService;
@@ -58,6 +60,38 @@ public class OpenChatRoomCommandServiceImpl implements OpenChatRoomCommandServic
         }
     }
 
+    @Override
+    @Transactional
+    public UpdateOpenChatRoomResponse updateOpenChatRoom(Long openChatRoomId, UpdateOpenChatRoomRequest request) {
+        Member member = getMember(UserContextHolder.getUserId());
+        String openChatUrl = normalizeUrl(request.getOpenChatroomUrl());
+
+        OpenChatRoom openChatRoom = getOpenChatRoom(member, openChatRoomId);
+
+        if (openChatRoom.isSameUrl(openChatUrl)) {
+            return UpdateOpenChatRoomResponse.of(openChatRoomId);
+        }
+
+        validateUrlUniqueness(openChatUrl, openChatRoomId);
+
+        openChatRoom.updateOpenChatUrl(openChatUrl);
+
+        return UpdateOpenChatRoomResponse.of(openChatRoom.getId());
+    }
+
+    /**
+     * 주어진 오픈채팅방 URL이 중복되지 않았는지 검사합니다.
+     *
+     * @param openChatUrl       검사할 오픈채팅방 URL
+     * @param currentChatRoomId 현재 오픈채팅방 ID. 중복 검사 시 제외할 ID
+     * @throws CustomException URL이 다른 오픈채팅방에서 이미 사용 중인 경우 발생
+     */
+    private void validateUrlUniqueness(String openChatUrl, Long currentChatRoomId) {
+        if (openChatRoomRepository.existsByUrlAndIdNotAndDeletedAtNull(openChatUrl, currentChatRoomId)) {
+            throw new CustomException(ErrorCode.OPEN_CHAT_ROOM_URL_DUPLICATED);
+        }
+    }
+
     /**
      * 주어진 URL을 정규화합니다. URL이 "http://"로 시작하는 경우 "https://"로 변경합니다.
      */
@@ -75,5 +109,22 @@ public class OpenChatRoomCommandServiceImpl implements OpenChatRoomCommandServic
      */
     private Member getMember(UUID memberId) {
         return memberRepository.findById(memberId).orElseThrow(() -> new CustomException(ErrorCode.MEMBER_NOT_FOUND));
+    }
+
+    /**
+     * 지정된 회원과 오픈채팅방 ID를 기반으로 오픈채팅방 정보를 조회합니다.
+     * 회원이 소유하지 않은 오픈채팅방에 접근할 경우 예외를 발생시킵니다.
+     */
+    private OpenChatRoom getOpenChatRoom(Member member, Long openChatId) {
+        OpenChatRoom openChatRoom = openChatRoomRepository.findByIdAndDeletedAtNull(openChatId).orElseThrow(
+                () -> new CustomException(ErrorCode.OPEN_CHAT_ROOM_NOT_FOUND)
+        );
+
+        // 자신이 소유한 오픈 채팅방이 아닐경우 403 에러
+        if (!member.getMemberId().equals(openChatRoom.getMember().getMemberId())) {
+            throw new CustomException(ErrorCode.AUTHORIZATION_DENIED);
+        }
+
+        return openChatRoom;
     }
 }

--- a/src/main/java/com/project200/undabang/openchat/service/impl/OpenChatRoomCommandServiceImpl.java
+++ b/src/main/java/com/project200/undabang/openchat/service/impl/OpenChatRoomCommandServiceImpl.java
@@ -29,10 +29,7 @@ public class OpenChatRoomCommandServiceImpl implements OpenChatRoomCommandServic
 
     /**
      * 새로운 오픈채팅방을 생성합니다.
-     *
-     * @param request 오픈채팅방 생성 요청 정보를 담고 있는 객체
-     * @return 생성된 오픈채팅방의 ID를 포함한 응답 객체
-     * @throws CustomException 오픈채팅방 URL 중복, 회원 정보 미존재, 또는 이미 존재하는 오픈채팅방이 있는 경우 발생
+     * 요청된 URL의 정규화 및 유효성 검사를 수행하며, 생성 중 데이터 충돌이 발생할 경우 예외를 반환합니다.
      */
     @Override
     @Transactional
@@ -56,6 +53,9 @@ public class OpenChatRoomCommandServiceImpl implements OpenChatRoomCommandServic
         }
     }
 
+    /**
+     * 주어진 오픈채팅방 ID와 요청 데이터를 기반으로 오픈채팅방 정보를 업데이트합니다.
+     */
     @Override
     @Transactional
     public UpdateOpenChatRoomResponse updateOpenChatRoom(Long openChatRoomId, UpdateOpenChatRoomRequest request) {
@@ -68,7 +68,7 @@ public class OpenChatRoomCommandServiceImpl implements OpenChatRoomCommandServic
             return UpdateOpenChatRoomResponse.of(openChatRoomId);
         }
 
-        validateUrlUniqueness(openChatUrl, openChatRoomId);
+        validateUrlIsUniqueForUpdate(openChatUrl, openChatRoomId);
 
         openChatRoom.updateOpenChatUrl(openChatUrl);
 
@@ -77,12 +77,8 @@ public class OpenChatRoomCommandServiceImpl implements OpenChatRoomCommandServic
 
     /**
      * 주어진 오픈채팅방 URL이 중복되지 않았는지 검사합니다.
-     *
-     * @param openChatUrl       검사할 오픈채팅방 URL
-     * @param currentChatRoomId 현재 오픈채팅방 ID. 중복 검사 시 제외할 ID
-     * @throws CustomException URL이 다른 오픈채팅방에서 이미 사용 중인 경우 발생
      */
-    private void validateUrlUniqueness(String openChatUrl, Long currentChatRoomId) {
+    private void validateUrlIsUniqueForUpdate(String openChatUrl, Long currentChatRoomId) {
         if (openChatRoomRepository.existsByUrlAndIdNotAndDeletedAtNull(openChatUrl, currentChatRoomId)) {
             throw new CustomException(ErrorCode.OPEN_CHAT_ROOM_URL_DUPLICATED);
         }
@@ -90,7 +86,6 @@ public class OpenChatRoomCommandServiceImpl implements OpenChatRoomCommandServic
 
     /**
      * 오픈채팅방 생성을 위한 유효성 검사를 수행합니다.
-     * <p>
      * 검사 대상
      * 1. 회원이 이미 오픈 채팅방을 보유중인지 확인
      * 2. 생성하려는 URL이 다른 사용자가 사용중인 URL인지 확인


### PR DESCRIPTION
## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

오픈 채팅방 URL 수정 기능을 개발하였습니다. 

URL 검사 조건은 생성과 똑같이 가져갔으며, 수정시 

1) 회원이 보유한 오픈 채팅방을 수정하는지
2) 기존에 보유중인 이름으로 변경 시도시 빠른 반환 적용
3) 다른 회원이 보유중인 URL로 변경을 시도하는지

세가지 조건에 대하여 검사를 진행하고, 변경감지를 통해 업데이트가 진행되도록 구현하였습니다.

### 스크린샷 (선택)
정상적인 업데이트 경우입니다.
<img width="385" height="246" alt="image" src="https://github.com/user-attachments/assets/95eb56cc-d4b9-47a5-a094-57b6d91836b4" />

존재하지 않는 ID로 수정을 하려는 경우입니다.
<img width="406" height="223" alt="image" src="https://github.com/user-attachments/assets/38b0bb33-e3ec-406a-a676-e8c0625c257a" />

타인의 오픈 채팅 ID로 접근하여 수정하려는 경우입니다.
<img width="340" height="191" alt="image" src="https://github.com/user-attachments/assets/2a36693a-0e0f-4937-990f-a6f092491f96" />

타인의 오픈 채팅 URL로 사용자가 변경을 시도하려는 경우입니다.
<img width="445" height="206" alt="image" src="https://github.com/user-attachments/assets/411ea0b6-593f-40c8-a847-836d85c2c32c" />


Closes #320 