### PR TITLE
[HOTFIX] QA중 발생한 데드락 관련 오류 해결

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ plugins {
 }
 
 group = 'com.project200'
-version = '0.7.7-SNAPSHOT'
+version = '0.8.0-SNAPSHOT'
 
 java {
     toolchain {

--- a/src/main/java/com/project200/undabang/chat/service/impl/ChatCommandServiceImpl.java
+++ b/src/main/java/com/project200/undabang/chat/service/impl/ChatCommandServiceImpl.java
@@ -15,11 +15,13 @@ import com.project200.undabang.common.web.exception.ErrorCode;
 import com.project200.undabang.member.entity.Member;
 import com.project200.undabang.member.repository.MemberBlockRepository;
 import com.project200.undabang.member.repository.MemberRepository;
+import jakarta.persistence.EntityManager;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.Comparator;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
@@ -35,6 +37,7 @@ public class ChatCommandServiceImpl implements ChatCommandService {
     private final ChatRepository chatRepository;
     private final ChatroomMemberRepository chatroomMemberRepository;
     private final MemberBlockRepository memberBlockRepository;
+    private final EntityManager em;
 
     private final int DIRECT_CHAT_MAX_MEMBER_COUNT = 2;
 
@@ -53,24 +56,8 @@ public class ChatCommandServiceImpl implements ChatCommandService {
             throw new CustomException(ErrorCode.SELF_CHAT_NOT_ALLOWED);
         }
 
-        // 혹시 두 회원이 동시에 채팅방을 생성할 가능성이 있기 때문에 비관적 락을 적용해서 채팅방이 동시에 생성되는 것을 방지함
-        List<UUID> sortedMemberIdList = Stream.of(currentMemberId, targetMemberId).sorted().toList();
-        List<Member> pessimisticLockedMemberList = memberRepository.findAllByIdWithPessimisticLock(sortedMemberIdList);
-
-        // 혹시 DB에서 락을 잘못 적용했을 경우 에러 반환
-        if (pessimisticLockedMemberList.size() != DIRECT_CHAT_MAX_MEMBER_COUNT) {
-            throw new CustomException(ErrorCode.INTERNAL_SERVER_ERROR);
-        }
-
-        Member currentMember = pessimisticLockedMemberList.stream()
-                .filter(m -> m.getMemberId().equals(currentMemberId))
-                .findFirst()
-                .orElseThrow(() -> new CustomException(ErrorCode.INTERNAL_SERVER_ERROR));
-
-        Member targetMember = pessimisticLockedMemberList.stream()
-                .filter(m -> m.getMemberId().equals(targetMemberId))
-                .findFirst()
-                .orElseThrow(() -> new CustomException(ErrorCode.INTERNAL_SERVER_ERROR));
+        Member currentMember = getMember(currentMemberId);
+        Member targetMember = getMember(targetMemberId);
 
         // 차단 관계가 있는 경우 채팅방 생성 금지
         if (memberBlockRepository.checkMemberBlockExists(currentMember, targetMember)) {
@@ -143,10 +130,9 @@ public class ChatCommandServiceImpl implements ChatCommandService {
         Optional<Chatroom> existingChatroom = chatroomRepository.findChatroomBetweenMembers(currentMember, targetMember);
 
         if (existingChatroom.isPresent()) {
-            Chatroom chatroom = existingChatroom.get();
-            return findExistingChatroom(chatroom, currentMember, targetMember);
+            return findExistingChatroom(existingChatroom.get(), currentMember, targetMember);
         } else {
-            return createNewChatroom(currentMember, targetMember);
+            return createNewChatroomWithLock(currentMember, targetMember);
         }
     }
 
@@ -175,8 +161,16 @@ public class ChatCommandServiceImpl implements ChatCommandService {
 
         boolean hasReactivated = (currentChatroomMember.getChatroomMemberStatus() == ChatroomMemberStatus.LEFT);
 
-        currentChatroomMember.updateMemberStatus(ChatroomMemberStatus.ACTIVE);
-        targetChatroomMember.updateMemberStatus(ChatroomMemberStatus.ACTIVE);
+        // 데드락 방지를 위해 ID를 기준으로 정렬하여 업데이트 순서를 보장 (기존 변경감지 코드는 데드락 유발)
+        // 그 후, flush를 사용하여 DB에 즉시 반영
+        List<ChatroomMember> membersToUpdate = Stream.of(currentChatroomMember, targetChatroomMember)
+                .sorted(Comparator.comparing(ChatroomMember::getChatroomMemberId))
+                .toList();
+
+        for (ChatroomMember cm : membersToUpdate) {
+            cm.updateMemberStatus(ChatroomMemberStatus.ACTIVE);
+            em.flush();
+        }
 
         if (hasReactivated) {
             Chat systemChat = Chat.ofRoomCreation(SystemMessage.USER_CREATED_CHAT_ROOM.format(currentMember.getMemberNickname()), chatroom);
@@ -184,6 +178,31 @@ public class ChatCommandServiceImpl implements ChatCommandService {
         }
 
         return chatroom;
+    }
+
+    /**
+     * 현재 멤버와 대상 멤버 간의 새 채팅방을 생성합니다.
+     * 비관적 락(pessimistic lock)을 사용하여 멀티스레드 환경에서의 동시성을 제어하고,
+     * 안전하게 새로운 채팅방을 생성하도록 구현되었습니다.
+     */
+    private Chatroom createNewChatroomWithLock(Member currentMember, Member targetMember) {
+        // 3. 신규 생성이 필요할 때만 비관적 락을 건다.
+        List<UUID> sortedMemberIdList = Stream.of(currentMember.getMemberId(), targetMember.getMemberId()).sorted().toList();
+        List<Member> pessimisticLockedMemberList = memberRepository.findAllByIdWithPessimisticLock(sortedMemberIdList);
+
+        if (pessimisticLockedMemberList.size() != DIRECT_CHAT_MAX_MEMBER_COUNT) {
+            // 이 부분은 이제 거의 발생하지 않아야 하지만 안전장치로 둔다.
+            throw new CustomException(ErrorCode.INTERNAL_SERVER_ERROR);
+        }
+
+        // 4. Double-checked locking: 락을 획득한 후, 그 사이에 다른 스레드가 채팅방을 만들었는지 다시 한번 확인
+        Optional<Chatroom> recheckChatroom = chatroomRepository.findChatroomBetweenMembers(currentMember, targetMember);
+        if (recheckChatroom.isPresent()) {
+            return recheckChatroom.get(); // 이미 생성되었다면 그것을 반환
+        }
+
+        // 5. 이제서야 안전하게 새로운 채팅방을 생성
+        return createNewChatroom(currentMember, targetMember);
     }
 
     /**

--- a/src/test/java/com/project200/undabang/chat/service/impl/ChatCommandServiceImplConcurrencyTest.java
+++ b/src/test/java/com/project200/undabang/chat/service/impl/ChatCommandServiceImplConcurrencyTest.java
@@ -1,0 +1,134 @@
+package com.project200.undabang.chat.service.impl;
+
+import com.project200.undabang.chat.dto.request.CreateChatroomRequest;
+import com.project200.undabang.chat.entity.Chatroom;
+import com.project200.undabang.chat.entity.ChatroomMember;
+import com.project200.undabang.chat.entity.ChatroomMemberStatus;
+import com.project200.undabang.chat.repository.ChatroomMemberRepository;
+import com.project200.undabang.chat.repository.ChatroomRepository;
+import com.project200.undabang.chat.service.ChatCommandService;
+import com.project200.undabang.common.context.UserContextHolder;
+import com.project200.undabang.member.entity.Member;
+import com.project200.undabang.member.repository.MemberRepository;
+import jakarta.persistence.EntityManager;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.transaction.TestTransaction;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+@ActiveProfiles("test")
+@SpringBootTest
+@DisplayName("ChatCommandService 데드락 방지 통합 테스트")
+class ChatCommandServiceImplConcurrencyTest {
+
+    @Autowired
+    private ChatCommandService chatCommandService;
+    @Autowired
+    private MemberRepository memberRepository;
+    @Autowired
+    private ChatroomRepository chatroomRepository;
+    @Autowired
+    private ChatroomMemberRepository chatroomMemberRepository;
+    @Autowired
+    private EntityManager em;
+
+    private Member createAndSaveMember(String nickname, String email) {
+        Member member = Member.builder()
+                .memberId(UUID.randomUUID())
+                .memberNickname(nickname)
+                .memberEmail(email)
+                .memberBday(LocalDate.of(2000, 1, 1))
+                .build();
+        return memberRepository.save(member);
+    }
+
+    private Chatroom setupLeftChatroom(Member memberA, Member memberB) {
+        Chatroom chatroom = chatroomRepository.save(Chatroom.createChatroom());
+        ChatroomMember cmA = ChatroomMember.of(chatroom, memberA);
+        cmA.updateMemberStatus(ChatroomMemberStatus.LEFT);
+        ChatroomMember cmB = ChatroomMember.of(chatroom, memberB);
+        cmB.updateMemberStatus(ChatroomMemberStatus.LEFT);
+        chatroomMemberRepository.saveAll(List.of(cmA, cmB));
+        return chatroom;
+    }
+
+    @Nested
+    @DisplayName("채팅방 생성 동시성 환경에서")
+    class ConcurrencyTest {
+
+        @Test
+        @Transactional
+        @DisplayName("두 사용자가 거의 동시에 서로에게 채팅방 생성을 요청해도 데드락이 발생하지 않아야 한다")
+        void createChatroom_concurrently_shouldNotCauseDeadlock() throws InterruptedException {
+            Member memberA = createAndSaveMember("UserA", "a@test.com");
+            Member memberB = createAndSaveMember("UserB", "b@test.com");
+            Chatroom chatroom = setupLeftChatroom(memberA, memberB);
+
+            TestTransaction.flagForCommit();
+            TestTransaction.end();
+            TestTransaction.start();
+
+            // 이제 새로운 트랜잭션이 시작되었으므로, 필요한 엔티티를 다시 조회해야 함
+            final Member persistedMemberA = memberRepository.findById(memberA.getMemberId()).get();
+            final Member persistedMemberB = memberRepository.findById(memberB.getMemberId()).get();
+            final Chatroom persistedChatroom = chatroomRepository.findById(chatroom.getId()).get();
+
+            int threadCount = 20;
+            ExecutorService executorService = Executors.newFixedThreadPool(threadCount);
+            CountDownLatch latch = new CountDownLatch(threadCount);
+            AtomicInteger failureCount = new AtomicInteger(0);
+
+            CreateChatroomRequest requestFromA = new CreateChatroomRequest(persistedMemberB.getMemberId());
+            CreateChatroomRequest requestFromB = new CreateChatroomRequest(persistedMemberA.getMemberId());
+
+            for (int i = 0; i < threadCount; i++) {
+                final boolean isAtoBRequest = i % 2 == 0;
+
+                executorService.submit(() -> {
+                    try (MockedStatic<UserContextHolder> mockedUserContext = Mockito.mockStatic(UserContextHolder.class)) {
+                        if (isAtoBRequest) {
+                            when(UserContextHolder.getUserId()).thenReturn(persistedMemberA.getMemberId());
+                            chatCommandService.createChatroom(requestFromA);
+                        } else {
+                            when(UserContextHolder.getUserId()).thenReturn(persistedMemberB.getMemberId());
+                            chatCommandService.createChatroom(requestFromB);
+                        }
+                    } catch (Exception e) {
+                        System.err.println("Exception occurred in thread: " + e.getClass().getSimpleName() + " - " + e.getMessage());
+                        failureCount.incrementAndGet();
+                    } finally {
+                        latch.countDown();
+                    }
+                });
+            }
+
+            latch.await();
+            executorService.shutdown();
+
+            assertThat(failureCount.get()).as("데드락 또는 다른 예외가 발생했습니다.").isEqualTo(0);
+
+            ChatroomMember updatedMemberA = chatroomMemberRepository.findByChatroomAndMember(persistedChatroom, persistedMemberA).get();
+            ChatroomMember updatedMemberB = chatroomMemberRepository.findByChatroomAndMember(persistedChatroom, persistedMemberB).get();
+
+            assertThat(updatedMemberA.getChatroomMemberStatus()).isEqualTo(ChatroomMemberStatus.ACTIVE);
+            assertThat(updatedMemberB.getChatroomMemberStatus()).isEqualTo(ChatroomMemberStatus.ACTIVE);
+        }
+    }
+}

--- a/src/test/java/com/project200/undabang/chat/service/impl/ChatCommandServiceImplTest.java
+++ b/src/test/java/com/project200/undabang/chat/service/impl/ChatCommandServiceImplTest.java
@@ -17,6 +17,7 @@ import com.project200.undabang.common.web.exception.ErrorCode;
 import com.project200.undabang.member.entity.Member;
 import com.project200.undabang.member.repository.MemberBlockRepository;
 import com.project200.undabang.member.repository.MemberRepository;
+import jakarta.persistence.EntityManager;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -47,21 +48,21 @@ class ChatCommandServiceImplTest {
 
     @Mock
     private MemberRepository memberRepository;
+
     @Mock
     private ChatroomRepository chatroomRepository;
+
     @Mock
     private ChatRepository chatRepository;
+
     @Mock
     private ChatroomMemberRepository chatroomMemberRepository;
+
     @Mock
     private MemberBlockRepository memberBlockRepository;
 
-    private Member createMember() {
-        return Member.builder()
-                .memberId(UUID.randomUUID())
-                .memberNickname("user_" + UUID.randomUUID().toString().substring(0, 8))
-                .build();
-    }
+    @Mock
+    private EntityManager em;
 
     @Nested
     @DisplayName("deleteChatroom 메소드는")
@@ -327,6 +328,13 @@ class ChatCommandServiceImplTest {
         }
     }
 
+    private Member createMember() {
+        return Member.builder()
+                .memberId(UUID.randomUUID())
+                .memberNickname("user_" + UUID.randomUUID().toString().substring(0, 8))
+                .build();
+    }
+
     private Chatroom createChatroom(Long id) {
         return Chatroom.builder()
                 .id(id)
@@ -343,11 +351,19 @@ class ChatCommandServiceImplTest {
 
     private void mockMemberLocking(Member member1, Member member2) {
         List<UUID> sortedIds = Stream.of(member1.getMemberId(), member2.getMemberId()).sorted().toList();
-        // 정렬된 ID 순서에 맞춰 Member 객체도 정렬하여 반환하도록 설정
         List<Member> sortedMembers = Stream.of(member1, member2)
                 .sorted((m1, m2) -> m1.getMemberId().compareTo(m2.getMemberId()))
                 .toList();
         given(memberRepository.findAllByIdWithPessimisticLock(sortedIds)).willReturn(sortedMembers);
+    }
+
+    private ChatroomMember createChatroomMemberWithId(Long id, Chatroom chatroom, Member member, ChatroomMemberStatus status) {
+        return ChatroomMember.builder()
+                .chatroomMemberId(id)
+                .chatroom(chatroom)
+                .member(member)
+                .chatroomMemberStatus(status)
+                .build();
     }
 
     @Nested
@@ -365,15 +381,20 @@ class ChatCommandServiceImplTest {
             try (MockedStatic<UserContextHolder> ignored = mockStatic(UserContextHolder.class)) {
                 ignored.when(UserContextHolder::getUserId).thenReturn(currentMember.getMemberId());
 
-                mockMemberLocking(currentMember, targetMember);
+                // [수정] findById Mocking 추가 (리팩토링으로 인해 항상 호출됨)
+                given(memberRepository.findById(currentMember.getMemberId())).willReturn(Optional.of(currentMember));
+                given(memberRepository.findById(targetMember.getMemberId())).willReturn(Optional.of(targetMember));
 
                 given(memberBlockRepository.checkMemberBlockExists(currentMember, targetMember)).willReturn(true);
 
+                // when & then
                 assertThatThrownBy(() -> chatCommandService.createChatroom(request))
                         .isInstanceOf(CustomException.class)
                         .hasMessage(ErrorCode.CHATROOM_CREATE_BLOCKED.getMessage());
 
+                // then
                 verify(chatroomRepository, never()).findChatroomBetweenMembers(any(), any());
+                verify(memberRepository, never()).findAllByIdWithPessimisticLock(anyList());
             }
         }
 
@@ -395,26 +416,6 @@ class ChatCommandServiceImplTest {
         }
 
         @Test
-        @DisplayName("비관적 락으로 조회된 멤버 수가 2가 아니면 예외를 발생시킨다")
-        void it_throws_exception_when_pessimistic_lock_fails() {
-            // given
-            UUID currentMemberId = UUID.randomUUID();
-            UUID targetMemberId = UUID.randomUUID();
-            CreateChatroomRequest request = new CreateChatroomRequest(targetMemberId);
-            List<UUID> sortedIds = Stream.of(currentMemberId, targetMemberId).sorted().toList();
-
-            try (MockedStatic<UserContextHolder> ignored = mockStatic(UserContextHolder.class)) {
-                ignored.when(UserContextHolder::getUserId).thenReturn(currentMemberId);
-                given(memberRepository.findAllByIdWithPessimisticLock(sortedIds)).willReturn(Collections.emptyList());
-
-                // when & then
-                assertThatThrownBy(() -> chatCommandService.createChatroom(request))
-                        .isInstanceOf(CustomException.class)
-                        .hasMessage(ErrorCode.INTERNAL_SERVER_ERROR.getMessage());
-            }
-        }
-
-        @Test
         @DisplayName("기존 채팅방이 없을 경우 새로운 채팅방을 생성한다")
         void it_creates_new_chatroom_if_not_exists() {
             // given
@@ -425,8 +426,18 @@ class ChatCommandServiceImplTest {
 
             try (MockedStatic<UserContextHolder> ignored = mockStatic(UserContextHolder.class)) {
                 ignored.when(UserContextHolder::getUserId).thenReturn(currentMember.getMemberId());
+
+                given(memberRepository.findById(currentMember.getMemberId())).willReturn(Optional.of(currentMember));
+                given(memberRepository.findById(targetMember.getMemberId())).willReturn(Optional.of(targetMember));
+                given(memberBlockRepository.checkMemberBlockExists(any(), any())).willReturn(false);
+
+                // [수정] Double-checked locking 시나리오를 위해 순차적으로 다른 값을 반환하도록 설정
+                // 1차 조회 (락 이전) -> 없음, 2차 조회 (락 이후) -> 없음
+                given(chatroomRepository.findChatroomBetweenMembers(currentMember, targetMember))
+                        .willReturn(Optional.empty())
+                        .willReturn(Optional.empty());
+
                 mockMemberLocking(currentMember, targetMember);
-                given(chatroomRepository.findChatroomBetweenMembers(currentMember, targetMember)).willReturn(Optional.empty());
                 given(chatroomRepository.save(any(Chatroom.class))).willReturn(newChatroom);
 
                 // when
@@ -434,7 +445,46 @@ class ChatCommandServiceImplTest {
 
                 // then
                 assertThat(response.getChatRoomId()).isEqualTo(newChatroom.getId());
-                verify(chatroomMemberRepository).saveAll(any());
+                then(memberRepository).should(times(1)).findAllByIdWithPessimisticLock(anyList());
+                then(chatroomRepository).should(times(1)).save(any(Chatroom.class));
+                then(chatroomMemberRepository).should(times(1)).saveAll(any());
+            }
+        }
+
+        // [추가] Double-checked locking 로직 검증을 위한 테스트 케이스
+        @Test
+        @DisplayName("신규 생성 시, 락을 잡은 후 다른 스레드가 생성한 채팅방을 발견하면 중복 생성하지 않는다")
+        void it_returns_existing_chatroom_when_found_after_lock() {
+            // given
+            Member currentMember = createMember();
+            Member targetMember = createMember();
+            CreateChatroomRequest request = new CreateChatroomRequest(targetMember.getMemberId());
+            Chatroom existingChatroom = createChatroom(1L);
+
+            try (MockedStatic<UserContextHolder> ignored = mockStatic(UserContextHolder.class)) {
+                ignored.when(UserContextHolder::getUserId).thenReturn(currentMember.getMemberId());
+
+                given(memberRepository.findById(currentMember.getMemberId())).willReturn(Optional.of(currentMember));
+                given(memberRepository.findById(targetMember.getMemberId())).willReturn(Optional.of(targetMember));
+                given(memberBlockRepository.checkMemberBlockExists(any(), any())).willReturn(false);
+
+                // [핵심] 1차 조회 시에는 채팅방이 없다가, 2차 조회(락 획득 후) 시에는 채팅방이 있도록 설정
+                given(chatroomRepository.findChatroomBetweenMembers(currentMember, targetMember))
+                        .willReturn(Optional.empty()) // 락 이전 조회
+                        .willReturn(Optional.of(existingChatroom)); // 락 이후 조회
+
+                mockMemberLocking(currentMember, targetMember);
+
+                // when
+                CreateChatroomResponse response = chatCommandService.createChatroom(request);
+
+                // then
+                assertThat(response.getChatRoomId()).isEqualTo(existingChatroom.getId());
+                // 비관적 락은 실행되었어야 함
+                then(memberRepository).should(times(1)).findAllByIdWithPessimisticLock(anyList());
+                // 하지만 새로운 채팅방 생성(save) 로직은 실행되지 않았어야 함
+                then(chatroomRepository).should(never()).save(any(Chatroom.class));
+                then(chatroomMemberRepository).should(never()).saveAll(any());
             }
         }
 
@@ -449,7 +499,10 @@ class ChatCommandServiceImplTest {
 
             try (MockedStatic<UserContextHolder> ignored = mockStatic(UserContextHolder.class)) {
                 ignored.when(UserContextHolder::getUserId).thenReturn(currentMember.getMemberId());
-                mockMemberLocking(currentMember, targetMember);
+
+                given(memberRepository.findById(currentMember.getMemberId())).willReturn(Optional.of(currentMember));
+                given(memberRepository.findById(targetMember.getMemberId())).willReturn(Optional.of(targetMember));
+
                 given(chatroomRepository.findChatroomBetweenMembers(currentMember, targetMember)).willReturn(Optional.of(existingChatroom));
                 given(chatroomMemberRepository.countByChatroomAndChatroomMemberStatus(existingChatroom, ChatroomMemberStatus.ACTIVE)).willReturn(2L);
 
@@ -458,55 +511,29 @@ class ChatCommandServiceImplTest {
 
                 // then
                 assertThat(response.getChatRoomId()).isEqualTo(existingChatroom.getId());
+                then(memberRepository).should(never()).findAllByIdWithPessimisticLock(anyList());
                 verify(chatroomMemberRepository, never()).saveAll(any());
                 verify(chatRepository, never()).save(any());
             }
         }
 
         @Test
-        @DisplayName("기존 채팅방에 나간 멤버가 있으면 멤버 상태를 활성으로 변경하고 채팅방을 반환한다")
-        void it_reactivates_and_returns_chatroom_when_member_left() {
-            // given
-            Member currentMember = createMember();
-            Member targetMember = createMember();
-            CreateChatroomRequest request = new CreateChatroomRequest(targetMember.getMemberId());
-            Chatroom existingChatroom = createChatroom(1L);
-            ChatroomMember currentChatroomMember = createChatroomMember(existingChatroom, currentMember, ChatroomMemberStatus.LEFT);
-            ChatroomMember targetChatroomMember = createChatroomMember(existingChatroom, targetMember, ChatroomMemberStatus.ACTIVE);
-
-            try (MockedStatic<UserContextHolder> ignored = mockStatic(UserContextHolder.class)) {
-                ignored.when(UserContextHolder::getUserId).thenReturn(currentMember.getMemberId());
-                mockMemberLocking(currentMember, targetMember);
-                given(chatroomRepository.findChatroomBetweenMembers(currentMember, targetMember)).willReturn(Optional.of(existingChatroom));
-                given(chatroomMemberRepository.countByChatroomAndChatroomMemberStatus(existingChatroom, ChatroomMemberStatus.ACTIVE)).willReturn(1L);
-                given(chatroomMemberRepository.findByChatroomAndMember(existingChatroom, currentMember)).willReturn(Optional.of(currentChatroomMember));
-                given(chatroomMemberRepository.findByChatroomAndMember(existingChatroom, targetMember)).willReturn(Optional.of(targetChatroomMember));
-
-                // when
-                CreateChatroomResponse response = chatCommandService.createChatroom(request);
-
-                // then
-                assertThat(response.getChatRoomId()).isEqualTo(existingChatroom.getId());
-                assertThat(currentChatroomMember.getChatroomMemberStatus()).isEqualTo(ChatroomMemberStatus.ACTIVE);
-                assertThat(targetChatroomMember.getChatroomMemberStatus()).isEqualTo(ChatroomMemberStatus.ACTIVE);
-                verify(chatRepository).save(any(Chat.class));
-            }
-        }
-
-        @Test
-        @DisplayName("기존 채팅방에 상대방만 나간 상태일 경우 멤버 상태를 활성으로 변경하고 채팅방을 반환한다")
+        @DisplayName("기존 채팅방에 상대방만 나간 상태일 경우 재활성화하고 채팅방을 반환한다")
         void it_reactivates_and_returns_chatroom_when_target_member_left() {
             // given
             Member currentMember = createMember();
             Member targetMember = createMember();
             CreateChatroomRequest request = new CreateChatroomRequest(targetMember.getMemberId());
             Chatroom existingChatroom = createChatroom(1L);
-            ChatroomMember currentChatroomMember = createChatroomMember(existingChatroom, currentMember, ChatroomMemberStatus.ACTIVE);
-            ChatroomMember targetChatroomMember = createChatroomMember(existingChatroom, targetMember, ChatroomMemberStatus.LEFT);
+            ChatroomMember currentChatroomMember = spy(createChatroomMemberWithId(2L, existingChatroom, currentMember, ChatroomMemberStatus.ACTIVE));
+            ChatroomMember targetChatroomMember = spy(createChatroomMemberWithId(3L, existingChatroom, targetMember, ChatroomMemberStatus.LEFT));
 
             try (MockedStatic<UserContextHolder> ignored = mockStatic(UserContextHolder.class)) {
                 ignored.when(UserContextHolder::getUserId).thenReturn(currentMember.getMemberId());
-                mockMemberLocking(currentMember, targetMember);
+
+                given(memberRepository.findById(currentMember.getMemberId())).willReturn(Optional.of(currentMember));
+                given(memberRepository.findById(targetMember.getMemberId())).willReturn(Optional.of(targetMember));
+
                 given(chatroomRepository.findChatroomBetweenMembers(currentMember, targetMember)).willReturn(Optional.of(existingChatroom));
                 given(chatroomMemberRepository.countByChatroomAndChatroomMemberStatus(existingChatroom, ChatroomMemberStatus.ACTIVE)).willReturn(1L);
                 given(chatroomMemberRepository.findByChatroomAndMember(existingChatroom, currentMember)).willReturn(Optional.of(currentChatroomMember));
@@ -517,28 +544,31 @@ class ChatCommandServiceImplTest {
 
                 // then
                 assertThat(response.getChatRoomId()).isEqualTo(existingChatroom.getId());
-                assertThat(currentChatroomMember.getChatroomMemberStatus()).isEqualTo(ChatroomMemberStatus.ACTIVE);
-                assertThat(targetChatroomMember.getChatroomMemberStatus()).isEqualTo(ChatroomMemberStatus.ACTIVE);
+                then(currentChatroomMember).should().updateMemberStatus(ChatroomMemberStatus.ACTIVE);
+                then(targetChatroomMember).should().updateMemberStatus(ChatroomMemberStatus.ACTIVE);
+                then(memberRepository).should(never()).findAllByIdWithPessimisticLock(anyList());
                 // hasReactivated가 false이므로 시스템 메시지는 생성되지 않아야 함
                 verify(chatRepository, never()).save(any(Chat.class));
             }
         }
 
         @Test
-        @DisplayName("비관적 락 이후 멤버를 찾지 못하면 예외를 발생시킨다")
-        void it_throws_exception_when_member_not_found_after_lock() {
+        @DisplayName("신규 생성 시, 비관적 락 이후 멤버 수가 2가 아니면 예외를 발생시킨다")
+        void it_throws_exception_when_pessimistic_lock_fails_on_creation() {
             // given
             Member currentMember = createMember();
             Member targetMember = createMember();
-            // DB 데이터와 불일치하는 상황을 가정하기 위해 다른 ID를 가진 멤버 생성
-            Member anotherMember = createMember();
             CreateChatroomRequest request = new CreateChatroomRequest(targetMember.getMemberId());
             List<UUID> sortedIds = Stream.of(currentMember.getMemberId(), targetMember.getMemberId()).sorted().toList();
 
             try (MockedStatic<UserContextHolder> ignored = mockStatic(UserContextHolder.class)) {
                 ignored.when(UserContextHolder::getUserId).thenReturn(currentMember.getMemberId());
-                // 락은 2개의 멤버를 반환했지만, 그 중 하나가 예상과 다른 멤버인 경우
-                given(memberRepository.findAllByIdWithPessimisticLock(sortedIds)).willReturn(List.of(currentMember, anotherMember));
+
+                given(memberRepository.findById(currentMember.getMemberId())).willReturn(Optional.of(currentMember));
+                given(memberRepository.findById(targetMember.getMemberId())).willReturn(Optional.of(targetMember));
+
+                given(chatroomRepository.findChatroomBetweenMembers(currentMember, targetMember)).willReturn(Optional.empty());
+                given(memberRepository.findAllByIdWithPessimisticLock(sortedIds)).willReturn(Collections.emptyList());
 
                 // when & then
                 assertThatThrownBy(() -> chatCommandService.createChatroom(request))
@@ -548,33 +578,9 @@ class ChatCommandServiceImplTest {
         }
 
         @Test
-        @DisplayName("비관적 락 이후 두 멤버 모두 찾지 못하면 예외를 발생시킨다")
-        void it_throws_exception_when_both_members_not_found_after_lock() {
-            // given
-            Member currentMember = createMember();
-            Member targetMember = createMember();
-            // DB 데이터와 불일치하는 상황을 가정하기 위해 다른 ID를 가진 멤버들 생성
-            Member anotherMember1 = createMember();
-            Member anotherMember2 = createMember();
-            CreateChatroomRequest request = new CreateChatroomRequest(targetMember.getMemberId());
-            List<UUID> sortedIds = Stream.of(currentMember.getMemberId(), targetMember.getMemberId()).sorted().toList();
-
-            try (MockedStatic<UserContextHolder> ignored = mockStatic(UserContextHolder.class)) {
-                ignored.when(UserContextHolder::getUserId).thenReturn(currentMember.getMemberId());
-                // 락은 2개의 멤버를 반환했지만, 둘 다 예상과 다른 멤버인 경우
-                given(memberRepository.findAllByIdWithPessimisticLock(sortedIds)).willReturn(List.of(anotherMember1, anotherMember2));
-
-                // when & then
-                assertThatThrownBy(() -> chatCommandService.createChatroom(request))
-                        .isInstanceOf(CustomException.class)
-                        .hasMessage(ErrorCode.INTERNAL_SERVER_ERROR.getMessage());
-            }
-        }
-
-        @Test
-        @DisplayName("재활성화 시 채팅방 멤버를 찾지 못하면 예외를 발생시킨다")
+        @DisplayName("재활성화 시, 채팅방 멤버 데이터를 찾지 못하면 예외를 발생시킨다")
         void it_throws_exception_when_chatroom_member_not_found_on_reactivation() {
-            // given
+            // given: 재활성화가 필요한 상황 설정
             Member currentMember = createMember();
             Member targetMember = createMember();
             CreateChatroomRequest request = new CreateChatroomRequest(targetMember.getMemberId());
@@ -582,13 +588,20 @@ class ChatCommandServiceImplTest {
 
             try (MockedStatic<UserContextHolder> ignored = mockStatic(UserContextHolder.class)) {
                 ignored.when(UserContextHolder::getUserId).thenReturn(currentMember.getMemberId());
-                mockMemberLocking(currentMember, targetMember);
+
+                // 공통 Mocking 설정
+                given(memberRepository.findById(currentMember.getMemberId())).willReturn(Optional.of(currentMember));
+                given(memberRepository.findById(targetMember.getMemberId())).willReturn(Optional.of(targetMember));
                 given(chatroomRepository.findChatroomBetweenMembers(currentMember, targetMember)).willReturn(Optional.of(existingChatroom));
+
+                // reActiveChatroom 진입 조건 설정
                 given(chatroomMemberRepository.countByChatroomAndChatroomMemberStatus(existingChatroom, ChatroomMemberStatus.ACTIVE)).willReturn(1L);
-                // getChatroomMember 메소드에서 예외가 발생하도록 Optional.empty() 반환
+
+                // [핵심] getChatroomMember 메소드에서 예외가 발생하도록 Optional.empty() 반환 설정
+                // currentMember에 대한 ChatroomMember 정보가 DB에 없는 비정상적인 상황을 시뮬레이션
                 given(chatroomMemberRepository.findByChatroomAndMember(existingChatroom, currentMember)).willReturn(Optional.empty());
 
-                // when & then
+                // when & then: 예외 발생 검증
                 assertThatThrownBy(() -> chatCommandService.createChatroom(request))
                         .isInstanceOf(CustomException.class)
                         .hasMessage(ErrorCode.CHATROOM_MEMBERS_NOT_FOUND.getMessage());


### PR DESCRIPTION
## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

채팅방 생성시 기존의 코드는 A->B // B->A가 동시에 요청하면 데드락이 발생 가능했기 때문에 이를
채팅방 멤버의 식별자를 이용하여 무조건 정렬된 채팅방 멤버의 식별자 순서로 데이터베이스에 저장되게 하여 데드락 발생 상황을 제거하였습니다.

또한 ChatCommandServiceImplConcurrencyTest.java 파일을 통해 동시성 문제에 대해 통합 테스트를 만들고, 동시성 문제가 발생하지 않음을 확인하였습니다.
