### PR TITLE
[Feat] 오픈채팅 응답 객체에 식별자 추가 및 관련 테스트 수정 및 보완 

### DIFF
--- a/src/main/java/com/project200/undabang/openchat/dto/response/GetOpenChatUrlResponse.java
+++ b/src/main/java/com/project200/undabang/openchat/dto/response/GetOpenChatUrlResponse.java
@@ -10,9 +10,13 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 public class GetOpenChatUrlResponse {
+    private Long openChatroomId;
     private String openChatroomUrl;
 
-    public static GetOpenChatUrlResponse of(String openChatroomUrl) {
-        return new GetOpenChatUrlResponse(openChatroomUrl);
+    public static GetOpenChatUrlResponse of(Long openChatroomId, String openChatroomUrl) {
+        return GetOpenChatUrlResponse.builder()
+                .openChatroomId(openChatroomId)
+                .openChatroomUrl(openChatroomUrl)
+                .build();
     }
 }

--- a/src/main/java/com/project200/undabang/openchat/dto/response/GetOpenChatUrlResponse.java
+++ b/src/main/java/com/project200/undabang/openchat/dto/response/GetOpenChatUrlResponse.java
@@ -14,9 +14,6 @@ public class GetOpenChatUrlResponse {
     private String openChatroomUrl;
 
     public static GetOpenChatUrlResponse of(Long openChatroomId, String openChatroomUrl) {
-        return GetOpenChatUrlResponse.builder()
-                .openChatroomId(openChatroomId)
-                .openChatroomUrl(openChatroomUrl)
-                .build();
+        return new GetOpenChatUrlResponse(openChatroomId, openChatroomUrl);
     }
 }

--- a/src/main/java/com/project200/undabang/openchat/service/OpenChatRoomQueryService.java
+++ b/src/main/java/com/project200/undabang/openchat/service/OpenChatRoomQueryService.java
@@ -7,6 +7,5 @@ import java.util.UUID;
 
 public interface OpenChatRoomQueryService {
     GetOtherMemberOpenChatUrlResponse getOtherMemberOpenChatroomUrl(UUID memberId);
-
     GetOpenChatUrlResponse getOpenChatroomUrl();
 }

--- a/src/main/java/com/project200/undabang/openchat/service/impl/OpenChatRoomQueryServiceImpl.java
+++ b/src/main/java/com/project200/undabang/openchat/service/impl/OpenChatRoomQueryServiceImpl.java
@@ -34,7 +34,7 @@ public class OpenChatRoomQueryServiceImpl implements OpenChatRoomQueryService {
     public GetOpenChatUrlResponse getOpenChatroomUrl() {
         OpenChatRoom openChatRoom = getMemberOpenChatRoom(UserContextHolder.getUserId());
 
-        return GetOpenChatUrlResponse.of(openChatRoom.getUrl());
+        return GetOpenChatUrlResponse.of(openChatRoom.getId(), openChatRoom.getUrl());
     }
 
     /**

--- a/src/test/java/com/project200/undabang/openchat/controller/OpenChatRoomQueryControllerTest.java
+++ b/src/test/java/com/project200/undabang/openchat/controller/OpenChatRoomQueryControllerTest.java
@@ -106,8 +106,9 @@ class OpenChatRoomQueryControllerTest extends AbstractRestDocSupport {
                 .build();
     }
 
-    private GetOpenChatUrlResponse createMyChatUrlResponse(String url) {
+    private GetOpenChatUrlResponse createMyChatUrlResponse(Long id, String url) {
         return GetOpenChatUrlResponse.builder()
+                .openChatroomId(id)
                 .openChatroomUrl(url)
                 .build();
     }
@@ -121,8 +122,9 @@ class OpenChatRoomQueryControllerTest extends AbstractRestDocSupport {
         void getMyOpenChatUrl_Success() throws Exception {
             // given
             UUID memberId = UUID.randomUUID();
+            Long openChatId = 123456789L;
             String openChatUrl = "https://open.kakao.com/o/myurl456";
-            GetOpenChatUrlResponse response = createMyChatUrlResponse(openChatUrl);
+            GetOpenChatUrlResponse response = createMyChatUrlResponse(openChatId, openChatUrl);
 
             BDDMockito.given(openChatQueryService.getOpenChatroomUrl()).willReturn(response);
 
@@ -135,11 +137,13 @@ class OpenChatRoomQueryControllerTest extends AbstractRestDocSupport {
                             status().isOk(),
                             jsonPath("$.succeed").value(true),
                             jsonPath("$.code").value("SUCCESS"),
+                            jsonPath("$.data.openChatroomId").value(openChatId),
                             jsonPath("$.data.openChatroomUrl").value(openChatUrl)
                     )
                     .andDo(document.document(
                             requestHeaders(HEADER_ACCESS_TOKEN),
                             responseFields(commonResponseFields(
+                                    fieldWithPath("data.openChatroomId").type(JsonFieldType.NUMBER).description("자신의 카카오톡 오픈채팅방 식별자 정보 입니다."),
                                     fieldWithPath("data.openChatroomUrl").type(JsonFieldType.STRING).description("자신의 카카오톡 오픈채팅방 URL 링크 입니다.")
                             ))
                     ));

--- a/src/test/java/com/project200/undabang/openchat/service/impl/OpenChatRoomCommandServiceImplTest.java
+++ b/src/test/java/com/project200/undabang/openchat/service/impl/OpenChatRoomCommandServiceImplTest.java
@@ -370,6 +370,38 @@ class OpenChatRoomCommandServiceImplTest {
                         .hasFieldOrPropertyWithValue("errorCode", ErrorCode.OPEN_CHAT_ROOM_URL_DUPLICATED);
             }
         }
+
+        @Test
+        @DisplayName("http로 시작하는 URL로 수정하면 https로 정규화되어 updateOpenChatUrl이 호출된다")
+        void normalizes_http_url_to_https_on_update() {
+            UUID userId = UUID.randomUUID();
+            Member member = createMember(userId);
+            Long openChatId = 30L;
+            String httpUrl = "http://open.chat/update";
+            String expectedHttpsUrl = "https://open.chat/update";
+            UpdateOpenChatRoomRequest request = updateRequest(httpUrl);
+
+            OpenChatRoom existing = mock(OpenChatRoom.class);
+            given(existing.getMember()).willReturn(member);
+            given(existing.isSameUrl(expectedHttpsUrl)).willReturn(false);
+            given(existing.getId()).willReturn(openChatId);
+
+            given(openChatRoomRepository.findByIdAndDeletedAtNull(openChatId)).willReturn(Optional.of(existing));
+            given(openChatRoomRepository.existsByUrlAndIdNotAndDeletedAtNull(expectedHttpsUrl, openChatId)).willReturn(false);
+
+            try (MockedStatic<UserContextHolder> ignored = mockStatic(UserContextHolder.class)) {
+                given(UserContextHolder.getUserId()).willReturn(userId);
+                given(memberRepository.findById(userId)).willReturn(Optional.of(member));
+
+                var response = openChatRoomCommandService.updateOpenChatRoom(openChatId, request);
+
+                ArgumentCaptor<String> urlCaptor = ArgumentCaptor.forClass(String.class);
+                verify(existing).updateOpenChatUrl(urlCaptor.capture());
+                assertThat(urlCaptor.getValue()).isEqualTo(expectedHttpsUrl);
+                assertThat(response).isNotNull();
+                assertThat(response.getOpenChatroomId()).isEqualTo(openChatId);
+            }
+        }
     }
 
     @Nested

--- a/src/test/java/com/project200/undabang/openchat/service/impl/OpenChatRoomQueryServiceImplTest.java
+++ b/src/test/java/com/project200/undabang/openchat/service/impl/OpenChatRoomQueryServiceImplTest.java
@@ -46,76 +46,9 @@ class OpenChatRoomQueryServiceImplTest {
 
     private OpenChatRoom createOpenChatRoom(String url) {
         OpenChatRoom openChatRoom = mock(OpenChatRoom.class);
-        // lenient stubbing: 일부 테스트에서 mock.getUrl()이 사용되지 않더라도 UnnecessaryStubbingException을 피함
         lenient().when(openChatRoom.getUrl()).thenReturn(url);
+        lenient().when(openChatRoom.getId()).thenReturn(1L);
         return openChatRoom;
-    }
-
-    private Member createMember(UUID memberId) {
-        return Member.builder()
-                .memberId(memberId)
-                .memberEmail(memberId + "@test.com")
-                .memberNickname("test-user-" + memberId)
-                .memberGender(MemberGender.UNKNOWN)
-                .memberBday(LocalDate.now().minusYears(20))
-                .build();
-    }
-
-    @Nested
-    @DisplayName("getOpenChatroomUrl() 메소드는")
-    class Describe_getOpenChatroomUrl {
-
-        @Test
-        @DisplayName("현재 사용자의 오픈 채팅 URL을 정상적으로 반환한다")
-        void returns_url_for_current_user() {
-            UUID userId = UUID.randomUUID();
-            Member member = createMember(userId);
-            OpenChatRoom openChatRoom = createOpenChatRoom("https://open.chat/test");
-
-            try (MockedStatic<UserContextHolder> ignored = mockStatic(UserContextHolder.class)) {
-                given(UserContextHolder.getUserId()).willReturn(userId);
-                // 불필요한 stubbing 제거: memberRepository.existsById(...) 삭제
-                given(openChatRoomRepository.findByMember_MemberIdAndDeletedAtNull(member.getMemberId())).willReturn(Optional.of(openChatRoom));
-
-                GetOpenChatUrlResponse response = openChatQueryService.getOpenChatroomUrl();
-
-                assertThat(response).isNotNull();
-                assertThat(response.getOpenChatroomUrl()).isEqualTo("https://open.chat/test");
-            }
-        }
-
-        @Test
-        @DisplayName("회원이 존재하지 않으면 MEMBER_NOT_FOUND 예외를 던진다")
-        void throws_when_member_not_found() {
-            UUID userId = UUID.randomUUID();
-
-            try (MockedStatic<UserContextHolder> ignored = mockStatic(UserContextHolder.class)) {
-                given(UserContextHolder.getUserId()).willReturn(userId);
-                given(openChatRoomRepository.findByMember_MemberIdAndDeletedAtNull(userId)).willReturn(Optional.empty());
-                given(memberRepository.existsById(userId)).willReturn(false);
-
-                assertThatThrownBy(() -> openChatQueryService.getOpenChatroomUrl())
-                        .isInstanceOf(CustomException.class)
-                        .hasFieldOrPropertyWithValue("errorCode", ErrorCode.MEMBER_NOT_FOUND);
-            }
-        }
-
-        @Test
-        @DisplayName("회원은 존재하지만 오픈 채팅방이 없으면 OPEN_CHAT_ROOM_NOT_FOUND 예외를 던진다")
-        void throws_when_open_chat_not_found() {
-            UUID userId = UUID.randomUUID();
-            Member member = createMember(userId);
-
-            try (MockedStatic<UserContextHolder> ignored = mockStatic(UserContextHolder.class)) {
-                given(UserContextHolder.getUserId()).willReturn(userId);
-                given(openChatRoomRepository.findByMember_MemberIdAndDeletedAtNull(member.getMemberId())).willReturn(Optional.empty());
-                given(memberRepository.existsById(userId)).willReturn(true);
-
-                assertThatThrownBy(() -> openChatQueryService.getOpenChatroomUrl())
-                        .isInstanceOf(CustomException.class)
-                        .hasFieldOrPropertyWithValue("errorCode", ErrorCode.OPEN_CHAT_ROOM_NOT_FOUND);
-            }
-        }
     }
 
     @Nested
@@ -190,6 +123,73 @@ class OpenChatRoomQueryServiceImplTest {
                 given(memberRepository.existsById(targetMemberId)).willReturn(true);
 
                 assertThatThrownBy(() -> openChatQueryService.getOtherMemberOpenChatroomUrl(targetMemberId))
+                        .isInstanceOf(CustomException.class)
+                        .hasFieldOrPropertyWithValue("errorCode", ErrorCode.OPEN_CHAT_ROOM_NOT_FOUND);
+            }
+        }
+    }
+
+    private Member createMember(UUID memberId) {
+        return Member.builder()
+                .memberId(memberId)
+                .memberEmail(memberId + "@test.com")
+                .memberNickname("test-user-" + memberId)
+                .memberGender(MemberGender.UNKNOWN)
+                .memberBday(LocalDate.now().minusYears(20))
+                .build();
+    }
+
+    @Nested
+    @DisplayName("getOpenChatroomUrl() 메소드는")
+    class Describe_getOpenChatroomUrl {
+
+        @Test
+        @DisplayName("현재 사용자의 오픈 채팅 URL을 정상적으로 반환한다")
+        void returns_url_for_current_user() {
+            UUID userId = UUID.randomUUID();
+            Member member = createMember(userId);
+            OpenChatRoom openChatRoom = createOpenChatRoom("https://open.chat/test");
+
+            try (MockedStatic<UserContextHolder> ignored = mockStatic(UserContextHolder.class)) {
+                given(UserContextHolder.getUserId()).willReturn(userId);
+                given(openChatRoomRepository.findByMember_MemberIdAndDeletedAtNull(member.getMemberId())).willReturn(Optional.of(openChatRoom));
+
+                GetOpenChatUrlResponse response = openChatQueryService.getOpenChatroomUrl();
+
+                assertThat(response).isNotNull();
+                assertThat(response.getOpenChatroomUrl()).isEqualTo("https://open.chat/test");
+                assertThat(response.getOpenChatroomId()).isEqualTo(1L);
+            }
+        }
+
+        @Test
+        @DisplayName("회원이 존재하지 않으면 MEMBER_NOT_FOUND 예외를 던진다")
+        void throws_when_member_not_found() {
+            UUID userId = UUID.randomUUID();
+
+            try (MockedStatic<UserContextHolder> ignored = mockStatic(UserContextHolder.class)) {
+                given(UserContextHolder.getUserId()).willReturn(userId);
+                given(openChatRoomRepository.findByMember_MemberIdAndDeletedAtNull(userId)).willReturn(Optional.empty());
+                given(memberRepository.existsById(userId)).willReturn(false);
+
+                assertThatThrownBy(() -> openChatQueryService.getOpenChatroomUrl())
+                        .isInstanceOf(CustomException.class)
+                        .hasFieldOrPropertyWithValue("errorCode", ErrorCode.MEMBER_NOT_FOUND);
+            }
+        }
+
+        @Test
+        @DisplayName("회원은 존재하지만 오픈 채팅방이 없으면 OPEN_CHAT_ROOM_NOT_FOUND 예외를 던진다")
+        void throws_when_open_chat_not_found() {
+            UUID userId = UUID.randomUUID();
+            Member member = createMember(userId);
+
+            try (MockedStatic<UserContextHolder> ignored = mockStatic(UserContextHolder.class)) {
+                given(UserContextHolder.getUserId()).willReturn(userId);
+                given(openChatRoomRepository.findByMember_MemberIdAndDeletedAtNull(member.getMemberId())).willReturn(Optional.empty());
+                given(memberRepository.existsById(userId)).willReturn(true);
+
+                assertThatThrownBy(() -> openChatQueryService.getOpenChatroomUrl())
                         .isInstanceOf(CustomException.class)
                         .hasFieldOrPropertyWithValue("errorCode", ErrorCode.OPEN_CHAT_ROOM_NOT_FOUND);
             }


### PR DESCRIPTION
## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

자신의 카카오톡 오픈 프로필 조회시 식별자를 반환하지 않아서 수정,삭제가 불가능 했던 부분을 수정하였습니다.

테스트코드 수정하였으며 API 명세서도 수정하였습니다.

### 스크린샷 (선택)
**명세서 사진입니다.**
<img width="1013" height="655" alt="image" src="https://github.com/user-attachments/assets/92203d4e-e3c8-49a0-a40f-213926eb5d2e" />
<img width="988" height="668" alt="image" src="https://github.com/user-attachments/assets/f078168b-2ee4-4120-8b42-11dd614659a1" />
<img width="988" height="816" alt="image" src="https://github.com/user-attachments/assets/c7b94724-d44d-44e0-83ed-c8f5fc5efb6e" />
<img width="1040" height="426" alt="image" src="https://github.com/user-attachments/assets/a99825b0-ea3a-4cae-810b-fef31c134949" />

**테스트 코드 사진입니다.**
<img width="721" height="380" alt="image" src="https://github.com/user-attachments/assets/676657ba-729b-485a-ae37-88fdeff4192d" />
<img width="718" height="81" alt="image" src="https://github.com/user-attachments/assets/cc0766bd-bd57-4b56-bae0-2945f9d65368" />

Closes #345 