### PR TITLE
[Feat] 자신의 오픈채팅방 URL 조회 API 추가 (#338)

### DIFF
--- a/src/main/java/com/project200/undabang/openchat/controller/OpenChatQueryController.java
+++ b/src/main/java/com/project200/undabang/openchat/controller/OpenChatQueryController.java
@@ -1,6 +1,7 @@
 package com.project200.undabang.openchat.controller;
 
 import com.project200.undabang.common.web.response.CommonResponse;
+import com.project200.undabang.openchat.dto.response.GetOpenChatUrlResponse;
 import com.project200.undabang.openchat.dto.response.GetOtherMemberOpenChatUrlResponse;
 import com.project200.undabang.openchat.service.OpenChatQueryService;
 import lombok.RequiredArgsConstructor;
@@ -23,5 +24,11 @@ public class OpenChatQueryController {
     public ResponseEntity<CommonResponse<GetOtherMemberOpenChatUrlResponse>> getOtherMemberOpenChatroomUrl(@PathVariable UUID memberId) {
 
         return ResponseEntity.ok(CommonResponse.success(openChatQueryService.getOtherMemberOpenChatroomUrl(memberId)));
+    }
+
+    @GetMapping("/v1/open-chat")
+    public ResponseEntity<CommonResponse<GetOpenChatUrlResponse>> getOpenChatroomUrl() {
+
+        return ResponseEntity.ok(CommonResponse.success(openChatQueryService.getOpenChatroomUrl()));
     }
 }

--- a/src/main/java/com/project200/undabang/openchat/dto/response/GetOpenChatUrlResponse.java
+++ b/src/main/java/com/project200/undabang/openchat/dto/response/GetOpenChatUrlResponse.java
@@ -1,0 +1,16 @@
+package com.project200.undabang.openchat.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class GetOpenChatUrlResponse {
+    private String openChatroomUrl;
+
+    public static GetOpenChatUrlResponse of(String openChatroomUrl) {
+        return new GetOpenChatUrlResponse(openChatroomUrl);
+    }
+}

--- a/src/main/java/com/project200/undabang/openchat/service/OpenChatQueryService.java
+++ b/src/main/java/com/project200/undabang/openchat/service/OpenChatQueryService.java
@@ -1,9 +1,12 @@
 package com.project200.undabang.openchat.service;
 
+import com.project200.undabang.openchat.dto.response.GetOpenChatUrlResponse;
 import com.project200.undabang.openchat.dto.response.GetOtherMemberOpenChatUrlResponse;
 
 import java.util.UUID;
 
 public interface OpenChatQueryService {
     GetOtherMemberOpenChatUrlResponse getOtherMemberOpenChatroomUrl(UUID memberId);
+
+    GetOpenChatUrlResponse getOpenChatroomUrl();
 }

--- a/src/main/java/com/project200/undabang/openchat/service/impl/OpenChatQueryServiceImpl.java
+++ b/src/main/java/com/project200/undabang/openchat/service/impl/OpenChatQueryServiceImpl.java
@@ -5,6 +5,7 @@ import com.project200.undabang.common.web.exception.CustomException;
 import com.project200.undabang.common.web.exception.ErrorCode;
 import com.project200.undabang.match.service.MatchService;
 import com.project200.undabang.member.repository.MemberRepository;
+import com.project200.undabang.openchat.dto.response.GetOpenChatUrlResponse;
 import com.project200.undabang.openchat.dto.response.GetOtherMemberOpenChatUrlResponse;
 import com.project200.undabang.openchat.entity.OpenChatRoom;
 import com.project200.undabang.openchat.repository.OpenChatRoomRepository;
@@ -24,6 +25,17 @@ public class OpenChatQueryServiceImpl implements OpenChatQueryService {
     private final OpenChatRoomRepository openChatRoomRepository;
     private final MemberRepository memberRepository;
     private final MatchService matchService;
+
+    /**
+     * 현재 사용자와 연관된 오픈 채팅방의 URL을 조회하여 반환합니다.
+     */
+    @Override
+    @Transactional(readOnly = true)
+    public GetOpenChatUrlResponse getOpenChatroomUrl() {
+        OpenChatRoom openChatRoom = getMemberOpenChatRoom(UserContextHolder.getUserId());
+
+        return GetOpenChatUrlResponse.of(openChatRoom.getUrl());
+    }
 
     /**
      * 주어진 회원 ID를 기반으로 해당 회원의 오픈 채팅방 URL을 조회하고 반환합니다.


### PR DESCRIPTION
## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

회원이 자신의 오픈채팅방을 조회하는 기능을 개발하였습니다.
이전 회원이 타 회원의 오픈채팅방을 조회하는 기능에서 대부분 재사용하여서 크게 추가한 사항은 없습니다.

1) 회원이 조회되지 않은 경우 (404)
2) 오픈 채팅이 없는경우 (404)

오류를 반환하도록 하였습니다.

### 스크린샷 (선택)
정상 경우의 응답 사진입니다.
<img width="601" height="246" alt="image" src="https://github.com/user-attachments/assets/8e1e274e-3ac8-4939-91de-003d5d5f1197" />

회원이 없을 경우의 응답 사진입니다.
<img width="395" height="251" alt="image" src="https://github.com/user-attachments/assets/748691e7-4cd2-4322-8562-8af51f485753" />

오픈 채팅이 없는 경우의 응답 사진입니다.
<img width="488" height="232" alt="image" src="https://github.com/user-attachments/assets/aae5fc80-1465-4a72-8653-5bbbe30f9c6e" />


## #️⃣연관된 이슈

Closes #338 