### PR TITLE
[FIX] 내 프로필 조회, 다른 회원의 프로필 조회 API에서 삭제된 선호 운동이 조회되는 에러 수정

### DIFF
--- a/src/main/java/com/project200/undabang/member/repository/MemberRepository.java
+++ b/src/main/java/com/project200/undabang/member/repository/MemberRepository.java
@@ -17,6 +17,6 @@ public interface MemberRepository extends JpaRepository<Member, UUID>, MemberRep
 
     Optional<Member> findByMemberIdAndMemberDeletedAtNull(UUID memberId);
 
-    @EntityGraph(attributePaths = {"memberPicture", "memberPicture.picture", "preferredExercises", "preferredExercises.exercise"})
-    Optional<Member> findMemberProfileByMemberIdAndMemberDeletedAtNull(UUID memberId);
+//    @EntityGraph(attributePaths = {"memberPicture", "memberPicture.picture", "preferredExercises", "preferredExercises.exercise"})
+//    Optional<Member> findMemberProfileByMemberIdAndMemberDeletedAtNull(UUID memberId);
 }

--- a/src/main/java/com/project200/undabang/member/repository/MemberRepositoryCustom.java
+++ b/src/main/java/com/project200/undabang/member/repository/MemberRepositoryCustom.java
@@ -15,4 +15,6 @@ public interface MemberRepositoryCustom {
     List<Member> findAllByIdWithPessimisticLock(List<UUID> sortedMemberIdList);
 
     Optional<Member> findMemberWithProfileImage(UUID memberId);
+
+    Optional<Member> findMemberProfileByMemberIdAndMemberDeletedAtNull(UUID memberId);
 }

--- a/src/main/java/com/project200/undabang/member/repository/impl/MemberRepositoryImpl.java
+++ b/src/main/java/com/project200/undabang/member/repository/impl/MemberRepositoryImpl.java
@@ -2,9 +2,11 @@ package com.project200.undabang.member.repository.impl;
 
 import com.project200.undabang.common.entity.QPicture;
 import com.project200.undabang.exercise.entity.QExercise;
+import com.project200.undabang.exercise.entity.QExerciseType;
 import com.project200.undabang.member.entity.Member;
 import com.project200.undabang.member.entity.QMember;
 import com.project200.undabang.member.entity.QMemberPicture;
+import com.project200.undabang.member.entity.QPreferredExercise;
 import com.project200.undabang.member.repository.MemberRepositoryCustom;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import jakarta.persistence.LockModeType;
@@ -30,7 +32,7 @@ public class MemberRepositoryImpl implements MemberRepositoryCustom {
      *
      * @param memberId 조회할 회원의 고유 식별자 (UUID 형식)
      * @return 주어진 회원 ID와 일치하는 회원 정보를 포함한 Optional 객체
-     * 반환된 객체가 비어있을 경우 해당 ID에 해당하는 회원 정보가 존재하지 않음을 나타냅니다.
+     *         반환된 객체가 비어있을 경우 해당 ID에 해당하는 회원 정보가 존재하지 않음을 나타냅니다.
      */
     @Override
     public Optional<Member> findMemberWithProfileImage(UUID memberId) {
@@ -44,6 +46,31 @@ public class MemberRepositoryImpl implements MemberRepositoryCustom {
                 .where(member.memberId.eq(memberId))
                 .fetchOne();
 
+        return Optional.ofNullable(result);
+    }
+
+    /**
+     * 회원의 프로필 정보(사진, 선호 운동 등)를 포함하여 조회합니다.
+     * preferredExerciseDeletedAt이 null인(삭제되지 않은) 선호 운동만 필터링하여 가져옵니다.
+     */
+    @Override
+    public Optional<Member> findMemberProfileByMemberIdAndMemberDeletedAtNull(UUID memberId) {
+        QMember member = QMember.member;
+        QMemberPicture memberPicture = QMemberPicture.memberPicture;
+        QPicture picture = QPicture.picture;
+        QPreferredExercise preferredExercise = QPreferredExercise.preferredExercise;
+        QExerciseType exerciseType = QExerciseType.exerciseType;
+        Member result = queryFactory.selectFrom(member)
+                .leftJoin(member.memberPicture, memberPicture).fetchJoin()
+                .leftJoin(memberPicture.picture, picture).fetchJoin()
+                .leftJoin(member.preferredExercises, preferredExercise).fetchJoin()
+                .leftJoin(preferredExercise.exercise, exerciseType).fetchJoin()
+                .where(
+                        member.memberId.eq(memberId),
+                        member.memberDeletedAt.isNull(),
+                        preferredExercise.preferredExerciseDeletedAt.isNull().or(preferredExercise.isNull()))
+                .distinct()
+                .fetchOne();
         return Optional.ofNullable(result);
     }
 

--- a/src/test/java/com/project200/undabang/member/controller/MemberQueryControllerTest.java
+++ b/src/test/java/com/project200/undabang/member/controller/MemberQueryControllerTest.java
@@ -220,7 +220,7 @@ class MemberQueryControllerTest extends AbstractRestDocSupport {
                                     fieldWithPath("data.preferredExercises[]").type(JsonFieldType.ARRAY).description("사용자가 선호하는 운동 목록"),
                                     fieldWithPath("data.preferredExercises[].preferredExerciseId").type(JsonFieldType.NUMBER).description("선호 운동 ID").optional(),
                                     fieldWithPath("data.preferredExercises[].name").type(JsonFieldType.STRING).description("선호 운동 이름"),
-                                    fieldWithPath("data.preferredExercises[].skillLevel").type(JsonFieldType.STRING).description("운동 수준: NOVICE, BEGINNER, INTERMEDIATE, ADVANCED, EXPERT, PROFESSIONAL(입문자, 초급자, 중급자, 고급자, 숙련자, 선출)"),
+                                    fieldWithPath("data.preferredExercises[].skillLevel").type(JsonFieldType.STRING).description("운동 수준: BEGINNER, ROOKIE, INTERMEDIATE, ADVANCED, SKILLED, PRO(입문자, 초급자, 중급자, 고급자, 숙련자, 선출)"),
                                     fieldWithPath("data.preferredExercises[].daysOfWeek").type(JsonFieldType.ARRAY).description("운동 요일(월 ~ 일 순)").optional(),
                                     fieldWithPath("data.preferredExercises[].imageUrl").type(JsonFieldType.STRING).description("운동 이미지(최대 255자)").optional()
                             ))
@@ -351,7 +351,7 @@ class MemberQueryControllerTest extends AbstractRestDocSupport {
                                     fieldWithPath("data.preferredExercises[]").type(JsonFieldType.ARRAY).description("다른 회원이 선호하는 운동 목록"),
                                     fieldWithPath("data.preferredExercises[].preferredExerciseId").type(JsonFieldType.NUMBER).description("다른 회원의 선호 운동 ID").optional(),
                                     fieldWithPath("data.preferredExercises[].name").type(JsonFieldType.STRING).description("다른 회원의 선호 운동 이름"),
-                                    fieldWithPath("data.preferredExercises[].skillLevel").type(JsonFieldType.STRING).description("다른 회원의 운동 수준: NOVICE, BEGINNER, INTERMEDIATE, ADVANCED, EXPERT, PROFESSIONAL(입문자, 초급자, 중급자, 고급자, 숙련자, 선출)"),
+                                    fieldWithPath("data.preferredExercises[].skillLevel").type(JsonFieldType.STRING).description("다른 회원의 운동 수준: BEGINNER, ROOKIE, INTERMEDIATE, ADVANCED, SKILLED, PRO(입문자, 초급자, 중급자, 고급자, 숙련자, 선출)"),
                                     fieldWithPath("data.preferredExercises[].daysOfWeek").type(JsonFieldType.ARRAY).description("다른 회원의 운동 요일(월 ~ 일 순)").optional(),
                                     fieldWithPath("data.preferredExercises[].imageUrl").type(JsonFieldType.STRING).description("운동 이미지(최대 255자)").optional()
                             ))

--- a/src/test/java/com/project200/undabang/member/controller/PreferredExerciseQueryControllerTest.java
+++ b/src/test/java/com/project200/undabang/member/controller/PreferredExerciseQueryControllerTest.java
@@ -133,7 +133,7 @@ class PreferredExerciseQueryControllerTest extends AbstractRestDocSupport {
                                             .description("현재 사용자가 보유하고 있는 운동 이미지 URL"),
                                     fieldWithPath("data[].skillLevel")
                                             .type(JsonFieldType.STRING)
-                                            .description("현재 사용자가 보유하고 있는 운동 숙련도 (NOVICE, BEGINNER, INTERMEDIATE, ADVANCED, EXPERT, PROFESSIONAL)"),
+                                            .description("현재 사용자가 보유하고 있는 운동 숙련도 (BEGINNER, ROOKIE, INTERMEDIATE, ADVANCED, SKILLED, PRO)"),
                                     fieldWithPath("data[].daysOfWeek")
                                             .type(JsonFieldType.ARRAY)
                                             .description("현재 사용자가 보유하고 있는 운동 요일 (월~일)")))))


### PR DESCRIPTION
## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
사용자가 삭제한 선호운동이 내 프로필 조회, 다른 회원의 프로필 조회 API에서 조회되는 에러가 발생했습니다. 선호 운동 삭제 기능이 원래 있던 API가 아니였고, 선호 운동 삭제 기능이 Soft Delete로 구현이 돼서 생긴 문제였습니다. 따라서 선호운동이 삭제된 시점인 preferredExerciseDeletedAt 이 null인 선호운동은 조회 않도록 repository를 수정하였습니다.

### 스크린샷 (선택)
**API 응답 사진:** (API 응답 스크린샷을 첨부해주세요.)
<img width="2010" height="2034" alt="image" src="https://github.com/user-attachments/assets/f3d13b57-0b3b-4d6b-b093-68dd1187c922" />

**API 명세서 사진:** (API 명세서 스크린샷을 첨부해주세요.)
<img width="508" height="902" alt="image" src="https://github.com/user-attachments/assets/14bbce42-1024-46d3-9612-06de516b7481" />
<img width="506" height="938" alt="image" src="https://github.com/user-attachments/assets/4bce57cd-517a-43c0-baa6-db5d989b5567" />
<img width="492" height="463" alt="image" src="https://github.com/user-attachments/assets/74446ae1-0a2b-467f-a9e0-d739feb9fc1f" />

<img width="511" height="845" alt="image" src="https://github.com/user-attachments/assets/0d7fde5f-2ae8-48ec-ae97-964090ba9b65" />
<img width="506" height="894" alt="image" src="https://github.com/user-attachments/assets/597e318b-8919-4f18-b158-801420fa3bfd" />
<img width="494" height="598" alt="image" src="https://github.com/user-attachments/assets/0e31840d-5347-48e6-8ce3-a8cb3ee6c62d" />


**테스트 커버리지 사진:** (테스트 커버리지 스크린샷을 첨부해주세요.)
<img width="1124" height="359" alt="image" src="https://github.com/user-attachments/assets/6ab4417b-56a6-4e5c-b0e1-67ad44f97137" />

## 💬리뷰 요구사항(선택)

## #️⃣연관된 이슈

> ex) #이슈번호, Closes #이슈번호
