### PR TITLE
Hotfix(운동장소): 위도 및 경도 매핑 로직 오류 수정

### DIFF
--- a/src/main/java/com/project200/undabang/member/repository/impl/ExerciseLocationRepositoryImpl.java
+++ b/src/main/java/com/project200/undabang/member/repository/impl/ExerciseLocationRepositoryImpl.java
@@ -35,7 +35,6 @@ public class ExerciseLocationRepositoryImpl implements ExerciseLocationRepositor
         QMemberPicture memberPicture = QMemberPicture.memberPicture;
         QExerciseLocation exerciseLocation = QExerciseLocation.exerciseLocation;
         QPicture picture = QPicture.picture;
-
         return queryFactory
                 .from(exerciseLocation)
                 .join(exerciseLocation.member, member)
@@ -57,8 +56,8 @@ public class ExerciseLocationRepositoryImpl implements ExerciseLocationRepositor
                                                 Projections.constructor(
                                                         ExerciseLocationRecord.class,
                                                         exerciseLocation.exerciseLocationName,
-                                                        Expressions.numberTemplate(Double.class, "ST_Y({0})", exerciseLocation.exerciseLocationPoint), // 위도 좌표 매핑
-                                                        Expressions.numberTemplate(Double.class, "ST_X({0})", exerciseLocation.exerciseLocationPoint) // 경도 좌표 매핑
+                                                        Expressions.numberTemplate(Double.class, "ST_X({0})", exerciseLocation.exerciseLocationPoint), // 위도 좌표 매핑
+                                                        Expressions.numberTemplate(Double.class, "ST_Y({0})", exerciseLocation.exerciseLocationPoint) // 경도 좌표 매핑
                                                 )
                                         )
                                 )

--- a/src/test/java/com/project200/undabang/member/repository/impl/ExerciseLocationRepositoryImplTest.java
+++ b/src/test/java/com/project200/undabang/member/repository/impl/ExerciseLocationRepositoryImplTest.java
@@ -215,8 +215,8 @@ class ExerciseLocationRepositoryImplTest {
 
             ExerciseLocationRecord locationRecord = result.getLocations().get(0);
             assertThat(locationRecord.exerciseLocationName()).isEqualTo(activeLocation.getExerciseLocationName());
-            assertThat(locationRecord.latitude()).isEqualTo(37.5);
-            assertThat(locationRecord.longitude()).isEqualTo(127.0);
+            assertThat(locationRecord.longitude()).isEqualTo(37.5);
+            assertThat(locationRecord.latitude()).isEqualTo(127.0);
         }
 
         @Test


### PR DESCRIPTION
## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

위도와 경도 매핑 순서가 거꾸로 되어 있는 부분을 수정하였습니다.
또한 그에 맞추어 테스트코드를 수정하였습니다.