### PR TITLE
[Feat] 채팅방 목록 조회시 상대방 식별자 추가 [0.7.6]

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ plugins {
 }
 
 group = 'com.project200'
-version = '0.7.5-SNAPSHOT'
+version = '0.7.6-SNAPSHOT'
 
 java {
     toolchain {

--- a/src/main/java/com/project200/undabang/chat/dto/response/GetMemberChatroomResponse.java
+++ b/src/main/java/com/project200/undabang/chat/dto/response/GetMemberChatroomResponse.java
@@ -6,12 +6,14 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
+import java.util.UUID;
 
 @Getter
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
 public class GetMemberChatroomResponse {
+    private UUID otherMemberId;
     private Long chatRoomId;
     private String otherMemberNickname;
     private String otherMemberProfileImageUrl;

--- a/src/main/java/com/project200/undabang/chat/repository/ChatroomMemberRepositoryCustom.java
+++ b/src/main/java/com/project200/undabang/chat/repository/ChatroomMemberRepositoryCustom.java
@@ -11,6 +11,5 @@ import java.util.Optional;
 public interface ChatroomMemberRepositoryCustom {
     List<GetMemberChatroomResponse> getChatroomListByMemberId(Member member);
     Optional<ChatroomMemberStatus> getOpponentStatusByChatroomId(Long chatroomId, Member member);
-
     boolean checkOtherMemberBlocked(Chatroom currentChatroom, Member currentMember);
 }

--- a/src/main/java/com/project200/undabang/chat/repository/impl/ChatroomMemberRepositoryImpl.java
+++ b/src/main/java/com/project200/undabang/chat/repository/impl/ChatroomMemberRepositoryImpl.java
@@ -83,6 +83,7 @@ public class ChatroomMemberRepositoryImpl implements ChatroomMemberRepositoryCus
 
         return queryFactory
                 .select(Projections.constructor(GetMemberChatroomResponse.class,
+                        otherMember.memberId,
                         chatroom.id,
                         otherMember.memberNickname,
                         otherMemberPicture.memberPicturesUrl,

--- a/src/test/java/com/project200/undabang/chat/controller/ChatQueryControllerTest.java
+++ b/src/test/java/com/project200/undabang/chat/controller/ChatQueryControllerTest.java
@@ -49,87 +49,18 @@ class ChatQueryControllerTest extends AbstractRestDocSupport {
     @MockitoBean
     private ChatQueryService chatQueryService;
 
-    @Nested
-    @DisplayName("GET /api/v1/chat-rooms API는")
-    class GetChatRoomList {
-
-        @Test
-        @DisplayName("다양한 종류의 채팅방 목록을 성공적으로 조회한다")
-        void getChatRoomList_Success() throws Exception {
-            // given: 실제 앱과 유사한 풍부한 Mock 데이터 준비 (최신순으로 정렬됨)
-            UUID memberId = UUID.randomUUID();
-            LocalDateTime now = LocalDateTime.now();
-
-            List<GetMemberChatroomResponse> richResponseList = createRichChatroomResponseList(now);
-
-            given(chatQueryService.getMemberChatroomList()).willReturn(richResponseList);
-
-            // when
-            String response = mockMvc.perform(get("/api/v1/chat-rooms")
-                            .contentType(MediaType.APPLICATION_JSON)
-                            .accept(MediaType.APPLICATION_JSON)
-                            .headers(getCommonApiHeaders(memberId)))
-                    .andExpect(status().isOk())
-                    // then: 응답 본문의 정렬 순서 및 주요 값 검증
-                    .andExpect(jsonPath("$.data[0].chatRoomId").value(101L)) // 가장 최신
-                    .andExpect(jsonPath("$.data[0].unreadCount").value(2))
-                    .andExpect(jsonPath("$.data[4].otherMemberProfileImageUrl").doesNotExist()) // 프로필 없는 유저
-                    .andExpect(jsonPath("$.data[6].lastChatContent").doesNotExist()) // 대화 없는 방
-                    // andDo: API 문서화 수행
-                    .andDo(document.document(
-                            requestHeaders(HEADER_ACCESS_TOKEN),
-                            responseFields(commonResponseFieldsForList(
-                                    fieldWithPath("data[].chatRoomId").type(JsonFieldType.NUMBER).description("채팅방 식별자 정보 입니다."),
-                                    fieldWithPath("data[].otherMemberNickname").type(JsonFieldType.STRING).description("상대방 닉네임 정보 입니다."),
-                                    fieldWithPath("data[].otherMemberProfileImageUrl").type(JsonFieldType.STRING).description("상대방 프로필 이미지 URL 입니다. 프로필 이미지가 없는 경우 기본 이미지를 사용해주세요").optional(),
-                                    fieldWithPath("data[].otherMemberThumbnailImageUrl").type(JsonFieldType.STRING).description("상대방 썸네일 이미지 URL 입니다. 썸네일 이미지가 없는 경우 프로필 이미지를 사용해주세요").optional(),
-                                    fieldWithPath("data[].lastChatContent").type(JsonFieldType.STRING).description("특정 채팅방의 마지막 대화 내용 입니다.").optional(),
-                                    fieldWithPath("data[].lastChatReceivedAt").type(JsonFieldType.STRING).description("특정 채팅방의 마지막 대화 수신 시간을 나타냅니다.").optional(),
-                                    fieldWithPath("data[].unreadCount").type(JsonFieldType.NUMBER).description("특정 채팅방의 읽지 않은 메시지 수를 의미합니다.")
-                            ))
-                    ))
-                    .andReturn().getResponse().getContentAsString();
-
-            // then: 전체 응답 본문 비교
-            String expected = objectMapper.writeValueAsString(CommonResponse.success(richResponseList));
-            assertThat(response).isEqualTo(expected);
-            BDDMockito.then(chatQueryService).should(BDDMockito.times(1)).getMemberChatroomList();
-        }
-
-        @Test
-        @DisplayName("참여중인 채팅방이 없을 경우 빈 목록을 반환한다")
-        void getChatRoomList_Success_Empty() throws Exception {
-            // given
-            UUID memberId = UUID.randomUUID();
-            given(chatQueryService.getMemberChatroomList()).willReturn(Collections.emptyList());
-
-            // when & then
-            mockMvc.perform(get("/api/v1/chat-rooms")
-                            .headers(getCommonApiHeaders(memberId)))
-                    .andExpect(status().isOk())
-                    .andExpect(jsonPath("$.data").isEmpty())
-                    .andDo(document.document(
-                            requestHeaders(HEADER_ACCESS_TOKEN),
-                            responseFields(commonResponseFieldsForList(
-                                    // data가 빈 배열일 경우, 내부 필드를 기술하지 않습니다.
-                            ))
-                    ));
-        }
-
-        @Test
-        @DisplayName("사용자를 찾을 수 없을 경우 404 Not Found를 반환한다")
-        void getChatRoomList_Fail_MemberNotFound() throws Exception {
-            // given
-            UUID memberId = UUID.randomUUID();
-            given(chatQueryService.getMemberChatroomList()).willThrow(new CustomException(ErrorCode.MEMBER_NOT_FOUND));
-
-            // when & then
-            mockMvc.perform(get("/api/v1/chat-rooms")
-                            .headers(getCommonApiHeaders(memberId)))
-                    .andExpect(status().isNotFound());
-
-            BDDMockito.then(chatQueryService).should(BDDMockito.times(1)).getMemberChatroomList();
-        }
+    private ChatMessageDto createChatMessageResponse(Long chatId, String content, boolean isMine) {
+        return new ChatMessageDto(
+                chatId,
+                UUID.randomUUID(),
+                isMine ? "currentUser" : "otherUser",
+                "http://profile.url",
+                "http://thumbnail.url",
+                content,
+                ChatType.USER,
+                LocalDateTime.now(),
+                isMine
+        );
     }
 
     @Nested
@@ -211,68 +142,6 @@ class ChatQueryControllerTest extends AbstractRestDocSupport {
                             .contentType(MediaType.APPLICATION_JSON))
                     .andExpect(status().isNotFound());
         }
-    }
-
-    private ChatMessageDto createChatMessageResponse(Long chatId, String content, boolean isMine) {
-        return new ChatMessageDto(
-                chatId,
-                UUID.randomUUID(),
-                isMine ? "currentUser" : "otherUser",
-                "http://profile.url",
-                "http://thumbnail.url",
-                content,
-                ChatType.USER,
-                LocalDateTime.now(),
-                isMine
-        );
-    }
-
-    private List<GetMemberChatroomResponse> createRichChatroomResponseList(LocalDateTime now) {
-        return List.of(
-                createChatroomResponse(101L, "운동메이트 김민준", "네, 그럼 내일 6시에 헬스장에서 뵐게요!", 2L, now.minusMinutes(5)),
-                createChatroomResponse(102L, "트레이너 C", "이모티콘", 0L, now.minusMinutes(30)),
-                createChatroomResponse(103L, "박서준 축구", "안녕하세요, 오늘 회의록 정리해서 보내드립니다. 검토해보시고 피드백 부탁드리겠습니다. 내용이 길어서...", 1L, now.minusHours(3)),
-                createChatroomResponse(104L, "런닝 이지은", "사진", 0L, now.minusDays(1).withHour(18).withMinute(30)),
-                createChatroomResponseWithNoProfile(105L, "(알수없음)", "혹시 중고거래 가능하신가요?", 1L, now.minusDays(3)),
-                createChatroomResponse(106L, "마성의 러너", "이번주 정모는 강남역 OOO에서 진행됩니다. 꼭 참석해주세요!", 99L, now.minusWeeks(1)),
-                createChatroomResponseWithNoChat(107L, "엣지러너", "https://example.com/profile_new.jpg", "https://example.com/thumbnail_new.jpg")
-        );
-    }
-
-    private GetMemberChatroomResponse createChatroomResponse(Long chatRoomId, String otherNickname, String lastChat, Long unreadCount, LocalDateTime receivedAt) {
-        return GetMemberChatroomResponse.builder()
-                .chatRoomId(chatRoomId)
-                .otherMemberNickname(otherNickname)
-                .otherMemberProfileImageUrl("https://example.com/profile_" + chatRoomId + ".jpg")
-                .otherMemberThumbnailImageUrl("https://example.com/thumbnail_" + chatRoomId + ".jpg")
-                .lastChatContent(lastChat)
-                .lastChatReceivedAt(receivedAt)
-                .unreadCount(unreadCount)
-                .build();
-    }
-
-    private GetMemberChatroomResponse createChatroomResponseWithNoProfile(Long chatRoomId, String otherNickname, String lastChat, Long unreadCount, LocalDateTime receivedAt) {
-        return GetMemberChatroomResponse.builder()
-                .chatRoomId(chatRoomId)
-                .otherMemberNickname(otherNickname)
-                .otherMemberProfileImageUrl(null)
-                .otherMemberThumbnailImageUrl(null)
-                .lastChatContent(lastChat)
-                .lastChatReceivedAt(receivedAt)
-                .unreadCount(unreadCount)
-                .build();
-    }
-
-    private GetMemberChatroomResponse createChatroomResponseWithNoChat(Long chatRoomId, String otherNickname, String profileUrl, String thumbUrl) {
-        return GetMemberChatroomResponse.builder()
-                .chatRoomId(chatRoomId)
-                .otherMemberNickname(otherNickname)
-                .otherMemberProfileImageUrl(profileUrl)
-                .otherMemberThumbnailImageUrl(thumbUrl)
-                .lastChatContent(null)
-                .lastChatReceivedAt(null)
-                .unreadCount(0L)
-                .build();
     }
 
     @Nested
@@ -361,6 +230,141 @@ class ChatQueryControllerTest extends AbstractRestDocSupport {
                     .andExpect(status().isNotFound())
                     .andExpect(jsonPath("$.succeed").value(false))
                     .andExpect(jsonPath("$.code").value(ErrorCode.CHATROOM_MEMBERS_NOT_FOUND.getCode()));
+        }
+    }
+
+    private List<GetMemberChatroomResponse> createRichChatroomResponseList(LocalDateTime now) {
+        return List.of(
+                createChatroomResponse(101L, "운동메이트 김민준", "네, 그럼 내일 6시에 헬스장에서 뵐게요!", 2L, now.minusMinutes(5)),
+                createChatroomResponse(102L, "트레이너 C", "이모티콘", 0L, now.minusMinutes(30)),
+                createChatroomResponse(103L, "박서준 축구", "안녕하세요, 오늘 회의록 정리해서 보내드립니다. 검토해보시고 피드백 부탁드리겠습니다. 내용이 길어서...", 1L, now.minusHours(3)),
+                createChatroomResponse(104L, "런닝 이지은", "사진", 0L, now.minusDays(1).withHour(18).withMinute(30)),
+                createChatroomResponseWithNoProfile(105L, "(알수없음)", "혹시 중고거래 가능하신가요?", 1L, now.minusDays(3)),
+                createChatroomResponse(106L, "마성의 러너", "이번주 정모는 강남역 OOO에서 진행됩니다. 꼭 참석해주세요!", 99L, now.minusWeeks(1)),
+                createChatroomResponseWithNoChat(107L, "엣지러너", "https://example.com/profile_new.jpg", "https://example.com/thumbnail_new.jpg")
+        );
+    }
+
+    private GetMemberChatroomResponse createChatroomResponse(Long chatRoomId, String otherNickname, String lastChat, Long unreadCount, LocalDateTime receivedAt) {
+        return GetMemberChatroomResponse.builder()
+                .otherMemberId(UUID.randomUUID()) // 추가된 필드
+                .chatRoomId(chatRoomId)
+                .otherMemberNickname(otherNickname)
+                .otherMemberProfileImageUrl("https://example.com/profile_" + chatRoomId + ".jpg")
+                .otherMemberThumbnailImageUrl("https://example.com/thumbnail_" + chatRoomId + ".jpg")
+                .lastChatContent(lastChat)
+                .lastChatReceivedAt(receivedAt)
+                .unreadCount(unreadCount)
+                .build();
+    }
+
+    private GetMemberChatroomResponse createChatroomResponseWithNoProfile(Long chatRoomId, String otherNickname, String lastChat, Long unreadCount, LocalDateTime receivedAt) {
+        return GetMemberChatroomResponse.builder()
+                .otherMemberId(UUID.randomUUID()) // 추가된 필드
+                .chatRoomId(chatRoomId)
+                .otherMemberNickname(otherNickname)
+                .otherMemberProfileImageUrl(null)
+                .otherMemberThumbnailImageUrl(null)
+                .lastChatContent(lastChat)
+                .lastChatReceivedAt(receivedAt)
+                .unreadCount(unreadCount)
+                .build();
+    }
+
+    private GetMemberChatroomResponse createChatroomResponseWithNoChat(Long chatRoomId, String otherNickname, String profileUrl, String thumbUrl) {
+        return GetMemberChatroomResponse.builder()
+                .otherMemberId(UUID.randomUUID()) // 추가된 필드
+                .chatRoomId(chatRoomId)
+                .otherMemberNickname(otherNickname)
+                .otherMemberProfileImageUrl(profileUrl)
+                .otherMemberThumbnailImageUrl(thumbUrl)
+                .lastChatContent(null)
+                .lastChatReceivedAt(null)
+                .unreadCount(0L)
+                .build();
+    }
+
+    @Nested
+    @DisplayName("GET /api/v1/chat-rooms API는")
+    class GetChatRoomList {
+
+        @Test
+        @DisplayName("다양한 종류의 채팅방 목록을 성공적으로 조회한다")
+        void getChatRoomList_Success() throws Exception {
+            // given: 실제 앱과 유사한 풍부한 Mock 데이터 준비 (최신순으로 정렬됨)
+            UUID memberId = UUID.randomUUID();
+            LocalDateTime now = LocalDateTime.now();
+
+            List<GetMemberChatroomResponse> richResponseList = createRichChatroomResponseList(now);
+
+            given(chatQueryService.getMemberChatroomList()).willReturn(richResponseList);
+
+            // when
+            String response = mockMvc.perform(get("/api/v1/chat-rooms")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .accept(MediaType.APPLICATION_JSON)
+                            .headers(getCommonApiHeaders(memberId)))
+                    .andExpect(status().isOk())
+                    // then: 응답 본문의 정렬 순서 및 주요 값 검증
+                    .andExpect(jsonPath("$.data[0].chatRoomId").value(101L)) // 가장 최신
+                    .andExpect(jsonPath("$.data[0].unreadCount").value(2))
+                    .andExpect(jsonPath("$.data[4].otherMemberProfileImageUrl").doesNotExist()) // 프로필 없는 유저
+                    .andExpect(jsonPath("$.data[6].lastChatContent").doesNotExist()) // 대화 없는 방
+                    // andDo: API 문서화 수행
+                    .andDo(document.document(
+                            requestHeaders(HEADER_ACCESS_TOKEN),
+                            responseFields(commonResponseFieldsForList(
+                                    fieldWithPath("data[].otherMemberId").type(JsonFieldType.STRING).description("채팅방을 유지중인 다른 회원의 회원 식별자 정보 입니다."),
+                                    fieldWithPath("data[].chatRoomId").type(JsonFieldType.NUMBER).description("채팅방 식별자 정보 입니다."),
+                                    fieldWithPath("data[].otherMemberNickname").type(JsonFieldType.STRING).description("상대방 닉네임 정보 입니다."),
+                                    fieldWithPath("data[].otherMemberProfileImageUrl").type(JsonFieldType.STRING).description("상대방 프로필 이미지 URL 입니다. 프로필 이미지가 없는 경우 기본 이미지를 사용해주세요").optional(),
+                                    fieldWithPath("data[].otherMemberThumbnailImageUrl").type(JsonFieldType.STRING).description("상대방 썸네일 이미지 URL 입니다. 썸네일 이미지가 없는 경우 프로필 이미지를 사용해주세요").optional(),
+                                    fieldWithPath("data[].lastChatContent").type(JsonFieldType.STRING).description("특정 채팅방의 마지막 대화 내용 입니다.").optional(),
+                                    fieldWithPath("data[].lastChatReceivedAt").type(JsonFieldType.STRING).description("특정 채팅방의 마지막 대화 수신 시간을 나타냅니다.").optional(),
+                                    fieldWithPath("data[].unreadCount").type(JsonFieldType.NUMBER).description("특정 채팅방의 읽지 않은 메시지 수를 의미합니다.")
+                            ))
+                    ))
+                    .andReturn().getResponse().getContentAsString();
+
+            // then: 전체 응답 본문 비교
+            String expected = objectMapper.writeValueAsString(CommonResponse.success(richResponseList));
+            assertThat(response).isEqualTo(expected);
+            BDDMockito.then(chatQueryService).should(BDDMockito.times(1)).getMemberChatroomList();
+        }
+
+        @Test
+        @DisplayName("참여중인 채팅방이 없을 경우 빈 목록을 반환한다")
+        void getChatRoomList_Success_Empty() throws Exception {
+            // given
+            UUID memberId = UUID.randomUUID();
+            given(chatQueryService.getMemberChatroomList()).willReturn(Collections.emptyList());
+
+            // when & then
+            mockMvc.perform(get("/api/v1/chat-rooms")
+                            .headers(getCommonApiHeaders(memberId)))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.data").isEmpty())
+                    .andDo(document.document(
+                            requestHeaders(HEADER_ACCESS_TOKEN),
+                            responseFields(commonResponseFieldsForList(
+                                    // data가 빈 배열일 경우, 내부 필드를 기술하지 않습니다.
+                            ))
+                    ));
+        }
+
+        @Test
+        @DisplayName("사용자를 찾을 수 없을 경우 404 Not Found를 반환한다")
+        void getChatRoomList_Fail_MemberNotFound() throws Exception {
+            // given
+            UUID memberId = UUID.randomUUID();
+            given(chatQueryService.getMemberChatroomList()).willThrow(new CustomException(ErrorCode.MEMBER_NOT_FOUND));
+
+            // when & then
+            mockMvc.perform(get("/api/v1/chat-rooms")
+                            .headers(getCommonApiHeaders(memberId)))
+                    .andExpect(status().isNotFound());
+
+            BDDMockito.then(chatQueryService).should(BDDMockito.times(1)).getMemberChatroomList();
         }
     }
 }

--- a/src/test/java/com/project200/undabang/chat/repository/impl/ChatroomMemberRepositoryImplTest.java
+++ b/src/test/java/com/project200/undabang/chat/repository/impl/ChatroomMemberRepositoryImplTest.java
@@ -40,83 +40,6 @@ class ChatroomMemberRepositoryImplTest {
         em.clear();
     }
 
-    private Member createMember(String email, String nickname) {
-        return Member.builder()
-                .memberId(UUID.randomUUID())
-                .memberEmail(email)
-                .memberNickname(nickname)
-                .memberGender(MemberGender.UNKNOWN)
-                .memberBday(LocalDate.of(1990, 1, 1))
-                .build();
-    }
-
-    private Chatroom createChatroom() {
-        return Chatroom.builder().build();
-    }
-
-    // ===== Helper Methods (One per Entity) =====
-
-    private ChatroomMember createChatroomMember(Chatroom chatroom, Member member, ChatroomMemberStatus status, Long lastReadChatId) {
-        return ChatroomMember.builder()
-                .chatroom(chatroom)
-                .member(member)
-                .chatroomMemberStatus(status)
-                .lastReadChatId(lastReadChatId)
-                .build();
-    }
-
-    private Chat createChat(Chatroom chatroom, Member sender, String content, ChatType chatType) {
-        return Chat.builder()
-                .chatroom(chatroom)
-                .sender(sender)
-                .chatContent(content)
-                .chatType(chatType)
-                .build();
-    }
-
-    private MemberBlock createMemberBlock(Member blocker, Member blocked) {
-        return MemberBlock.builder()
-                .blocker(blocker)
-                .blocked(blocked)
-                .build();
-    }
-
-    @Nested
-    class GetChatroomListByMemberIdTests {
-
-        @Test
-        void shouldReturnEmptyListWhenNoChatrooms() {
-            Member member = createMember("test@example.com", "testUser");
-            persistAndFlush(member);
-
-            List<GetMemberChatroomResponse> result = chatroomMemberRepository.getChatroomListByMemberId(member);
-
-            assertThat(result).isEmpty();
-        }
-
-        @Test
-        void shouldReturnChatroomListWithUnreadCount() {
-            // given
-            Member currentMember = createMember("current@example.com", "currentUser");
-            Member otherMember = createMember("other@example.com", "otherUser");
-            Chatroom chatroom = createChatroom();
-            // 각 참여자의 상태와 마지막으로 읽은 채팅 ID를 명시적으로 설정
-            ChatroomMember currentCM = createChatroomMember(chatroom, currentMember, ChatroomMemberStatus.ACTIVE, 0L);
-            ChatroomMember otherCM = createChatroomMember(chatroom, otherMember, ChatroomMemberStatus.ACTIVE, 0L);
-            Chat unreadChat = createChat(chatroom, otherMember, "Unread message", ChatType.USER);
-            persistAndFlush(currentMember, otherMember, chatroom, currentCM, otherCM, unreadChat);
-
-            // when
-            List<GetMemberChatroomResponse> result = chatroomMemberRepository.getChatroomListByMemberId(currentMember);
-
-            // then
-            assertThat(result).hasSize(1);
-            GetMemberChatroomResponse response = result.get(0);
-            assertThat(response.getOtherMemberNickname()).isEqualTo(otherMember.getMemberNickname());
-            assertThat(response.getUnreadCount()).isEqualTo(1L);
-        }
-    }
-
     @Nested
     @DisplayName("상대방 상태 조회 (getOpponentStatusByChatroomId)")
     class GetOpponentStatusByChatroomIdTests {
@@ -198,6 +121,82 @@ class ChatroomMemberRepositoryImplTest {
 
             // then
             assertThat(isBlocked).isFalse();
+        }
+    }
+
+    private Member createMember(String email, String nickname) {
+        return Member.builder()
+                .memberId(UUID.randomUUID())
+                .memberEmail(email)
+                .memberNickname(nickname)
+                .memberGender(MemberGender.UNKNOWN)
+                .memberBday(LocalDate.of(1990, 1, 1))
+                .build();
+    }
+
+    private Chatroom createChatroom() {
+        return Chatroom.builder().build();
+    }
+
+    private ChatroomMember createChatroomMember(Chatroom chatroom, Member member, ChatroomMemberStatus status, Long lastReadChatId) {
+        return ChatroomMember.builder()
+                .chatroom(chatroom)
+                .member(member)
+                .chatroomMemberStatus(status)
+                .lastReadChatId(lastReadChatId)
+                .build();
+    }
+
+    private Chat createChat(Chatroom chatroom, Member sender, String content, ChatType chatType) {
+        return Chat.builder()
+                .chatroom(chatroom)
+                .sender(sender)
+                .chatContent(content)
+                .chatType(chatType)
+                .build();
+    }
+
+    private MemberBlock createMemberBlock(Member blocker, Member blocked) {
+        return MemberBlock.builder()
+                .blocker(blocker)
+                .blocked(blocked)
+                .build();
+    }
+
+    @Nested
+    class GetChatroomListByMemberIdTests {
+
+        @Test
+        void shouldReturnEmptyListWhenNoChatrooms() {
+            Member member = createMember("test@example.com", "testUser");
+            persistAndFlush(member);
+
+            List<GetMemberChatroomResponse> result = chatroomMemberRepository.getChatroomListByMemberId(member);
+
+            assertThat(result).isEmpty();
+        }
+
+        @Test
+        void shouldReturnChatroomListWithUnreadCount() {
+            // given
+            Member currentMember = createMember("current@example.com", "currentUser");
+            Member otherMember = createMember("other@example.com", "otherUser");
+            Chatroom chatroom = createChatroom();
+            ChatroomMember currentCM = createChatroomMember(chatroom, currentMember, ChatroomMemberStatus.ACTIVE, 0L);
+            ChatroomMember otherCM = createChatroomMember(chatroom, otherMember, ChatroomMemberStatus.ACTIVE, 0L);
+            Chat unreadChat = createChat(chatroom, otherMember, "Unread message", ChatType.USER);
+            persistAndFlush(currentMember, otherMember, chatroom, currentCM, otherCM, unreadChat);
+
+            // when
+            List<GetMemberChatroomResponse> result = chatroomMemberRepository.getChatroomListByMemberId(currentMember);
+
+            // then
+            assertThat(result).hasSize(1);
+            GetMemberChatroomResponse response = result.get(0);
+            assertThat(response.getOtherMemberNickname()).isEqualTo(otherMember.getMemberNickname());
+            assertThat(response.getUnreadCount()).isEqualTo(1L);
+            // 추가 검증: 반환된 DTO의 memberId가 실제 상대 멤버의 memberId와 동일한지 확인
+            assertThat(response.getOtherMemberId()).isEqualTo(otherMember.getMemberId());
         }
     }
 }

--- a/src/test/java/com/project200/undabang/chat/service/impl/ChatQueryServiceImplTest.java
+++ b/src/test/java/com/project200/undabang/chat/service/impl/ChatQueryServiceImplTest.java
@@ -42,7 +42,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
-class dChatQueryServiceImplTest {
+class ChatQueryServiceImplTest {
 
     @InjectMocks
     private ChatQueryServiceImpl chatQueryService;
@@ -126,10 +126,6 @@ class dChatQueryServiceImplTest {
                 verify(chatroomMemberRepository, never()).getChatroomListByMemberId(any(Member.class));
             }
         }
-    }
-
-    private Member createMember(UUID id) {
-        return Member.builder().memberId(id).memberEmail("test@test.com").memberNickname("test").build();
     }
 
     @Nested
@@ -281,30 +277,6 @@ class dChatQueryServiceImplTest {
                 assertThat(result.getNewChats()).isEqualTo(messages);
             }
         }
-    }
-
-    private ChatroomMember createChatroomMember(Member member, ChatroomMemberStatus status) {
-        return createChatroomMember(member, status, null);
-    }
-
-    private ChatroomMember createChatroomMember(Member member, ChatroomMemberStatus status, Long lastReadChatId) {
-        return ChatroomMember.builder().member(member).chatroomMemberStatus(status).lastReadChatId(lastReadChatId).build();
-    }
-
-    private ChatMessageDto createChatMessageDto(Long chatId, String content) {
-        return new ChatMessageDto(chatId, UUID.randomUUID(), "sender", null, null, content, ChatType.USER, LocalDateTime.now(), false);
-    }
-
-    private GetMemberChatroomResponse createGetMemberChatroomResponse() {
-        return GetMemberChatroomResponse.builder()
-                .chatRoomId(1L)
-                .otherMemberNickname("otherUser")
-                .otherMemberProfileImageUrl("http://example.com/profile.jpg")
-                .otherMemberThumbnailImageUrl("http://example.com/thumbnail.jpg")
-                .lastChatContent("Hello")
-                .lastChatReceivedAt(LocalDateTime.now())
-                .unreadCount(1L)
-                .build();
     }
 
     @Nested
@@ -486,5 +458,34 @@ class dChatQueryServiceImplTest {
                 verify(chatroomMemberRepository, never()).checkOtherMemberBlocked(any(), any());
             }
         }
+    }
+
+    private Member createMember(UUID id) {
+        return Member.builder().memberId(id).memberEmail("test@test.com").memberNickname("test").build();
+    }
+
+    private ChatroomMember createChatroomMember(Member member, ChatroomMemberStatus status) {
+        return createChatroomMember(member, status, null);
+    }
+
+    private ChatroomMember createChatroomMember(Member member, ChatroomMemberStatus status, Long lastReadChatId) {
+        return ChatroomMember.builder().member(member).chatroomMemberStatus(status).lastReadChatId(lastReadChatId).build();
+    }
+
+    private ChatMessageDto createChatMessageDto(Long chatId, String content) {
+        return new ChatMessageDto(chatId, UUID.randomUUID(), "sender", null, null, content, ChatType.USER, LocalDateTime.now(), false);
+    }
+
+    private GetMemberChatroomResponse createGetMemberChatroomResponse() {
+        return GetMemberChatroomResponse.builder()
+                .otherMemberId(UUID.randomUUID()) // 추가된 필드
+                .chatRoomId(1L)
+                .otherMemberNickname("otherUser")
+                .otherMemberProfileImageUrl("http://example.com/profile.jpg")
+                .otherMemberThumbnailImageUrl("http://example.com/thumbnail.jpg")
+                .lastChatContent("Hello")
+                .lastChatReceivedAt(LocalDateTime.now())
+                .unreadCount(1L)
+                .build();
     }
 }


### PR DESCRIPTION
## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

현재 내 채팅방 목록 조회 기능에서 차단 기능 수행을 위해 상대방 식별자를 반환값에 추가하였습니다.
테스트코드를 작성한 상태입니다.

### 스크린샷 (선택)
**API 응답 사진:** (API 응답 스크린샷을 첨부해주세요.)
<img width="539" height="416" alt="image" src="https://github.com/user-attachments/assets/f47a2b65-83ab-4e8a-9cab-321270e14533" />

**API 명세서 사진:** (API 명세서 스크린샷을 첨부해주세요.)
<img width="966" height="726" alt="image" src="https://github.com/user-attachments/assets/d2ab84eb-3d5d-4079-b619-7d0ea1effb3d" />
<img width="1043" height="358" alt="image" src="https://github.com/user-attachments/assets/5b1f82a0-cd81-48e6-9623-a5577dee7f87" />

**테스트 커버리지 사진:** (테스트 커버리지 스크린샷을 첨부해주세요.)
<img width="718" height="104" alt="image" src="https://github.com/user-attachments/assets/e17946ac-cc49-4019-8185-bb8562c17662" />

Closes #388 
@copilot 