### PR TITLE
[Fix] 마이페이지, 다른 회원의 프로필 조회시 삭제된 선호운동이 조회되는 오류 해결

### DIFF
--- a/src/main/java/com/project200/undabang/member/dto/record/MemberProfileRecord.java
+++ b/src/main/java/com/project200/undabang/member/dto/record/MemberProfileRecord.java
@@ -1,0 +1,18 @@
+package com.project200.undabang.member.dto.record;
+
+import com.project200.undabang.member.enums.MemberGender;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.UUID;
+
+public record MemberProfileRecord(UUID memberId,
+                                  String nickname,
+                                  String bio,
+                                  MemberGender gender,
+                                  LocalDate birthDate,
+                                  String profileImageUrl,
+                                  String profileThumbnailUrl,
+                                  Byte memberScore,
+                                  List<PreferredExerciseRecord> preferredExerciseRecordList) {
+}

--- a/src/main/java/com/project200/undabang/member/dto/record/PreferredExerciseRecord.java
+++ b/src/main/java/com/project200/undabang/member/dto/record/PreferredExerciseRecord.java
@@ -1,0 +1,22 @@
+package com.project200.undabang.member.dto.record;
+
+import com.project200.undabang.member.enums.ExerciseSkillLevel;
+
+public record PreferredExerciseRecord(
+        Long preferredExerciseId,
+        String name,
+        ExerciseSkillLevel skillLevel,
+        Byte daysOfWeek,
+        String imageUrl) {
+
+    public boolean[] getDaysOfWeek() {
+        boolean[] days = new boolean[7];
+        byte dateValue = (daysOfWeek != null) ? daysOfWeek : 0;
+
+        for (int i = 0; i < 7; i++) {
+            days[i] = (dateValue & (1 << i)) != 0;
+        }
+
+        return days;
+    }
+}

--- a/src/main/java/com/project200/undabang/member/dto/response/GetOtherMemberProfileResponse.java
+++ b/src/main/java/com/project200/undabang/member/dto/response/GetOtherMemberProfileResponse.java
@@ -1,6 +1,7 @@
 package com.project200.undabang.member.dto.response;
 
 import com.project200.undabang.common.entity.Picture;
+import com.project200.undabang.member.dto.record.MemberProfileRecord;
 import com.project200.undabang.member.entity.Member;
 import com.project200.undabang.member.entity.MemberPicture;
 import com.project200.undabang.member.enums.MemberGender;
@@ -43,7 +44,6 @@ public class GetOtherMemberProfileResponse {
 
         List<PreferredExercisesOfMemberResponse> preferredExercises = Optional.ofNullable(member.getPreferredExercises())
                 .map(exercises -> exercises.stream()
-                        .filter(pe -> pe.getPreferredExerciseDeletedAt() == null)
                         .map(PreferredExercisesOfMemberResponse::new)
                         .toList())
                 .orElse(Collections.emptyList());
@@ -58,6 +58,27 @@ public class GetOtherMemberProfileResponse {
                 yearlyExerciseDays,
                 exerciseCountInLast30Days,
                 member.getMemberScore(),
+                preferredExercises
+        );
+    }
+
+    public static GetOtherMemberProfileResponse from(MemberProfileRecord record, int yearlyExerciseDays, int exerciseCountInLast30Days) {
+        List<PreferredExercisesOfMemberResponse> preferredExercises = Optional.ofNullable(record.preferredExerciseRecordList())
+                .map(pe -> pe.stream()
+                        .map(PreferredExercisesOfMemberResponse::from)
+                        .toList())
+                .orElse(Collections.emptyList());
+
+        return new GetOtherMemberProfileResponse(
+                record.profileThumbnailUrl(),
+                record.profileImageUrl(),
+                record.nickname(),
+                record.gender(),
+                record.birthDate().toString(),
+                record.bio(),
+                yearlyExerciseDays,
+                exerciseCountInLast30Days,
+                record.memberScore(),
                 preferredExercises
         );
     }

--- a/src/main/java/com/project200/undabang/member/dto/response/GetOtherMemberProfileResponse.java
+++ b/src/main/java/com/project200/undabang/member/dto/response/GetOtherMemberProfileResponse.java
@@ -43,6 +43,7 @@ public class GetOtherMemberProfileResponse {
 
         List<PreferredExercisesOfMemberResponse> preferredExercises = Optional.ofNullable(member.getPreferredExercises())
                 .map(exercises -> exercises.stream()
+                        .filter(pe -> pe.getPreferredExerciseDeletedAt() == null)
                         .map(PreferredExercisesOfMemberResponse::new)
                         .toList())
                 .orElse(Collections.emptyList());

--- a/src/main/java/com/project200/undabang/member/dto/response/MemberProfileResponse.java
+++ b/src/main/java/com/project200/undabang/member/dto/response/MemberProfileResponse.java
@@ -1,6 +1,7 @@
 package com.project200.undabang.member.dto.response;
 
 import com.project200.undabang.common.entity.Picture;
+import com.project200.undabang.member.dto.record.MemberProfileRecord;
 import com.project200.undabang.member.entity.Member;
 import com.project200.undabang.member.entity.MemberPicture;
 import com.project200.undabang.member.enums.MemberGender;
@@ -43,7 +44,6 @@ public class MemberProfileResponse {
 
         List<PreferredExercisesOfMemberResponse> preferredExercises = Optional.ofNullable(member.getPreferredExercises())
                 .map(exercises -> exercises.stream()
-                        .filter(pe -> pe.getPreferredExerciseDeletedAt() == null)
                         .map(PreferredExercisesOfMemberResponse::new)
                         .toList())
                 .orElse(Collections.emptyList()); // null 대신 빈 리스트 반환
@@ -58,6 +58,27 @@ public class MemberProfileResponse {
                 yearlyExerciseDays,
                 exerciseCountInLast30Days,
                 member.getMemberScore(),
+                preferredExercises
+        );
+    }
+
+    public static MemberProfileResponse from(MemberProfileRecord record, int yearlyExerciseDays, int exerciseCountInLast30Days) {
+        List<PreferredExercisesOfMemberResponse> preferredExercises = Optional.ofNullable(record.preferredExerciseRecordList())
+                .map(pe -> pe.stream()
+                        .map(PreferredExercisesOfMemberResponse::from)
+                        .toList())
+                .orElse(Collections.emptyList());
+
+        return new MemberProfileResponse(
+                record.profileThumbnailUrl(),
+                record.profileImageUrl(),
+                record.nickname(),
+                record.gender(),
+                record.birthDate().toString(),
+                record.bio(),
+                yearlyExerciseDays,
+                exerciseCountInLast30Days,
+                record.memberScore(),
                 preferredExercises
         );
     }

--- a/src/main/java/com/project200/undabang/member/dto/response/MemberProfileResponse.java
+++ b/src/main/java/com/project200/undabang/member/dto/response/MemberProfileResponse.java
@@ -43,6 +43,7 @@ public class MemberProfileResponse {
 
         List<PreferredExercisesOfMemberResponse> preferredExercises = Optional.ofNullable(member.getPreferredExercises())
                 .map(exercises -> exercises.stream()
+                        .filter(pe -> pe.getPreferredExerciseDeletedAt() == null)
                         .map(PreferredExercisesOfMemberResponse::new)
                         .toList())
                 .orElse(Collections.emptyList()); // null 대신 빈 리스트 반환

--- a/src/main/java/com/project200/undabang/member/dto/response/PreferredExercisesOfMemberResponse.java
+++ b/src/main/java/com/project200/undabang/member/dto/response/PreferredExercisesOfMemberResponse.java
@@ -1,5 +1,6 @@
 package com.project200.undabang.member.dto.response;
 
+import com.project200.undabang.member.dto.record.PreferredExerciseRecord;
 import com.project200.undabang.member.entity.PreferredExercise;
 import com.project200.undabang.member.enums.ExerciseSkillLevel;
 import lombok.AllArgsConstructor;
@@ -24,5 +25,15 @@ public class PreferredExercisesOfMemberResponse {
         this.skillLevel = preferredExercise.getPreferredExerciseSkillLevel();
         this.daysOfWeek = preferredExercise.getDaysOfWeek();
         this.imageUrl = preferredExercise.getExercise().getExerciseTypeImageUrl();
+    }
+
+    public static PreferredExercisesOfMemberResponse from(PreferredExerciseRecord record) {
+        return PreferredExercisesOfMemberResponse.builder()
+                .preferredExerciseId(record.preferredExerciseId())
+                .name(record.name())
+                .skillLevel(record.skillLevel())
+                .daysOfWeek(record.getDaysOfWeek())
+                .imageUrl(record.imageUrl())
+                .build();
     }
 }

--- a/src/main/java/com/project200/undabang/member/repository/MemberRepositoryCustom.java
+++ b/src/main/java/com/project200/undabang/member/repository/MemberRepositoryCustom.java
@@ -17,5 +17,5 @@ public interface MemberRepositoryCustom {
 
     Optional<Member> findMemberWithProfileImage(UUID memberId);
 
-    Optional<MemberProfileRecord> findMemberProfileWithByMemberIdAndPreferredExerciseActive(UUID memberId);
+    Optional<MemberProfileRecord> findMemberProfileWithPreferredExerciseActiveByMemberId(UUID memberId);
 }

--- a/src/main/java/com/project200/undabang/member/repository/MemberRepositoryCustom.java
+++ b/src/main/java/com/project200/undabang/member/repository/MemberRepositoryCustom.java
@@ -1,5 +1,6 @@
 package com.project200.undabang.member.repository;
 
+import com.project200.undabang.member.dto.record.MemberProfileRecord;
 import com.project200.undabang.member.entity.Member;
 
 import java.util.List;
@@ -15,4 +16,6 @@ public interface MemberRepositoryCustom {
     List<Member> findAllByIdWithPessimisticLock(List<UUID> sortedMemberIdList);
 
     Optional<Member> findMemberWithProfileImage(UUID memberId);
+
+    Optional<MemberProfileRecord> findMemberProfileWithByMemberIdAndPreferredExerciseActive(UUID memberId);
 }

--- a/src/main/java/com/project200/undabang/member/repository/impl/MemberRepositoryImpl.java
+++ b/src/main/java/com/project200/undabang/member/repository/impl/MemberRepositoryImpl.java
@@ -2,10 +2,16 @@ package com.project200.undabang.member.repository.impl;
 
 import com.project200.undabang.common.entity.QPicture;
 import com.project200.undabang.exercise.entity.QExercise;
+import com.project200.undabang.exercise.entity.QExerciseType;
+import com.project200.undabang.member.dto.record.MemberProfileRecord;
+import com.project200.undabang.member.dto.record.PreferredExerciseRecord;
 import com.project200.undabang.member.entity.Member;
 import com.project200.undabang.member.entity.QMember;
 import com.project200.undabang.member.entity.QMemberPicture;
+import com.project200.undabang.member.entity.QPreferredExercise;
 import com.project200.undabang.member.repository.MemberRepositoryCustom;
+import com.querydsl.core.group.GroupBy;
+import com.querydsl.core.types.Projections;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import jakarta.persistence.LockModeType;
 import lombok.RequiredArgsConstructor;
@@ -14,6 +20,7 @@ import org.springframework.stereotype.Repository;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -22,6 +29,50 @@ import java.util.UUID;
 public class MemberRepositoryImpl implements MemberRepositoryCustom {
 
     private final JPAQueryFactory queryFactory;
+
+    @Override
+    public Optional<MemberProfileRecord> findMemberProfileWithByMemberIdAndPreferredExerciseActive(UUID memberId) {
+        QMember member = QMember.member;
+        QMemberPicture memberPicture = QMemberPicture.memberPicture;
+        QPicture picture = QPicture.picture;
+        QPreferredExercise preferredExercise = QPreferredExercise.preferredExercise;
+        QExerciseType exerciseType = QExerciseType.exerciseType;
+
+        Map<UUID, MemberProfileRecord> result = queryFactory.from(member)
+                .leftJoin(member.memberPicture, memberPicture)
+                .leftJoin(memberPicture.picture, picture)
+                .leftJoin(member.preferredExercises, preferredExercise).on(preferredExercise.preferredExerciseDeletedAt.isNull())
+                .leftJoin(preferredExercise.exercise, exerciseType)
+                .where(member.memberId.eq(memberId),
+                        member.memberDeletedAt.isNull()
+                )
+                .transform(
+                        GroupBy.groupBy(member.memberId)
+                                .as(
+                                        Projections.constructor(MemberProfileRecord.class,
+                                                member.memberId,
+                                                member.memberNickname,
+                                                member.memberDesc,
+                                                member.memberGender,
+                                                member.memberBday,
+                                                picture.pictureUrl,
+                                                member.memberPicture.memberPicturesUrl,
+                                                member.memberScore,
+                                                GroupBy.list(
+                                                        Projections.constructor(PreferredExerciseRecord.class,
+                                                                preferredExercise.id,
+                                                                exerciseType.exerciseName,
+                                                                preferredExercise.preferredExerciseSkillLevel,
+                                                                preferredExercise.preferredExerciseDate,
+                                                                exerciseType.exerciseTypeImageUrl
+                                                        ).skipNulls() // 선호운동이 없는 회원은 null 대신 빈 리스트를 넣도록 함
+                                                )
+                                        )
+                                )
+                );
+
+        return Optional.ofNullable(result.get(memberId));
+    }
 
     /**
      * 회원의 프로필 이미지 정보를 포함한 상세 정보를 조회합니다.

--- a/src/main/java/com/project200/undabang/member/repository/impl/MemberRepositoryImpl.java
+++ b/src/main/java/com/project200/undabang/member/repository/impl/MemberRepositoryImpl.java
@@ -31,7 +31,7 @@ public class MemberRepositoryImpl implements MemberRepositoryCustom {
     private final JPAQueryFactory queryFactory;
 
     @Override
-    public Optional<MemberProfileRecord> findMemberProfileWithByMemberIdAndPreferredExerciseActive(UUID memberId) {
+    public Optional<MemberProfileRecord> findMemberProfileWithPreferredExerciseActiveByMemberId(UUID memberId) {
         QMember member = QMember.member;
         QMemberPicture memberPicture = QMemberPicture.memberPicture;
         QPicture picture = QPicture.picture;

--- a/src/main/java/com/project200/undabang/member/service/impl/MemberQueryServiceImpl.java
+++ b/src/main/java/com/project200/undabang/member/service/impl/MemberQueryServiceImpl.java
@@ -5,6 +5,7 @@ import com.project200.undabang.common.web.exception.CustomException;
 import com.project200.undabang.common.web.exception.ErrorCode;
 import com.project200.undabang.exercise.dto.response.FindExerciseRecordByPeriodResponseDto;
 import com.project200.undabang.exercise.repository.ExerciseRepository;
+import com.project200.undabang.member.dto.record.MemberProfileRecord;
 import com.project200.undabang.member.dto.response.*;
 import com.project200.undabang.member.entity.Member;
 import com.project200.undabang.member.repository.MemberRepository;
@@ -57,26 +58,26 @@ public class MemberQueryServiceImpl implements MemberQueryService {
     }
 
     /**
-     * 다른 사용자의 멤버 프로필 정보를 조회합니다.
-     * 요청한 사용자가 자신에 대해 요청한 경우 예외를 발생시킵니다.
-     * 삭제된 사용자이거나 존재하지 않는 사용자에 대해 요청한 경우 예외를 발생시킵니다.
+     * 다른 회원의 프로필 정보를 조회합니다.
+     * 조회 대상 회원은 삭제되지 않은 상태여야 하며, 회원이 존재하지 않을 경우 예외가 발생합니다.
+     * 회원의 연간 운동 횟수와 최근 특정 기간 동안의 운동 횟수를 함께 반환합니다.
      *
-     * @param memberId 조회할 다른 사용자의 멤버 ID
-     * @return GetOtherMemberProfileResponse 객체로, 조회된 사용자의 프로필 정보 및 연간 운동 횟수, 최근 운동 횟수를 포함합니다.
+     * @param memberId 조회할 회원의 고유 식별자(UUID)
+     * @return GetOtherMemberProfileResponse 객체로, 다른 회원의 프로필 정보,
+     *         연간 운동 횟수, 최근 운동 횟수를 포함합니다.
      */
     @Override
     public GetOtherMemberProfileResponse getOtherMemberProfile(UUID memberId) {
         validateNotSelfRequest(memberId);
-
-        Member otherMember = memberRepository.findMemberProfileByMemberIdAndMemberDeletedAtNull(memberId)
-                .orElseThrow(() -> new CustomException(ErrorCode.MEMBER_NOT_FOUND));
-
         // TODO : 추후 차단 기능 개발 시, 다른 회원이 차단한 경우 검색 안되게 하는 기능 추가
 
-        int yearlyExerciseCounts = memberRepository.countMemberExerciseInThisYear(otherMember.getMemberId()).intValue();
-        int exerciseCountInLastDays = memberRepository.countMemberExerciseInLastDays(otherMember.getMemberId(), RECENT_EXERCISE_PERIOD_DAYS).intValue();
+        MemberProfileRecord record = memberRepository.findMemberProfileWithByMemberIdAndPreferredExerciseActive(memberId)
+                .orElseThrow(() -> new CustomException(ErrorCode.MEMBER_NOT_FOUND));
 
-        return GetOtherMemberProfileResponse.of(otherMember, yearlyExerciseCounts, exerciseCountInLastDays);
+        int yearlyExerciseCounts = memberRepository.countMemberExerciseInThisYear(record.memberId()).intValue();
+        int exerciseCountInLastDays = memberRepository.countMemberExerciseInLastDays(record.memberId(), RECENT_EXERCISE_PERIOD_DAYS).intValue();
+
+        return GetOtherMemberProfileResponse.from(record, yearlyExerciseCounts, exerciseCountInLastDays);
     }
 
     /**
@@ -118,21 +119,23 @@ public class MemberQueryServiceImpl implements MemberQueryService {
     }
 
     /**
-     * 현재 사용자와 관련된 멤버 프로필 정보를 조회합니다.
-     * 삭제된 멤버는 조회 대상에서 제외되며, 해당 사용자의 프로필 정보가 존재하지 않을 경우 예외가 발생합니다.
+     * 현재 사용자의 멤버 프로필 정보를 조회합니다.
+     * 조회된 프로필 정보에는 사용자의 선호 운동 상태, 연간 운동 횟수,
+     * 최근 특정 기간 동안의 운동 횟수가 포함됩니다.
      *
-     * @return MemberProfileResponse 객체로, 현재 사용자와 연결된 멤버의 프로필 정보를 포함합니다.
+     * @return MemberProfileResponse 객체로, 현재 사용자의 멤버 프로필 정보,
+     * 연간 운동 횟수 및 최근 운동 횟수를 포함합니다.
      */
     @Override
     public MemberProfileResponse getMemberProfile() {
-        Member member = memberRepository.findMemberProfileByMemberIdAndMemberDeletedAtNull(UserContextHolder.getUserId())
+        MemberProfileRecord memberProfileRecord = memberRepository.findMemberProfileWithByMemberIdAndPreferredExerciseActive(UserContextHolder.getUserId())
                 .orElseThrow(() -> new CustomException(ErrorCode.MEMBER_NOT_FOUND));
 
-        int yearlyExerciseCounts = memberRepository.countMemberExerciseInThisYear(member.getMemberId()).intValue();
+        int yearlyExerciseCounts = memberRepository.countMemberExerciseInThisYear(memberProfileRecord.memberId()).intValue();
 
-        int exerciseCountInLastDays = memberRepository.countMemberExerciseInLastDays(member.getMemberId(), RECENT_EXERCISE_PERIOD_DAYS).intValue();
+        int exerciseCountInLastDays = memberRepository.countMemberExerciseInLastDays(memberProfileRecord.memberId(), RECENT_EXERCISE_PERIOD_DAYS).intValue();
 
-        return MemberProfileResponse.of(member, yearlyExerciseCounts, exerciseCountInLastDays);
+        return MemberProfileResponse.from(memberProfileRecord, yearlyExerciseCounts, exerciseCountInLastDays);
     }
 
     /**

--- a/src/main/java/com/project200/undabang/member/service/impl/MemberQueryServiceImpl.java
+++ b/src/main/java/com/project200/undabang/member/service/impl/MemberQueryServiceImpl.java
@@ -71,7 +71,7 @@ public class MemberQueryServiceImpl implements MemberQueryService {
         validateNotSelfRequest(memberId);
         // TODO : 추후 차단 기능 개발 시, 다른 회원이 차단한 경우 검색 안되게 하는 기능 추가
 
-        MemberProfileRecord record = memberRepository.findMemberProfileWithByMemberIdAndPreferredExerciseActive(memberId)
+        MemberProfileRecord record = memberRepository.findMemberProfileWithPreferredExerciseActiveByMemberId(memberId)
                 .orElseThrow(() -> new CustomException(ErrorCode.MEMBER_NOT_FOUND));
 
         int yearlyExerciseCounts = memberRepository.countMemberExerciseInThisYear(record.memberId()).intValue();
@@ -128,7 +128,7 @@ public class MemberQueryServiceImpl implements MemberQueryService {
      */
     @Override
     public MemberProfileResponse getMemberProfile() {
-        MemberProfileRecord memberProfileRecord = memberRepository.findMemberProfileWithByMemberIdAndPreferredExerciseActive(UserContextHolder.getUserId())
+        MemberProfileRecord memberProfileRecord = memberRepository.findMemberProfileWithPreferredExerciseActiveByMemberId(UserContextHolder.getUserId())
                 .orElseThrow(() -> new CustomException(ErrorCode.MEMBER_NOT_FOUND));
 
         int yearlyExerciseCounts = memberRepository.countMemberExerciseInThisYear(memberProfileRecord.memberId()).intValue();

--- a/src/test/java/com/project200/undabang/member/repository/impl/MemberRepositoryImplTest.java
+++ b/src/test/java/com/project200/undabang/member/repository/impl/MemberRepositoryImplTest.java
@@ -1,8 +1,15 @@
 package com.project200.undabang.member.repository.impl;
 
+import com.project200.undabang.common.entity.Picture;
 import com.project200.undabang.configuration.TestQuerydslConfig;
 import com.project200.undabang.exercise.entity.Exercise;
+import com.project200.undabang.exercise.entity.ExerciseType;
+import com.project200.undabang.member.dto.record.MemberProfileRecord;
+import com.project200.undabang.member.dto.record.PreferredExerciseRecord;
 import com.project200.undabang.member.entity.Member;
+import com.project200.undabang.member.entity.MemberPicture;
+import com.project200.undabang.member.entity.PreferredExercise;
+import com.project200.undabang.member.enums.ExerciseSkillLevel;
 import com.project200.undabang.member.enums.MemberGender;
 import com.project200.undabang.member.repository.MemberRepository;
 import jakarta.persistence.EntityManager;
@@ -16,6 +23,7 @@ import org.springframework.context.annotation.Import;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -29,15 +37,17 @@ class MemberRepositoryImplTest {
     @Autowired
     private MemberRepository memberRepository;
 
-    // Helper Methods
     private Member createAndSaveMember(String nickname) {
         Member member = Member.builder()
                 .memberId(UUID.randomUUID())
-                .memberEmail(nickname + "@email.com")
+                .memberEmail(nickname + "@example.com")
                 .memberNickname(nickname)
-                .memberGender(MemberGender.UNKNOWN)
-                .memberBday(LocalDate.of(2000, 1, 1))
+                .memberGender(MemberGender.MALE)
+                .memberBday(LocalDate.of(1995, 5, 5))
+                .memberScore((byte) 36)
+                .memberDesc("안녕하세요, " + nickname + "입니다.")
                 .build();
+
         em.persist(member);
         return member;
     }
@@ -53,9 +63,181 @@ class MemberRepositoryImplTest {
         return exercise;
     }
 
+    private ExerciseType createAndSaveExerciseType(String name) {
+        ExerciseType type = ExerciseType.builder()
+                .exerciseName(name)
+                .exerciseTypeImageUrl("http://example.com/" + name + ".png")
+                .build();
+        em.persist(type);
+        return type;
+    }
+
+    private void createAndSavePreferredExercise(Member member, ExerciseType type, boolean isDeleted) {
+        boolean[] days = new boolean[7];
+        days[0] = true;
+
+        PreferredExercise preferred = PreferredExercise.builder()
+                .member(member)
+                .exercise(type)
+                .preferredExerciseSkillLevel(ExerciseSkillLevel.BEGINNER)
+                .build();
+
+        preferred.setDaysOfWeek(days);
+
+        if (isDeleted) {
+            preferred.delete();
+        }
+
+        em.persist(preferred);
+    }
+
+    // [수정됨] Member 엔티티에 사진 정보를 업데이트하는 로직 추가
+    private void createAndSaveMemberPicture(Member member, String url) {
+        // 1. Picture 생성 및 저장
+        Picture picture = Picture.builder()
+                .pictureUrl(url)
+                .build();
+        em.persist(picture);
+
+        // 2. MemberPicture 생성 및 저장
+        MemberPicture memberPicture = MemberPicture.builder()
+                .member(member)
+                .picture(picture)
+                .memberPicturesUrl(url)
+                .build();
+        em.persist(memberPicture);
+
+        // 3. [중요] Member 엔티티(연관관계의 주인)에 사진 정보 업데이트
+        member.updateProfilePicture(memberPicture);
+        // em.persist(member)는 필요 없음 (이미 영속 상태이므로 flush 시점에 Update 쿼리 발생)
+    }
+
     private void flushAndClear() {
         em.flush();
         em.clear();
+    }
+
+    @Nested
+    @DisplayName("findMemberProfileWithByMemberIdAndPreferredExerciseActive 메소드는")
+    class Describe_findMemberProfileWithByMemberIdAndPreferredExerciseActive {
+
+        @Test
+        @DisplayName("회원 프로필 정보(사진 포함)와 삭제되지 않은 선호 운동 목록을 조회한다")
+        void it_returns_member_profile_with_active_preferred_exercises() {
+            // given
+            Member member = createAndSaveMember("healthyUser");
+            createAndSaveMemberPicture(member, "http://my-profile.com/img.jpg");
+
+            ExerciseType soccer = createAndSaveExerciseType("SOCCER");
+            ExerciseType tennis = createAndSaveExerciseType("TENNIS");
+
+            createAndSavePreferredExercise(member, soccer, false);
+            createAndSavePreferredExercise(member, tennis, false);
+
+            ExerciseType deletedSport = createAndSaveExerciseType("DELETED_SPORT");
+            createAndSavePreferredExercise(member, deletedSport, true);
+
+            flushAndClear();
+
+            // when
+            Optional<MemberProfileRecord> result = memberRepository
+                    .findMemberProfileWithByMemberIdAndPreferredExerciseActive(member.getMemberId());
+
+            // then
+            assertThat(result).isPresent();
+            MemberProfileRecord profile = result.get();
+
+            assertThat(profile.nickname()).isEqualTo("healthyUser");
+            assertThat(profile.bio()).isEqualTo("안녕하세요, healthyUser입니다.");
+            assertThat(profile.gender()).isEqualTo(MemberGender.MALE);
+            assertThat(profile.memberScore()).isEqualTo((byte) 36);
+
+            assertThat(profile.profileImageUrl()).isEqualTo("http://my-profile.com/img.jpg");
+
+            List<PreferredExerciseRecord> exercises = profile.preferredExerciseRecordList();
+            assertThat(exercises).hasSize(2);
+            assertThat(exercises)
+                    .extracting("name")
+                    .containsExactlyInAnyOrder("SOCCER", "TENNIS");
+
+            PreferredExerciseRecord soccerRecord = exercises.stream()
+                    .filter(e -> e.name().equals("SOCCER"))
+                    .findFirst().orElseThrow();
+            assertThat(soccerRecord.skillLevel()).isEqualTo(ExerciseSkillLevel.BEGINNER);
+            assertThat(soccerRecord.imageUrl()).contains("SOCCER.png");
+        }
+
+        @Test
+        @DisplayName("선호 운동이 없어도 회원 프로필은 정상 조회되며, 운동 목록은 빈 리스트다")
+        void it_returns_profile_with_empty_exercise_list() {
+            // given
+            Member member = createAndSaveMember("lonelyUser");
+            createAndSaveMemberPicture(member, "http://my-profile.com/lonely.jpg");
+
+            flushAndClear();
+
+            // when
+            Optional<MemberProfileRecord> result = memberRepository
+                    .findMemberProfileWithByMemberIdAndPreferredExerciseActive(member.getMemberId());
+
+            // then
+            assertThat(result).isPresent();
+            assertThat(result.get().preferredExerciseRecordList()).isNotNull().isEmpty();
+        }
+
+        @Test
+        @DisplayName("프로필 사진이 설정되지 않은 경우 사진 URL은 null이다")
+        void it_returns_null_image_url_when_no_picture_set() {
+            // given
+            Member member = createAndSaveMember("noPicUser");
+
+            ExerciseType gym = createAndSaveExerciseType("GYM");
+            createAndSavePreferredExercise(member, gym, false);
+
+            flushAndClear();
+
+            // when
+            Optional<MemberProfileRecord> result = memberRepository
+                    .findMemberProfileWithByMemberIdAndPreferredExerciseActive(member.getMemberId());
+
+            // then
+            assertThat(result).isPresent();
+            assertThat(result.get().profileImageUrl()).isNull();
+            assertThat(result.get().preferredExerciseRecordList()).hasSize(1);
+        }
+
+        @Test
+        @DisplayName("탈퇴한(삭제된) 회원은 조회되지 않는다")
+        void it_returns_empty_when_member_is_deleted() {
+            // given
+            Member member = createAndSaveMember("deletedUser");
+
+            org.springframework.test.util.ReflectionTestUtils.setField(member, "memberDeletedAt", LocalDateTime.now());
+
+            em.persist(member);
+            flushAndClear();
+
+            // when
+            Optional<MemberProfileRecord> result = memberRepository
+                    .findMemberProfileWithByMemberIdAndPreferredExerciseActive(member.getMemberId());
+
+            // then
+            assertThat(result).isEmpty();
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 회원 ID 조회 시 Empty Optional을 반환한다")
+        void it_returns_empty_when_id_does_not_exist() {
+            // given
+            UUID randomId = UUID.randomUUID();
+
+            // when
+            Optional<MemberProfileRecord> result = memberRepository
+                    .findMemberProfileWithByMemberIdAndPreferredExerciseActive(randomId);
+
+            // then
+            assertThat(result).isEmpty();
+        }
     }
 
     @Nested

--- a/src/test/java/com/project200/undabang/member/repository/impl/MemberRepositoryImplTest.java
+++ b/src/test/java/com/project200/undabang/member/repository/impl/MemberRepositoryImplTest.java
@@ -141,7 +141,7 @@ class MemberRepositoryImplTest {
 
             // when
             Optional<MemberProfileRecord> result = memberRepository
-                    .findMemberProfileWithByMemberIdAndPreferredExerciseActive(member.getMemberId());
+                    .findMemberProfileWithPreferredExerciseActiveByMemberId(member.getMemberId());
 
             // then
             assertThat(result).isPresent();
@@ -178,7 +178,7 @@ class MemberRepositoryImplTest {
 
             // when
             Optional<MemberProfileRecord> result = memberRepository
-                    .findMemberProfileWithByMemberIdAndPreferredExerciseActive(member.getMemberId());
+                    .findMemberProfileWithPreferredExerciseActiveByMemberId(member.getMemberId());
 
             // then
             assertThat(result).isPresent();
@@ -198,7 +198,7 @@ class MemberRepositoryImplTest {
 
             // when
             Optional<MemberProfileRecord> result = memberRepository
-                    .findMemberProfileWithByMemberIdAndPreferredExerciseActive(member.getMemberId());
+                    .findMemberProfileWithPreferredExerciseActiveByMemberId(member.getMemberId());
 
             // then
             assertThat(result).isPresent();
@@ -219,7 +219,7 @@ class MemberRepositoryImplTest {
 
             // when
             Optional<MemberProfileRecord> result = memberRepository
-                    .findMemberProfileWithByMemberIdAndPreferredExerciseActive(member.getMemberId());
+                    .findMemberProfileWithPreferredExerciseActiveByMemberId(member.getMemberId());
 
             // then
             assertThat(result).isEmpty();
@@ -233,7 +233,7 @@ class MemberRepositoryImplTest {
 
             // when
             Optional<MemberProfileRecord> result = memberRepository
-                    .findMemberProfileWithByMemberIdAndPreferredExerciseActive(randomId);
+                    .findMemberProfileWithPreferredExerciseActiveByMemberId(randomId);
 
             // then
             assertThat(result).isEmpty();

--- a/src/test/java/com/project200/undabang/member/service/impl/MemberQueryServiceImplTest.java
+++ b/src/test/java/com/project200/undabang/member/service/impl/MemberQueryServiceImplTest.java
@@ -7,6 +7,8 @@ import com.project200.undabang.common.web.exception.ErrorCode;
 import com.project200.undabang.exercise.dto.response.FindExerciseRecordByPeriodResponseDto;
 import com.project200.undabang.exercise.entity.ExerciseType;
 import com.project200.undabang.exercise.repository.ExerciseRepository;
+import com.project200.undabang.member.dto.record.MemberProfileRecord;
+import com.project200.undabang.member.dto.record.PreferredExerciseRecord;
 import com.project200.undabang.member.dto.response.*;
 import com.project200.undabang.member.entity.Member;
 import com.project200.undabang.member.entity.MemberPicture;
@@ -27,10 +29,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.util.ReflectionTestUtils;
 
 import java.time.LocalDate;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Optional;
-import java.util.UUID;
+import java.util.*;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -63,106 +62,6 @@ class MemberQueryServiceImplTest {
                 .memberScore((byte) 50)
                 .memberDesc("테스트 자기소개입니다.")
                 .build();
-    }
-
-    private Member createMemberWithFullProfile(UUID memberId) {
-        Member member = createMember(memberId);
-        addPictureToMember(member);
-        addPreferredExerciseToMember(member, "헬스", false);
-        return member;
-    }
-
-    private Member createMemberWithMixedPreferredExercises(UUID memberId) {
-        Member member = createMember(memberId);
-        addPreferredExerciseToMember(member, "헬스", false); // 활성
-        addPreferredExerciseToMember(member, "요가", true);  // 삭제됨
-        return member;
-    }
-
-    private void addPictureToMember(Member member) {
-        Picture picture = Picture.builder()
-                .id(1L)
-                .pictureName("profile_image.jpg")
-                .pictureUrl("http://example.com/profile_image.jpg")
-                .build();
-
-        MemberPicture memberPicture = MemberPicture.builder()
-                .id(1L)
-                .picture(picture)
-                .member(member)
-                .memberPicturesUrl("http://example.com/profile_image.jpg")
-                .build();
-
-        member.updateProfilePicture(memberPicture);
-    }
-
-    private void addPreferredExerciseToMember(Member member, String exerciseName, boolean isDeleted) {
-        ExerciseType exerciseType = ExerciseType.builder()
-                .id(1L)
-                .exerciseName(exerciseName)
-                .exerciseTypeImageUrl("http://example.com/exercise/weight_training.jpg")
-                .build();
-
-        boolean[] days = {false, false, true, true, true, true, true};
-        PreferredExercise preferredExercise = PreferredExercise.createPreferredExercise(
-                member,
-                exerciseType,
-                ExerciseSkillLevel.PRO,
-                days
-        );
-
-        if (isDeleted) {
-            preferredExercise.delete();
-        }
-
-        List<PreferredExercise> currentList = (List<PreferredExercise>) ReflectionTestUtils.getField(member, "preferredExercises");
-        if (currentList == null) {
-            currentList = new ArrayList<>();
-        }
-
-        List<PreferredExercise> newList = new ArrayList<>(currentList);
-        newList.add(preferredExercise);
-
-        ReflectionTestUtils.setField(member, "preferredExercises", newList);
-    }
-
-    @Nested
-    @DisplayName("getRegistrationStatus 메소드는")
-    class GetRegistrationStatus {
-
-        @Test
-        @DisplayName("이미 가입된 회원이면 registered=true를 반환한다")
-        void returnsTrue_WhenMemberExists() {
-            UUID userId = UUID.randomUUID();
-            try (MockedStatic<UserContextHolder> ignored = mockStatic(UserContextHolder.class)) {
-                given(UserContextHolder.getUserId()).willReturn(userId);
-                given(memberRepository.existsByMemberId(userId)).willReturn(true);
-
-                MemberRegistrationStatusResponseDto response = memberQueryService.getRegistrationStatus();
-
-                assertSoftly(softly -> {
-                    softly.assertThat(response.getMemberId()).isEqualTo(userId);
-                    softly.assertThat(response.isRegistered()).isTrue();
-                });
-            }
-        }
-
-        @Test
-        @DisplayName("가입되지 않은 회원이면 registered=false를 반환한다")
-        void returnsFalse_WhenMemberDoesNotExist() {
-            UUID userId = UUID.randomUUID();
-            try (MockedStatic<UserContextHolder> ignored = mockStatic(UserContextHolder.class)) {
-                given(UserContextHolder.getUserId()).willReturn(userId);
-                given(memberRepository.existsByMemberId(userId)).willReturn(false);
-
-                MemberRegistrationStatusResponseDto response = memberQueryService.getRegistrationStatus();
-
-                assertSoftly(softly -> {
-                    softly.assertThat(response.getMemberId()).isEqualTo(userId);
-                    softly.assertThat(response.isRegistered()).isFalse();
-                });
-            }
-        }
     }
 
     @Nested
@@ -207,65 +106,11 @@ class MemberQueryServiceImplTest {
         }
     }
 
-    @Nested
-    @DisplayName("getMemberProfile 메소드는")
-    class GetMemberProfile {
-
-        @Test
-        @DisplayName("프로필 사진과 선호 운동이 있는 회원의 전체 프로필 정보를 반환한다")
-        void returnsFullProfile_WhenAllDataExists() {
-            UUID userId = UUID.randomUUID();
-            Member member = createMemberWithFullProfile(userId);
-
-            try (MockedStatic<UserContextHolder> ignored = mockStatic(UserContextHolder.class)) {
-                given(UserContextHolder.getUserId()).willReturn(userId);
-                given(memberRepository.findMemberProfileByMemberIdAndMemberDeletedAtNull(userId)).willReturn(Optional.of(member));
-                given(memberRepository.countMemberExerciseInThisYear(userId)).willReturn(10L);
-                given(memberRepository.countMemberExerciseInLastDays(userId, 30)).willReturn(5L);
-
-                MemberProfileResponse response = memberQueryService.getMemberProfile();
-
-                assertSoftly(softly -> {
-                    softly.assertThat(response.getNickname()).isEqualTo("테스트유저");
-                    softly.assertThat(response.getProfileImageUrl()).isEqualTo("http://example.com/profile_image.jpg");
-                    softly.assertThat(response.getPreferredExercises()).hasSize(1);
-                    softly.assertThat(response.getPreferredExercises().getFirst().getName()).isEqualTo("헬스");
-                    softly.assertThat(response.getYearlyExerciseDays()).isEqualTo(10);
-                    softly.assertThat(response.getExerciseCountInLast30Days()).isEqualTo(5);
-                });
-            }
-        }
-
-        @Test
-        @DisplayName("삭제된 선호 운동은 제외하고 반환한다")
-        void filtersOutDeletedPreferredExercises() {
-            UUID userId = UUID.randomUUID();
-            Member member = createMemberWithMixedPreferredExercises(userId);
-
-            try (MockedStatic<UserContextHolder> ignored = mockStatic(UserContextHolder.class)) {
-                given(UserContextHolder.getUserId()).willReturn(userId);
-                given(memberRepository.findMemberProfileByMemberIdAndMemberDeletedAtNull(userId)).willReturn(Optional.of(member));
-
-                MemberProfileResponse response = memberQueryService.getMemberProfile();
-
-                assertThat(response.getPreferredExercises()).hasSize(1);
-                assertThat(response.getPreferredExercises().getFirst().getName()).isEqualTo("헬스");
-            }
-        }
-
-        @Test
-        @DisplayName("회원 정보가 없으면 예외를 던진다")
-        void throwsException_WhenMemberNotFound() {
-            UUID userId = UUID.randomUUID();
-            try (MockedStatic<UserContextHolder> ignored = mockStatic(UserContextHolder.class)) {
-                given(UserContextHolder.getUserId()).willReturn(userId);
-                given(memberRepository.findMemberProfileByMemberIdAndMemberDeletedAtNull(userId)).willReturn(Optional.empty());
-
-                assertThatThrownBy(() -> memberQueryService.getMemberProfile())
-                        .isInstanceOf(CustomException.class)
-                        .hasFieldOrPropertyWithValue("errorCode", ErrorCode.MEMBER_NOT_FOUND);
-            }
-        }
+    private Member createMemberWithFullProfile(UUID memberId) {
+        Member member = createMember(memberId);
+        addPictureToMember(member);
+        addPreferredExerciseToMember(member, "헬스", false);
+        return member;
     }
 
     @Nested
@@ -374,6 +219,210 @@ class MemberQueryServiceImplTest {
         }
     }
 
+    private Member createMemberWithMixedPreferredExercises(UUID memberId) {
+        Member member = createMember(memberId);
+        addPreferredExerciseToMember(member, "헬스", false); // 활성
+        addPreferredExerciseToMember(member, "요가", true);  // 삭제됨
+        return member;
+    }
+
+    private void addPictureToMember(Member member) {
+        Picture picture = Picture.builder()
+                .id(1L)
+                .pictureName("profile_image.jpg")
+                .pictureUrl("http://example.com/profile_image.jpg")
+                .build();
+
+        MemberPicture memberPicture = MemberPicture.builder()
+                .id(1L)
+                .picture(picture)
+                .member(member)
+                .memberPicturesUrl("http://example.com/profile_image.jpg")
+                .build();
+
+        member.updateProfilePicture(memberPicture);
+    }
+
+    private void addPreferredExerciseToMember(Member member, String exerciseName, boolean isDeleted) {
+        ExerciseType exerciseType = ExerciseType.builder()
+                .id(1L)
+                .exerciseName(exerciseName)
+                .exerciseTypeImageUrl("http://example.com/exercise/weight_training.jpg")
+                .build();
+
+        boolean[] days = {false, false, true, true, true, true, true};
+        PreferredExercise preferredExercise = PreferredExercise.createPreferredExercise(
+                member,
+                exerciseType,
+                ExerciseSkillLevel.PRO,
+                days
+        );
+
+        if (isDeleted) {
+            preferredExercise.delete();
+        }
+
+        List<PreferredExercise> currentList = (List<PreferredExercise>) ReflectionTestUtils.getField(member, "preferredExercises");
+        if (currentList == null) {
+            currentList = new ArrayList<>();
+        }
+
+        List<PreferredExercise> newList = new ArrayList<>(currentList);
+        newList.add(preferredExercise);
+
+        ReflectionTestUtils.setField(member, "preferredExercises", newList);
+    }
+
+    private MemberProfileRecord createMemberProfileRecord(UUID memberId, List<PreferredExerciseRecord> preferredExercises) {
+        return new MemberProfileRecord(
+                memberId,
+                "테스트유저",
+                "테스트 자기소개입니다.",
+                MemberGender.MALE,
+                LocalDate.of(1990, 1, 1),
+                "http://example.com/profile.jpg",
+                "http://example.com/thumbnail.jpg",
+                (byte) 50,
+                preferredExercises
+        );
+    }
+
+    private PreferredExerciseRecord createPreferredExerciseRecord(Long id, String name, ExerciseSkillLevel level) {
+        byte daysOfWeek = 7;
+
+        return new PreferredExerciseRecord(
+                id,
+                name,
+                level,
+                daysOfWeek,
+                "http://example.com/exercise.jpg"
+        );
+    }
+
+    @Nested
+    @DisplayName("getRegistrationStatus 메소드는")
+    class GetRegistrationStatus {
+
+        @Test
+        @DisplayName("이미 가입된 회원이면 registered=true를 반환한다")
+        void returnsTrue_WhenMemberExists() {
+            UUID userId = UUID.randomUUID();
+            try (MockedStatic<UserContextHolder> ignored = mockStatic(UserContextHolder.class)) {
+                given(UserContextHolder.getUserId()).willReturn(userId);
+                given(memberRepository.existsByMemberId(userId)).willReturn(true);
+
+                MemberRegistrationStatusResponseDto response = memberQueryService.getRegistrationStatus();
+                assertThat(response.isRegistered()).isTrue();
+            }
+        }
+
+        @Test
+        @DisplayName("가입되지 않은 회원이면 registered=false를 반환한다")
+        void returnsFalse_WhenMemberDoesNotExist() {
+            UUID userId = UUID.randomUUID();
+            try (MockedStatic<UserContextHolder> ignored = mockStatic(UserContextHolder.class)) {
+                given(UserContextHolder.getUserId()).willReturn(userId);
+                given(memberRepository.existsByMemberId(userId)).willReturn(false);
+
+                MemberRegistrationStatusResponseDto response = memberQueryService.getRegistrationStatus();
+
+                assertSoftly(softly -> {
+                    softly.assertThat(response.getMemberId()).isEqualTo(userId);
+                    softly.assertThat(response.isRegistered()).isFalse();
+                });
+            }
+        }
+    }
+
+    @Nested
+    @DisplayName("getMemberProfile 메소드는")
+    class GetMemberProfile {
+
+        @Test
+        @DisplayName("프로필 사진과 선호 운동이 있는 회원의 전체 프로필 정보를 반환한다")
+        void returnsFullProfile_WhenAllDataExists() {
+            UUID userId = UUID.randomUUID();
+            PreferredExerciseRecord exerciseRecord = createPreferredExerciseRecord(1L, "헬스", ExerciseSkillLevel.PRO);
+            MemberProfileRecord record = createMemberProfileRecord(userId, List.of(exerciseRecord));
+
+            try (MockedStatic<UserContextHolder> ignored = mockStatic(UserContextHolder.class)) {
+                given(UserContextHolder.getUserId()).willReturn(userId);
+                given(memberRepository.findMemberProfileWithByMemberIdAndPreferredExerciseActive(userId))
+                        .willReturn(Optional.of(record));
+                given(memberRepository.countMemberExerciseInThisYear(userId)).willReturn(10L);
+                given(memberRepository.countMemberExerciseInLastDays(userId, 30)).willReturn(5L);
+
+                // when
+                MemberProfileResponse response = memberQueryService.getMemberProfile();
+
+                // then
+                assertSoftly(softly -> {
+                    softly.assertThat(response.getNickname()).isEqualTo("테스트유저");
+                    softly.assertThat(response.getProfileImageUrl()).isEqualTo("http://example.com/profile.jpg");
+                    softly.assertThat(response.getExerciseScore()).isEqualTo(50); // Record의 점수 확인
+
+                    softly.assertThat(response.getPreferredExercises()).hasSize(1);
+                    softly.assertThat(response.getPreferredExercises().get(0).getName()).isEqualTo("헬스");
+                    softly.assertThat(response.getPreferredExercises().get(0).getSkillLevel()).isEqualTo(ExerciseSkillLevel.PRO);
+
+                    softly.assertThat(response.getYearlyExerciseDays()).isEqualTo(10);
+                    softly.assertThat(response.getExerciseCountInLast30Days()).isEqualTo(5);
+                });
+            }
+        }
+
+        @Test
+        @DisplayName("선호 운동이 없는 경우(빈 리스트) 정상적으로 빈 목록을 반환한다")
+        void returnsEmptyList_WhenNoPreferredExercises() {
+            // given
+            UUID userId = UUID.randomUUID();
+            MemberProfileRecord record = createMemberProfileRecord(userId, Collections.emptyList());
+
+            try (MockedStatic<UserContextHolder> ignored = mockStatic(UserContextHolder.class)) {
+                given(UserContextHolder.getUserId()).willReturn(userId);
+                given(memberRepository.findMemberProfileWithByMemberIdAndPreferredExerciseActive(userId))
+                        .willReturn(Optional.of(record));
+
+                // when
+                MemberProfileResponse response = memberQueryService.getMemberProfile();
+
+                // then
+                assertThat(response.getPreferredExercises()).isEmpty();
+            }
+        }
+
+        @Test
+        @DisplayName("삭제된 선호 운동은 제외하고 반환한다")
+        void filtersOutDeletedPreferredExercises() {
+            UUID userId = UUID.randomUUID();
+            try (MockedStatic<UserContextHolder> ignored = mockStatic(UserContextHolder.class)) {
+                given(UserContextHolder.getUserId()).willReturn(userId);
+                given(memberRepository.findMemberProfileWithByMemberIdAndPreferredExerciseActive(userId))
+                        .willReturn(Optional.empty());
+
+                assertThatThrownBy(() -> memberQueryService.getMemberProfile())
+                        .isInstanceOf(CustomException.class)
+                        .hasFieldOrPropertyWithValue("errorCode", ErrorCode.MEMBER_NOT_FOUND);
+            }
+        }
+
+        @Test
+        @DisplayName("회원 정보가 없으면 예외를 던진다")
+        void throwsException_WhenMemberNotFound() {
+            UUID userId = UUID.randomUUID();
+            try (MockedStatic<UserContextHolder> ignored = mockStatic(UserContextHolder.class)) {
+                given(UserContextHolder.getUserId()).willReturn(userId);
+
+                given(memberRepository.findMemberProfileWithByMemberIdAndPreferredExerciseActive(userId))
+                        .willReturn(Optional.empty());
+
+                assertThatThrownBy(() -> memberQueryService.getMemberProfile())
+                        .isInstanceOf(CustomException.class)
+                        .hasFieldOrPropertyWithValue("errorCode", ErrorCode.MEMBER_NOT_FOUND);
+            }
+        }
+    }
+
     @Nested
     @DisplayName("getOtherMemberProfile 메소드는")
     class GetOtherMemberProfile {
@@ -384,13 +433,15 @@ class MemberQueryServiceImplTest {
             // given
             UUID myId = UUID.randomUUID();
             UUID otherId = UUID.randomUUID();
-            Member otherMember = createMemberWithFullProfile(otherId);
+
+            PreferredExerciseRecord exerciseRecord = createPreferredExerciseRecord(2L, "요가", ExerciseSkillLevel.BEGINNER);
+            MemberProfileRecord otherRecord = createMemberProfileRecord(otherId, List.of(exerciseRecord));
 
             try (MockedStatic<UserContextHolder> ignored = mockStatic(UserContextHolder.class)) {
                 given(UserContextHolder.getUserId()).willReturn(myId);
-                given(memberRepository.findMemberProfileByMemberIdAndMemberDeletedAtNull(otherId))
-                        .willReturn(Optional.of(otherMember));
-                // 운동 통계 Mocking
+                given(memberRepository.findMemberProfileWithByMemberIdAndPreferredExerciseActive(otherId))
+                        .willReturn(Optional.of(otherRecord));
+
                 given(memberRepository.countMemberExerciseInThisYear(otherId)).willReturn(20L);
                 given(memberRepository.countMemberExerciseInLastDays(otherId, 30)).willReturn(3L);
 
@@ -400,10 +451,10 @@ class MemberQueryServiceImplTest {
                 // then
                 assertSoftly(softly -> {
                     softly.assertThat(response.getNickname()).isEqualTo("테스트유저");
-                    softly.assertThat(response.getProfileImageUrl()).isEqualTo("http://example.com/profile_image.jpg"); // 사진 URL 확인
+                    softly.assertThat(response.getProfileImageUrl()).isEqualTo("http://example.com/profile.jpg");
+                    softly.assertThat(response.getPreferredExercises()).hasSize(1);
+                    softly.assertThat(response.getPreferredExercises().get(0).getName()).isEqualTo("요가");
                     softly.assertThat(response.getYearlyExerciseDays()).isEqualTo(20);
-                    softly.assertThat(response.getExerciseCountInLast30Days()).isEqualTo(3);
-                    softly.assertThat(response.getPreferredExercises()).hasSize(1); // 선호운동 개수 확인
                 });
             }
         }
@@ -414,12 +465,21 @@ class MemberQueryServiceImplTest {
             // given
             UUID myId = UUID.randomUUID();
             UUID otherId = UUID.randomUUID();
-            Member otherMember = createMember(otherId); // 사진 없이 생성
+
+            // 사진 URL이 null인 Record 생성
+            MemberProfileRecord record = new MemberProfileRecord(
+                    otherId, "닉네임", "소개", MemberGender.MALE, LocalDate.now(),
+                    null, null, (byte) 0, Collections.emptyList()
+            );
 
             try (MockedStatic<UserContextHolder> ignored = mockStatic(UserContextHolder.class)) {
                 given(UserContextHolder.getUserId()).willReturn(myId);
-                given(memberRepository.findMemberProfileByMemberIdAndMemberDeletedAtNull(otherId))
-                        .willReturn(Optional.of(otherMember));
+
+                // [수정] Record 반환 메서드 Mocking
+                given(memberRepository.findMemberProfileWithByMemberIdAndPreferredExerciseActive(otherId))
+                        .willReturn(Optional.of(record));
+
+                // 통계 메서드 Mocking
                 given(memberRepository.countMemberExerciseInThisYear(otherId)).willReturn(0L);
                 given(memberRepository.countMemberExerciseInLastDays(otherId, 30)).willReturn(0L);
 
@@ -435,18 +495,45 @@ class MemberQueryServiceImplTest {
         }
 
         @Test
-        @DisplayName("삭제된 선호 운동은 결과 목록에서 제외한다")
-        void filtersOutDeletedPreferredExercises() {
-            // given
+        @DisplayName("Repository에서 필터링된 선호 운동 목록을 그대로 반환한다")
+        void returnsFilteredPreferredExercises() {
             UUID myId = UUID.randomUUID();
             UUID otherId = UUID.randomUUID();
-            // 활성 운동 1개, 삭제된 운동 1개가 섞인 멤버 생성
-            Member otherMember = createMemberWithMixedPreferredExercises(otherId);
+
+            PreferredExerciseRecord activeExercise = createPreferredExerciseRecord(1L, "헬스", ExerciseSkillLevel.PRO);
+            MemberProfileRecord record = createMemberProfileRecord(otherId, List.of(activeExercise));
 
             try (MockedStatic<UserContextHolder> ignored = mockStatic(UserContextHolder.class)) {
                 given(UserContextHolder.getUserId()).willReturn(myId);
-                given(memberRepository.findMemberProfileByMemberIdAndMemberDeletedAtNull(otherId))
-                        .willReturn(Optional.of(otherMember));
+                given(memberRepository.findMemberProfileWithByMemberIdAndPreferredExerciseActive(otherId))
+                        .willReturn(Optional.of(record));
+                given(memberRepository.countMemberExerciseInThisYear(otherId)).willReturn(10L);
+                given(memberRepository.countMemberExerciseInLastDays(otherId, 30)).willReturn(5L);
+
+                // when
+                GetOtherMemberProfileResponse response = memberQueryService.getOtherMemberProfile(otherId);
+
+                // then
+                assertThat(response.getPreferredExercises()).hasSize(1);
+                assertThat(response.getPreferredExercises().get(0).getName()).isEqualTo("헬스");
+            }
+        }
+
+        @Test
+        @DisplayName("삭제된 선호 운동은 결과 목록에서 제외한다")
+        void filtersOutDeletedPreferredExercises() {
+            UUID myId = UUID.randomUUID();
+            UUID otherId = UUID.randomUUID();
+
+            PreferredExerciseRecord activeRecord = createPreferredExerciseRecord(1L, "헬스", ExerciseSkillLevel.PRO);
+            MemberProfileRecord memberRecord = createMemberProfileRecord(otherId, List.of(activeRecord));
+
+            try (MockedStatic<UserContextHolder> ignored = mockStatic(UserContextHolder.class)) {
+                given(UserContextHolder.getUserId()).willReturn(myId);
+
+                given(memberRepository.findMemberProfileWithByMemberIdAndPreferredExerciseActive(otherId))
+                        .willReturn(Optional.of(memberRecord));
+
                 given(memberRepository.countMemberExerciseInThisYear(otherId)).willReturn(10L);
                 given(memberRepository.countMemberExerciseInLastDays(otherId, 30)).willReturn(5L);
 
@@ -456,8 +543,7 @@ class MemberQueryServiceImplTest {
                 // then
                 assertSoftly(softly -> {
                     softly.assertThat(response.getPreferredExercises()).hasSize(1);
-                    softly.assertThat(response.getPreferredExercises().getFirst().getName()).isEqualTo("헬스");
-                    // "요가"는 삭제되었으므로 포함되지 않아야 함
+                    softly.assertThat(response.getPreferredExercises().get(0).getName()).isEqualTo("헬스");
                 });
             }
         }
@@ -484,7 +570,8 @@ class MemberQueryServiceImplTest {
 
             try (MockedStatic<UserContextHolder> ignored = mockStatic(UserContextHolder.class)) {
                 given(UserContextHolder.getUserId()).willReturn(myId);
-                given(memberRepository.findMemberProfileByMemberIdAndMemberDeletedAtNull(otherId))
+
+                given(memberRepository.findMemberProfileWithByMemberIdAndPreferredExerciseActive(otherId))
                         .willReturn(Optional.empty());
 
                 assertThatThrownBy(() -> memberQueryService.getOtherMemberProfile(otherId))

--- a/src/test/java/com/project200/undabang/member/service/impl/MemberQueryServiceImplTest.java
+++ b/src/test/java/com/project200/undabang/member/service/impl/MemberQueryServiceImplTest.java
@@ -16,12 +16,10 @@ import com.project200.undabang.member.enums.MemberGender;
 import com.project200.undabang.member.repository.MemberRepository;
 import com.project200.undabang.policy.entity.PolicyKey;
 import com.project200.undabang.policy.service.PolicyService;
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.BDDMockito;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockedStatic;
@@ -29,6 +27,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.util.ReflectionTestUtils;
 
 import java.time.LocalDate;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
@@ -37,8 +36,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.SoftAssertions.assertSoftly;
 import static org.mockito.BDDMockito.given;
-import static org.mockito.BDDMockito.then;
-import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.mockStatic;
 
 @ExtendWith(MockitoExtension.class)
 class MemberQueryServiceImplTest {
@@ -50,99 +48,14 @@ class MemberQueryServiceImplTest {
     private MemberRepository memberRepository;
 
     @Mock
-    private PolicyService policyService;
-
-    @Mock
     private ExerciseRepository exerciseRepository;
 
-    /**
-     * 등록된 회원의 상태를 확인하는 테스트
-     */
-    @Test
-    @DisplayName("회원이 등록되어 있을 경우 회원 상태는 등록됨으로 반환된다")
-    void getRegistrationStatus_RegisteredMember_ReturnsTrue() {
-        UUID testUserId = UUID.randomUUID();
+    @Mock
+    private PolicyService policyService;
 
-        try (MockedStatic<UserContextHolder> ignored = BDDMockito.mockStatic(UserContextHolder.class)) {
-            // given
-            given(UserContextHolder.getUserId()).willReturn(testUserId);
-            given(memberRepository.existsByMemberId(testUserId)).willReturn(true);
-
-            // when
-            MemberRegistrationStatusResponseDto response = memberQueryService.getRegistrationStatus();
-
-            // then
-            assertThat(response.getMemberId()).isEqualTo(testUserId);
-            assertThat(response.isRegistered()).isTrue();
-        }
-    }
-
-    /**
-     * 등록되지 않은 회원의 상태를 확인하는 테스트
-     */
-    @Test
-    @DisplayName("회원이 등록되어 있지 않을 경우 회원 상태는 미등록으로 반환된다")
-    void getRegistrationStatus_UnregisteredMember_ReturnsFalse() {
-        UUID testUserId = UUID.randomUUID();
-
-        try (MockedStatic<UserContextHolder> ignored = BDDMockito.mockStatic(UserContextHolder.class)) {
-            // given
-            given(UserContextHolder.getUserId()).willReturn(testUserId);
-            given(memberRepository.existsByMemberId(testUserId)).willReturn(false);
-
-            // when
-            MemberRegistrationStatusResponseDto response = memberQueryService.getRegistrationStatus();
-
-            // then
-            assertThat(response.getMemberId()).isEqualTo(testUserId);
-            assertThat(response.isRegistered()).isFalse();
-        }
-    }
-
-    private void setPreferredExercise(Member member) {
-        ExerciseType exerciseType = ExerciseType.builder()
-                .id(1L)
-                .exerciseName("헬스")
-                .exerciseTypeImageUrl("http://example.com/exercise/weight_training.jpg")
-                .build();
-
-        // 테스트용 선호 운동 설정
-        PreferredExercise preferredExercise = PreferredExercise.builder()
-                .id(1L)
-                .exercise(exerciseType)
-                .member(member)
-                .preferredExerciseSkillLevel(ExerciseSkillLevel.PRO)
-                .build();
-
-        preferredExercise.setDaysOfWeek(new boolean[]{false, false, true, true, true, true, true});
-
-        ReflectionTestUtils.setField(member, "preferredExercises", List.of(preferredExercise));
-    }
-
-    private void setMemberPicture(Member member) {
-        Picture picture = Picture.builder()
-                .id(1L)
-                .pictureName("profile_image.jpg")
-                .pictureExtension(".jpg")
-                .pictureSize(1024)
-                .pictureUrl("http://example.com/profile_image.jpg")
-                .build();
-
-        MemberPicture memberPicture = MemberPicture.builder()
-                .id(1L)
-                .memberPicturesUrl("http://example.com/profile_thumbnail.jpg")
-                .picture(picture)
-                .member(member)
-                .memberPicturesName("profile_thumbnail.jpg")
-                .memberPicturesUrl("http://example.com/profile_thumbnail.jpg")
-                .build();
-
-        member.updateProfilePicture(memberPicture);
-    }
-
-    private Member createMember() {
+    private Member createMember(UUID memberId) {
         return Member.builder()
-                .memberId(UUID.randomUUID())
+                .memberId(memberId)
                 .memberEmail("test@gmail.com")
                 .memberNickname("테스트유저")
                 .memberGender(MemberGender.UNKNOWN)
@@ -152,83 +65,145 @@ class MemberQueryServiceImplTest {
                 .build();
     }
 
+    private Member createMemberWithFullProfile(UUID memberId) {
+        Member member = createMember(memberId);
+        addPictureToMember(member);
+        addPreferredExerciseToMember(member, "헬스", false);
+        return member;
+    }
+
+    private Member createMemberWithMixedPreferredExercises(UUID memberId) {
+        Member member = createMember(memberId);
+        addPreferredExerciseToMember(member, "헬스", false); // 활성
+        addPreferredExerciseToMember(member, "요가", true);  // 삭제됨
+        return member;
+    }
+
+    private void addPictureToMember(Member member) {
+        Picture picture = Picture.builder()
+                .id(1L)
+                .pictureName("profile_image.jpg")
+                .pictureUrl("http://example.com/profile_image.jpg")
+                .build();
+
+        MemberPicture memberPicture = MemberPicture.builder()
+                .id(1L)
+                .picture(picture)
+                .member(member)
+                .memberPicturesUrl("http://example.com/profile_image.jpg")
+                .build();
+
+        member.updateProfilePicture(memberPicture);
+    }
+
+    private void addPreferredExerciseToMember(Member member, String exerciseName, boolean isDeleted) {
+        ExerciseType exerciseType = ExerciseType.builder()
+                .id(1L)
+                .exerciseName(exerciseName)
+                .exerciseTypeImageUrl("http://example.com/exercise/weight_training.jpg")
+                .build();
+
+        boolean[] days = {false, false, true, true, true, true, true};
+        PreferredExercise preferredExercise = PreferredExercise.createPreferredExercise(
+                member,
+                exerciseType,
+                ExerciseSkillLevel.PRO,
+                days
+        );
+
+        if (isDeleted) {
+            preferredExercise.delete();
+        }
+
+        List<PreferredExercise> currentList = (List<PreferredExercise>) ReflectionTestUtils.getField(member, "preferredExercises");
+        if (currentList == null) {
+            currentList = new ArrayList<>();
+        }
+
+        List<PreferredExercise> newList = new ArrayList<>(currentList);
+        newList.add(preferredExercise);
+
+        ReflectionTestUtils.setField(member, "preferredExercises", newList);
+    }
+
     @Nested
-    @DisplayName("운동기록 조회")
-    class findMemberExerciseScore {
+    @DisplayName("getRegistrationStatus 메소드는")
+    class GetRegistrationStatus {
+
         @Test
-        @DisplayName("회원의 운동점수 기록 조회")
-        void findMemberExerciseScore() {
-            Member testMember = createMember();
-            UUID testMemberId = testMember.getMemberId();
+        @DisplayName("이미 가입된 회원이면 registered=true를 반환한다")
+        void returnsTrue_WhenMemberExists() {
+            UUID userId = UUID.randomUUID();
+            try (MockedStatic<UserContextHolder> ignored = mockStatic(UserContextHolder.class)) {
+                given(UserContextHolder.getUserId()).willReturn(userId);
+                given(memberRepository.existsByMemberId(userId)).willReturn(true);
 
-            try (MockedStatic<UserContextHolder> ignored = BDDMockito.mockStatic(UserContextHolder.class)) {
-                // given
-                given(UserContextHolder.getUserId()).willReturn(testMemberId);
-                given(memberRepository.findByMemberIdAndMemberDeletedAtNull(testMemberId)).willReturn(Optional.of(testMember));
-                given(policyService.getPolicyValueAsInt(PolicyKey.EXERCISE_SCORE_MAX_POINTS)).willReturn(100);
-                given(policyService.getPolicyValueAsInt(PolicyKey.EXERCISE_SCORE_MIN_POINTS)).willReturn(0);
+                MemberRegistrationStatusResponseDto response = memberQueryService.getRegistrationStatus();
 
-                MemberScoreResponseDto respDto = memberQueryService.getMemberScore();
-
-
-                Assertions.assertThat(respDto).isNotNull();
-                Assertions.assertThat(respDto.getMemberScore()).isEqualTo(testMember.getMemberScore());
-                Assertions.assertThat(respDto.getMemberId()).isEqualTo(testMemberId);
-                Assertions.assertThat(respDto.getPolicyMaxScore()).isEqualTo(100);
-                Assertions.assertThat(respDto.getPolicyMinScore()).isEqualTo(0);
-
-                then(memberRepository).should(times(1)).findByMemberIdAndMemberDeletedAtNull(testMemberId);
+                assertSoftly(softly -> {
+                    softly.assertThat(response.getMemberId()).isEqualTo(userId);
+                    softly.assertThat(response.isRegistered()).isTrue();
+                });
             }
         }
 
         @Test
-        @DisplayName("회원의 운동점수 기록 조회_운동기록 없음")
-        void findMemberExerciseScore_NotHavingExerciseRecord() {
-            UUID testMemberId = UUID.randomUUID();
-            Byte initialScore = 35; // 초기 점수 설정
-            Member testMember = Member.builder().memberId(testMemberId).memberScore(initialScore).build();
+        @DisplayName("가입되지 않은 회원이면 registered=false를 반환한다")
+        void returnsFalse_WhenMemberDoesNotExist() {
+            UUID userId = UUID.randomUUID();
+            try (MockedStatic<UserContextHolder> ignored = mockStatic(UserContextHolder.class)) {
+                given(UserContextHolder.getUserId()).willReturn(userId);
+                given(memberRepository.existsByMemberId(userId)).willReturn(false);
 
-            try (MockedStatic<UserContextHolder> ignored = BDDMockito.mockStatic(UserContextHolder.class)) {
-                // given
-                given(UserContextHolder.getUserId()).willReturn(testMemberId);
-                given(memberRepository.findByMemberIdAndMemberDeletedAtNull(testMemberId)).willReturn(Optional.of(testMember));
+                MemberRegistrationStatusResponseDto response = memberQueryService.getRegistrationStatus();
+
+                assertSoftly(softly -> {
+                    softly.assertThat(response.getMemberId()).isEqualTo(userId);
+                    softly.assertThat(response.isRegistered()).isFalse();
+                });
+            }
+        }
+    }
+
+    @Nested
+    @DisplayName("getMemberScore 메소드는")
+    class GetMemberScore {
+
+        @Test
+        @DisplayName("회원의 현재 점수와 정책상 최대/최소 점수를 반환한다")
+        void returnsScoreAndPolicyLimits() {
+            UUID userId = UUID.randomUUID();
+            Member member = createMember(userId);
+
+            try (MockedStatic<UserContextHolder> ignored = mockStatic(UserContextHolder.class)) {
+                given(UserContextHolder.getUserId()).willReturn(userId);
+                given(memberRepository.findByMemberIdAndMemberDeletedAtNull(userId)).willReturn(Optional.of(member));
                 given(policyService.getPolicyValueAsInt(PolicyKey.EXERCISE_SCORE_MAX_POINTS)).willReturn(100);
                 given(policyService.getPolicyValueAsInt(PolicyKey.EXERCISE_SCORE_MIN_POINTS)).willReturn(0);
 
-                MemberScoreResponseDto respDto = memberQueryService.getMemberScore();
+                MemberScoreResponseDto response = memberQueryService.getMemberScore();
 
-                Assertions.assertThat(respDto).isNotNull();
-                Assertions.assertThat(respDto.getMemberScore()).isEqualTo((byte) 35);
-                Assertions.assertThat(respDto.getMemberId()).isEqualTo(testMemberId);
-                Assertions.assertThat(respDto.getPolicyMaxScore()).isEqualTo(100);
-                Assertions.assertThat(respDto.getPolicyMinScore()).isEqualTo(0);
-
-                then(memberRepository).should(times(1)).findByMemberIdAndMemberDeletedAtNull(testMemberId);
+                assertSoftly(softly -> {
+                    softly.assertThat(response.getMemberId()).isEqualTo(userId);
+                    softly.assertThat(response.getMemberScore()).isEqualTo(member.getMemberScore());
+                    softly.assertThat(response.getPolicyMaxScore()).isEqualTo(100);
+                    softly.assertThat(response.getPolicyMinScore()).isEqualTo(0);
+                });
             }
         }
 
         @Test
-        @DisplayName("회원의 운동점수 기록 조회_실패하는 경우")
-        void findMemberExerciseScore_Fail() {
-            UUID testMemberId = UUID.randomUUID();
-            given(memberRepository.findByMemberIdAndMemberDeletedAtNull(testMemberId)).willReturn(Optional.empty());
-            try (MockedStatic<UserContextHolder> ignored = BDDMockito.mockStatic(UserContextHolder.class)) {
-                // given
-                given(UserContextHolder.getUserId()).willReturn(testMemberId);
+        @DisplayName("회원을 찾을 수 없으면 MEMBER_NOT_FOUND 예외를 던진다")
+        void throwsException_WhenMemberNotFound() {
+            UUID userId = UUID.randomUUID();
+            try (MockedStatic<UserContextHolder> ignored = mockStatic(UserContextHolder.class)) {
+                given(UserContextHolder.getUserId()).willReturn(userId);
+                given(memberRepository.findByMemberIdAndMemberDeletedAtNull(userId)).willReturn(Optional.empty());
 
                 assertThatThrownBy(() -> memberQueryService.getMemberScore())
                         .isInstanceOf(CustomException.class)
                         .hasFieldOrPropertyWithValue("errorCode", ErrorCode.MEMBER_NOT_FOUND);
-
-                then(memberRepository).should(times(1)).findByMemberIdAndMemberDeletedAtNull(testMemberId);
             }
-        }
-
-        private Member createMember() {
-            return Member.builder()
-                    .memberId(UUID.randomUUID())
-                    .memberScore((byte) 50)
-                    .build();
         }
     }
 
@@ -237,422 +212,284 @@ class MemberQueryServiceImplTest {
     class GetMemberProfile {
 
         @Test
-        @DisplayName("성공적으로 모든 정보가 담긴 회원 프로필 정보를 반환한다")
-        void getMemberProfileAllData_Success() {
-            // given
-            UUID testUserId = UUID.randomUUID();
-            Member mockMember = createMember();
-            setMemberPicture(mockMember);
-            setPreferredExercise(mockMember);
+        @DisplayName("프로필 사진과 선호 운동이 있는 회원의 전체 프로필 정보를 반환한다")
+        void returnsFullProfile_WhenAllDataExists() {
+            UUID userId = UUID.randomUUID();
+            Member member = createMemberWithFullProfile(userId);
 
-            try (MockedStatic<UserContextHolder> ignored = BDDMockito.mockStatic(UserContextHolder.class)) {
-                BDDMockito.given(UserContextHolder.getUserId()).willReturn(testUserId);
-                BDDMockito.given(memberRepository.findMemberProfileByMemberIdAndMemberDeletedAtNull(testUserId))
-                        .willReturn(Optional.of(mockMember));
+            try (MockedStatic<UserContextHolder> ignored = mockStatic(UserContextHolder.class)) {
+                given(UserContextHolder.getUserId()).willReturn(userId);
+                given(memberRepository.findMemberProfileByMemberIdAndMemberDeletedAtNull(userId)).willReturn(Optional.of(member));
+                given(memberRepository.countMemberExerciseInThisYear(userId)).willReturn(10L);
+                given(memberRepository.countMemberExerciseInLastDays(userId, 30)).willReturn(5L);
 
-                // when
                 MemberProfileResponse response = memberQueryService.getMemberProfile();
 
-                // then
                 assertSoftly(softly -> {
-                    softly.assertThat(response).isNotNull();
-                    softly.assertThat(response.getProfileThumbnailUrl()).isEqualTo("http://example.com/profile_thumbnail.jpg");
+                    softly.assertThat(response.getNickname()).isEqualTo("테스트유저");
                     softly.assertThat(response.getProfileImageUrl()).isEqualTo("http://example.com/profile_image.jpg");
-                    softly.assertThat(response.getNickname()).isEqualTo("테스트유저");
-                    softly.assertThat(response.getGender()).isEqualTo(MemberGender.UNKNOWN);
-                    softly.assertThat(response.getBirthDate()).isEqualTo("1990-01-01");
-                    softly.assertThat(response.getBio()).isEqualTo("테스트 자기소개입니다.");
-                    softly.assertThat(response.getYearlyExerciseDays()).isEqualTo(0);
-                    softly.assertThat(response.getExerciseCountInLast30Days()).isEqualTo(0);
-                    softly.assertThat(response.getExerciseScore()).isEqualTo(50);
-                    softly.assertThat(response.getPreferredExercises()).isNotNull();
                     softly.assertThat(response.getPreferredExercises()).hasSize(1);
-                    softly.assertThat(response.getPreferredExercises().getFirst().getPreferredExerciseId()).isEqualTo(1L);
                     softly.assertThat(response.getPreferredExercises().getFirst().getName()).isEqualTo("헬스");
-                    softly.assertThat(response.getPreferredExercises().getFirst().getImageUrl()).isEqualTo("http://example.com/exercise/weight_training.jpg");
-                    softly.assertThat(response.getPreferredExercises().getFirst().getSkillLevel()).isEqualTo(ExerciseSkillLevel.PRO);
-                    softly.assertThat(response.getPreferredExercises().getFirst().getDaysOfWeek()).isNotNull();
-                    softly.assertThat(response.getPreferredExercises().getFirst().getDaysOfWeek()).isEqualTo(new boolean[]{false, false, true, true, true, true, true});
+                    softly.assertThat(response.getYearlyExerciseDays()).isEqualTo(10);
+                    softly.assertThat(response.getExerciseCountInLast30Days()).isEqualTo(5);
                 });
             }
         }
 
         @Test
-        @DisplayName("오직 회원 관련 정보만 있는 경우 성공적으로 회원 프로필 정보를 반환한다")
-        void getMemberProfileOnlyMember_Success() {
-            // given
-            UUID testUserId = UUID.randomUUID();
-            Member mockMember = createMember();
+        @DisplayName("삭제된 선호 운동은 제외하고 반환한다")
+        void filtersOutDeletedPreferredExercises() {
+            UUID userId = UUID.randomUUID();
+            Member member = createMemberWithMixedPreferredExercises(userId);
 
-            try (MockedStatic<UserContextHolder> ignored = BDDMockito.mockStatic(UserContextHolder.class)) {
-                BDDMockito.given(UserContextHolder.getUserId()).willReturn(testUserId);
-                BDDMockito.given(memberRepository.findMemberProfileByMemberIdAndMemberDeletedAtNull(testUserId))
-                        .willReturn(Optional.of(mockMember));
+            try (MockedStatic<UserContextHolder> ignored = mockStatic(UserContextHolder.class)) {
+                given(UserContextHolder.getUserId()).willReturn(userId);
+                given(memberRepository.findMemberProfileByMemberIdAndMemberDeletedAtNull(userId)).willReturn(Optional.of(member));
 
-                // when
                 MemberProfileResponse response = memberQueryService.getMemberProfile();
 
-                // then
-                assertSoftly(softly -> {
-                    softly.assertThat(response).isNotNull();
-                    softly.assertThat(response.getProfileThumbnailUrl()).isNull();
-                    softly.assertThat(response.getProfileImageUrl()).isNull();
-                    softly.assertThat(response.getNickname()).isEqualTo("테스트유저");
-                    softly.assertThat(response.getGender()).isEqualTo(MemberGender.UNKNOWN);
-                    softly.assertThat(response.getBirthDate()).isEqualTo("1990-01-01");
-                    softly.assertThat(response.getBio()).isEqualTo("테스트 자기소개입니다.");
-                    softly.assertThat(response.getYearlyExerciseDays()).isEqualTo(0);
-                    softly.assertThat(response.getExerciseCountInLast30Days()).isEqualTo(0);
-                    softly.assertThat(response.getExerciseScore()).isEqualTo(50);
-                    softly.assertThat(response.getPreferredExercises()).isEmpty();
-                });
+                assertThat(response.getPreferredExercises()).hasSize(1);
+                assertThat(response.getPreferredExercises().getFirst().getName()).isEqualTo("헬스");
             }
         }
 
         @Test
-        @DisplayName("회원을 찾을 수 없을 때 MEMBER_NOT_FOUND 예외를 던진다")
-        void getMemberProfile_ThrowsMemberNotFound() {
-            // given
-            UUID testUserId = UUID.randomUUID();
+        @DisplayName("회원 정보가 없으면 예외를 던진다")
+        void throwsException_WhenMemberNotFound() {
+            UUID userId = UUID.randomUUID();
+            try (MockedStatic<UserContextHolder> ignored = mockStatic(UserContextHolder.class)) {
+                given(UserContextHolder.getUserId()).willReturn(userId);
+                given(memberRepository.findMemberProfileByMemberIdAndMemberDeletedAtNull(userId)).willReturn(Optional.empty());
 
-            try (MockedStatic<UserContextHolder> mockedStatic = BDDMockito.mockStatic(UserContextHolder.class)) {
-                BDDMockito.given(UserContextHolder.getUserId()).willReturn(testUserId);
-                BDDMockito.given(memberRepository.findMemberProfileByMemberIdAndMemberDeletedAtNull(testUserId))
-                        .willReturn(Optional.empty());
-
-                // when & then
                 assertThatThrownBy(() -> memberQueryService.getMemberProfile())
-                        .as("존재하지 않는 회원 조회 시 예외가 발생해야 합니다.")
                         .isInstanceOf(CustomException.class)
                         .hasFieldOrPropertyWithValue("errorCode", ErrorCode.MEMBER_NOT_FOUND);
             }
         }
-
-        @Test
-        @DisplayName("운동 기록 횟수가 정확히 포함된 프로필 정보를 반환한다")
-        void getMemberProfile_withExerciseCounts_Success() {
-            // given: 테스트에 필요한 mock 데이터 설정
-            UUID testUserId = UUID.randomUUID();
-            Member mockMember = createMember();
-            // Mocking할 때 일관성을 유지하기 위해 Member의 ID를 testUserId로 설정합니다.
-            ReflectionTestUtils.setField(mockMember, "memberId", testUserId);
-
-            // Repository 메서드들이 반환할 값들을 미리 정의합니다.
-            long expectedYearlyCount = 15L;
-            long expectedMonthlyCount = 5L;
-
-            try (MockedStatic<UserContextHolder> ignored = BDDMockito.mockStatic(UserContextHolder.class)) {
-                // 1. UserContextHolder가 testUserId를 반환하도록 설정
-                BDDMockito.given(UserContextHolder.getUserId()).willReturn(testUserId);
-
-                // 2. 기본 프로필 조회 시 mockMember를 반환하도록 설정
-                BDDMockito.given(memberRepository.findMemberProfileByMemberIdAndMemberDeletedAtNull(testUserId))
-                        .willReturn(Optional.of(mockMember));
-
-                // 3. 올해 운동 일수 조회 시 expectedYearlyCount를 반환하도록 설정
-                BDDMockito.given(memberRepository.countMemberExerciseInThisYear(testUserId))
-                        .willReturn(expectedYearlyCount);
-
-                // 4. 최근 30일 운동 횟수 조회 시 expectedMonthlyCount를 반환하도록 설정
-                BDDMockito.given(memberRepository.countMemberExerciseInLastDays(testUserId, 30))
-                        .willReturn(expectedMonthlyCount);
-
-                // when: 실제 서비스 메서드 호출
-                MemberProfileResponse response = memberQueryService.getMemberProfile();
-
-                // then: 반환된 DTO의 값이 우리가 Mocking한 값과 일치하는지 검증
-                assertSoftly(softly -> {
-                    softly.assertThat(response).isNotNull();
-                    softly.assertThat(response.getNickname()).isEqualTo("테스트유저"); // 기본 정보 확인
-                    softly.assertThat(response.getExerciseScore()).isEqualTo(50); // 기본 정보 확인
-
-                    // 핵심 검증: 운동 기록 횟수가 정확히 매핑되었는지 확인
-                    softly.assertThat(response.getYearlyExerciseDays()).isEqualTo((int) expectedYearlyCount);
-                    softly.assertThat(response.getExerciseCountInLast30Days()).isEqualTo((int) expectedMonthlyCount);
-                });
-
-                // then: Repository의 메서드들이 정확히 1번씩 호출되었는지 검증 (Verify)
-                then(memberRepository).should(times(1)).findMemberProfileByMemberIdAndMemberDeletedAtNull(testUserId);
-                then(memberRepository).should(times(1)).countMemberExerciseInThisYear(testUserId);
-                then(memberRepository).should(times(1)).countMemberExerciseInLastDays(testUserId, 30);
-            }
-        }
     }
 
-
     @Nested
-    @DisplayName("닉네임 중복 검사")
+    @DisplayName("checkDuplicateNickname 메소드는")
     class CheckDuplicateNickname {
 
         @Test
-        @DisplayName("이미 존재하는 닉네임일 경우 available false를 반환한다")
-        void checkDuplicateNickname_ExistingNickname_ReturnsFalse() {
-            // given
-            String existingNickname = "이미존재하는닉네임";
-            given(memberRepository.existsByMemberNickname(existingNickname)).willReturn(true);
+        @DisplayName("중복된 닉네임이면 available=false를 반환한다")
+        void returnsFalse_WhenNicknameExists() {
+            String nickname = "중복닉네임";
+            given(memberRepository.existsByMemberNickname(nickname)).willReturn(true);
 
-            // when
-            CheckNicknameDuplicateResponse response = memberQueryService.checkDuplicateNickname(existingNickname);
+            CheckNicknameDuplicateResponse response = memberQueryService.checkDuplicateNickname(nickname);
 
-            // then
             assertThat(response.isAvailable()).isFalse();
-            then(memberRepository).should().existsByMemberNickname(existingNickname);
         }
 
         @Test
-        @DisplayName("사용 가능한 닉네임일 경우 available true를 반환한다")
-        void checkDuplicateNickname_AvailableNickname_ReturnsTrue() {
-            // given
-            String availableNickname = "새로운닉네임";
-            given(memberRepository.existsByMemberNickname(availableNickname)).willReturn(false);
+        @DisplayName("사용 가능한 닉네임이면 available=true를 반환한다")
+        void returnsTrue_WhenNicknameIsNew() {
+            String nickname = "새닉네임";
+            given(memberRepository.existsByMemberNickname(nickname)).willReturn(false);
 
-            // when
-            CheckNicknameDuplicateResponse response = memberQueryService.checkDuplicateNickname(availableNickname);
+            CheckNicknameDuplicateResponse response = memberQueryService.checkDuplicateNickname(nickname);
 
-            // then
             assertThat(response.isAvailable()).isTrue();
-            then(memberRepository).should().existsByMemberNickname(availableNickname);
         }
     }
 
     @Nested
-    @DisplayName("다른 회원 프로필 조회")
-    class GetOtherMemberProfile {
+    @DisplayName("getOtherMemberCalendars 메소드는")
+    class GetOtherMemberCalendars {
 
         @Test
-        @DisplayName("성공적으로 다른 회원의 프로필 정보를 반환한다")
-        void getOtherMemberProfile_Success() {
-            // given
-            UUID otherMemberId = UUID.randomUUID();
-            Member mockMember = createMember();
-            ReflectionTestUtils.setField(mockMember, "memberId", otherMemberId);
-            setMemberPicture(mockMember);
-            setPreferredExercise(mockMember);
+        @DisplayName("다른 회원의 운동 기록 목록을 정상 반환한다")
+        void returnsCalendarData_Success() {
+            UUID myId = UUID.randomUUID();
+            UUID otherId = UUID.randomUUID();
+            LocalDate start = LocalDate.now().minusDays(5);
+            LocalDate end = LocalDate.now();
+            Member otherMember = createMember(otherId);
 
-            long expectedYearlyCount = 15L;
-            long expectedMonthlyCount = 5L;
+            try (MockedStatic<UserContextHolder> ignored = mockStatic(UserContextHolder.class)) {
+                given(UserContextHolder.getUserId()).willReturn(myId);
+                given(memberRepository.findMemberProfileByMemberIdAndMemberDeletedAtNull(otherId)).willReturn(Optional.of(otherMember));
+                given(exerciseRepository.findExercisesByPeriod(otherId, start, end))
+                        .willReturn(List.of(new FindExerciseRecordByPeriodResponseDto(end, 1L)));
 
-            BDDMockito.given(memberRepository.findMemberProfileByMemberIdAndMemberDeletedAtNull(otherMemberId))
-                    .willReturn(Optional.of(mockMember));
-            BDDMockito.given(memberRepository.countMemberExerciseInThisYear(otherMemberId))
-                    .willReturn(expectedYearlyCount);
-            BDDMockito.given(memberRepository.countMemberExerciseInLastDays(otherMemberId, 30))
-                    .willReturn(expectedMonthlyCount);
+                List<FindExerciseRecordByPeriodResponseDto> result = memberQueryService.getOtherMemberCalendars(otherId, start, end);
 
-            // when
-            GetOtherMemberProfileResponse response = memberQueryService.getOtherMemberProfile(otherMemberId);
-
-            // then
-            assertSoftly(softly -> {
-                softly.assertThat(response).isNotNull();
-                softly.assertThat(response.getProfileThumbnailUrl()).isEqualTo("http://example.com/profile_thumbnail.jpg");
-                softly.assertThat(response.getProfileImageUrl()).isEqualTo("http://example.com/profile_image.jpg");
-                softly.assertThat(response.getNickname()).isEqualTo("테스트유저");
-                softly.assertThat(response.getGender()).isEqualTo(MemberGender.UNKNOWN);
-                softly.assertThat(response.getBirthDate()).isEqualTo("1990-01-01");
-                softly.assertThat(response.getBio()).isEqualTo("테스트 자기소개입니다.");
-                softly.assertThat(response.getYearlyExerciseDays()).isEqualTo((int) expectedYearlyCount);
-                softly.assertThat(response.getExerciseCountInLast30Days()).isEqualTo((int) expectedMonthlyCount);
-                softly.assertThat(response.getExerciseScore()).isEqualTo(50);
-                softly.assertThat(response.getPreferredExercises()).hasSize(1);
-            });
-
-            then(memberRepository).should(times(1)).findMemberProfileByMemberIdAndMemberDeletedAtNull(otherMemberId);
-            then(memberRepository).should(times(1)).countMemberExerciseInThisYear(otherMemberId);
-            then(memberRepository).should(times(1)).countMemberExerciseInLastDays(otherMemberId, 30);
+                assertThat(result).hasSize(1);
+            }
         }
 
         @Test
-        @DisplayName("회원 정보만 있는 경우 성공적으로 다른 회원 프로필 정보를 반환한다")
-        void getOtherMemberProfileOnlyMember_Success() {
-            // given
-            UUID otherMemberId = UUID.randomUUID();
-            Member mockMember = createMember();
-            ReflectionTestUtils.setField(mockMember, "memberId", otherMemberId);
+        @DisplayName("본인 ID로 요청 시 예외를 던진다 (Self Request)")
+        void throwsException_WhenRequestingSelf() {
+            UUID myId = UUID.randomUUID();
+            LocalDate now = LocalDate.now();
 
-            long expectedYearlyCount = 0L;
-            long expectedMonthlyCount = 0L;
+            try (MockedStatic<UserContextHolder> ignored = mockStatic(UserContextHolder.class)) {
+                given(UserContextHolder.getUserId()).willReturn(myId);
 
-            BDDMockito.given(memberRepository.findMemberProfileByMemberIdAndMemberDeletedAtNull(otherMemberId))
-                    .willReturn(Optional.of(mockMember));
-            BDDMockito.given(memberRepository.countMemberExerciseInThisYear(otherMemberId))
-                    .willReturn(expectedYearlyCount);
-            BDDMockito.given(memberRepository.countMemberExerciseInLastDays(otherMemberId, 30))
-                    .willReturn(expectedMonthlyCount);
-
-            // when
-            GetOtherMemberProfileResponse response = memberQueryService.getOtherMemberProfile(otherMemberId);
-
-            // then
-            assertSoftly(softly -> {
-                softly.assertThat(response).isNotNull();
-                softly.assertThat(response.getProfileThumbnailUrl()).isNull();
-                softly.assertThat(response.getProfileImageUrl()).isNull();
-                softly.assertThat(response.getNickname()).isEqualTo("테스트유저");
-                softly.assertThat(response.getYearlyExerciseDays()).isEqualTo(0);
-                softly.assertThat(response.getExerciseCountInLast30Days()).isEqualTo(0);
-                softly.assertThat(response.getPreferredExercises()).isEmpty();
-            });
-        }
-
-        @Test
-        @DisplayName("회원을 찾을 수 없을 때 MEMBER_NOT_FOUND 예외를 던진다")
-        void getOtherMemberProfile_ThrowsMemberNotFound() {
-            // given
-            UUID otherMemberId = UUID.randomUUID();
-            BDDMockito.given(memberRepository.findMemberProfileByMemberIdAndMemberDeletedAtNull(otherMemberId))
-                    .willReturn(Optional.empty());
-
-            // when & then
-            assertThatThrownBy(() -> memberQueryService.getOtherMemberProfile(otherMemberId))
-                    .isInstanceOf(CustomException.class)
-                    .hasFieldOrPropertyWithValue("errorCode", ErrorCode.MEMBER_NOT_FOUND);
-
-            then(memberRepository).should(times(1)).findMemberProfileByMemberIdAndMemberDeletedAtNull(otherMemberId);
-        }
-
-        @Test
-        @DisplayName("본인 UUID로 다른 회원 프로필 조회 시 MEMBER_SELF_REQUEST_NOT_ALLOWED 예외를 던진다")
-        void getOtherMemberProfile_SelfRequest_ThrowsException() {
-            UUID selfId = UUID.randomUUID();
-
-            try (MockedStatic<UserContextHolder> ignored = BDDMockito.mockStatic(UserContextHolder.class)) {
-                BDDMockito.given(UserContextHolder.getUserId()).willReturn(selfId);
-
-                assertThatThrownBy(() -> memberQueryService.getOtherMemberProfile(selfId))
+                assertThatThrownBy(() -> memberQueryService.getOtherMemberCalendars(myId, now, now))
                         .isInstanceOf(CustomException.class)
                         .hasFieldOrPropertyWithValue("errorCode", ErrorCode.MEMBER_SELF_REQUEST_NOT_ALLOWED);
             }
         }
 
+        @Test
+        @DisplayName("시작 날짜가 종료 날짜보다 늦으면 예외를 던진다")
+        void throwsException_WhenStartAfterEnd() {
+            UUID myId = UUID.randomUUID();
+            UUID otherId = UUID.randomUUID();
+            LocalDate start = LocalDate.now();
+            LocalDate end = LocalDate.now().minusDays(1);
+            Member otherMember = createMember(otherId);
+
+            try (MockedStatic<UserContextHolder> ignored = mockStatic(UserContextHolder.class)) {
+                given(UserContextHolder.getUserId()).willReturn(myId);
+                given(memberRepository.findMemberProfileByMemberIdAndMemberDeletedAtNull(otherId)).willReturn(Optional.of(otherMember));
+
+                assertThatThrownBy(() -> memberQueryService.getOtherMemberCalendars(otherId, start, end))
+                        .isInstanceOf(CustomException.class)
+                        .hasFieldOrPropertyWithValue("errorCode", ErrorCode.IMPOSSIBLE_INPUT_DATE);
+            }
+        }
+
+        @Test
+        @DisplayName("유효하지 않은 날짜 범위(미래 혹은 너무 먼 과거)면 예외를 던진다")
+        void throwsException_WhenDateInvalid() {
+            UUID myId = UUID.randomUUID();
+            UUID otherId = UUID.randomUUID();
+            Member otherMember = createMember(otherId);
+            LocalDate validStart = LocalDate.now().minusDays(1);
+            LocalDate futureEnd = LocalDate.now().plusDays(1);
+
+            try (MockedStatic<UserContextHolder> ignored = mockStatic(UserContextHolder.class)) {
+                given(UserContextHolder.getUserId()).willReturn(myId);
+                given(memberRepository.findMemberProfileByMemberIdAndMemberDeletedAtNull(otherId)).willReturn(Optional.of(otherMember));
+
+                assertThatThrownBy(() -> memberQueryService.getOtherMemberCalendars(otherId, validStart, futureEnd))
+                        .isInstanceOf(CustomException.class)
+                        .hasFieldOrPropertyWithValue("errorCode", ErrorCode.INVALID_INPUT_VALUE);
+            }
+        }
     }
 
     @Nested
-    @DisplayName("다른 회원 운동 달력 조회")
-    class GetOtherMemberCalendars {
+    @DisplayName("getOtherMemberProfile 메소드는")
+    class GetOtherMemberProfile {
 
         @Test
-        @DisplayName("성공적으로 다른 회원의 운동 기록을 반환한다")
-        void getOtherMemberCalendars_Success() {
+        @DisplayName("다른 회원의 프로필 정보를 정상 반환한다 (사진 및 선호운동 포함)")
+        void returnsOtherProfile_Success() {
             // given
-            UUID otherMemberId = UUID.randomUUID();
-            LocalDate startDate = LocalDate.now().minusDays(10);
-            LocalDate endDate = LocalDate.now();
-            Member mockMember = createMember();
-            ReflectionTestUtils.setField(mockMember, "memberId", otherMemberId);
+            UUID myId = UUID.randomUUID();
+            UUID otherId = UUID.randomUUID();
+            Member otherMember = createMemberWithFullProfile(otherId);
 
-            List<FindExerciseRecordByPeriodResponseDto> mockResponse = List.of(
-                    new FindExerciseRecordByPeriodResponseDto(startDate, 1L),
-                    new FindExerciseRecordByPeriodResponseDto(endDate, 2L)
-            );
+            try (MockedStatic<UserContextHolder> ignored = mockStatic(UserContextHolder.class)) {
+                given(UserContextHolder.getUserId()).willReturn(myId);
+                given(memberRepository.findMemberProfileByMemberIdAndMemberDeletedAtNull(otherId))
+                        .willReturn(Optional.of(otherMember));
+                // 운동 통계 Mocking
+                given(memberRepository.countMemberExerciseInThisYear(otherId)).willReturn(20L);
+                given(memberRepository.countMemberExerciseInLastDays(otherId, 30)).willReturn(3L);
 
-            given(memberRepository.findMemberProfileByMemberIdAndMemberDeletedAtNull(otherMemberId))
-                    .willReturn(Optional.of(mockMember));
-            given(exerciseRepository.findExercisesByPeriod(otherMemberId, startDate, endDate))
-                    .willReturn(mockResponse);
+                // when
+                GetOtherMemberProfileResponse response = memberQueryService.getOtherMemberProfile(otherId);
 
-            // when
-            List<FindExerciseRecordByPeriodResponseDto> response = memberQueryService.getOtherMemberCalendars(otherMemberId, startDate, endDate);
-
-            // then
-            assertSoftly(softly -> {
-                softly.assertThat(response).isNotNull();
-                softly.assertThat(response).hasSize(2);
-                softly.assertThat(response.get(0).getDate()).isEqualTo(startDate);
-                softly.assertThat(response.get(0).getExerciseCount()).isEqualTo(1);
-            });
-
-            then(memberRepository).should(times(1)).findMemberProfileByMemberIdAndMemberDeletedAtNull(otherMemberId);
-            then(exerciseRepository).should(times(1)).findExercisesByPeriod(otherMemberId, startDate, endDate);
+                // then
+                assertSoftly(softly -> {
+                    softly.assertThat(response.getNickname()).isEqualTo("테스트유저");
+                    softly.assertThat(response.getProfileImageUrl()).isEqualTo("http://example.com/profile_image.jpg"); // 사진 URL 확인
+                    softly.assertThat(response.getYearlyExerciseDays()).isEqualTo(20);
+                    softly.assertThat(response.getExerciseCountInLast30Days()).isEqualTo(3);
+                    softly.assertThat(response.getPreferredExercises()).hasSize(1); // 선호운동 개수 확인
+                });
+            }
         }
 
         @Test
-        @DisplayName("회원을 찾을 수 없을 때 MEMBER_NOT_FOUND 예외를 던진다")
-        void getOtherMemberCalendars_ThrowsMemberNotFound() {
+        @DisplayName("프로필 사진이 없는 회원의 경우 URL 필드에 null을 반환한다")
+        void returnsNullUrl_WhenNoPicture() {
             // given
-            UUID nonExistentMemberId = UUID.randomUUID();
-            LocalDate startDate = LocalDate.now().minusDays(10);
-            LocalDate endDate = LocalDate.now();
+            UUID myId = UUID.randomUUID();
+            UUID otherId = UUID.randomUUID();
+            Member otherMember = createMember(otherId); // 사진 없이 생성
 
-            given(memberRepository.findMemberProfileByMemberIdAndMemberDeletedAtNull(nonExistentMemberId))
-                    .willReturn(Optional.empty());
+            try (MockedStatic<UserContextHolder> ignored = mockStatic(UserContextHolder.class)) {
+                given(UserContextHolder.getUserId()).willReturn(myId);
+                given(memberRepository.findMemberProfileByMemberIdAndMemberDeletedAtNull(otherId))
+                        .willReturn(Optional.of(otherMember));
+                given(memberRepository.countMemberExerciseInThisYear(otherId)).willReturn(0L);
+                given(memberRepository.countMemberExerciseInLastDays(otherId, 30)).willReturn(0L);
 
-            // when & then
-            assertThatThrownBy(() -> memberQueryService.getOtherMemberCalendars(nonExistentMemberId, startDate, endDate))
-                    .isInstanceOf(CustomException.class)
-                    .hasFieldOrPropertyWithValue("errorCode", ErrorCode.MEMBER_NOT_FOUND);
+                // when
+                GetOtherMemberProfileResponse response = memberQueryService.getOtherMemberProfile(otherId);
 
-            then(memberRepository).should(times(1)).findMemberProfileByMemberIdAndMemberDeletedAtNull(nonExistentMemberId);
-            then(exerciseRepository).shouldHaveNoInteractions();
+                // then
+                assertSoftly(softly -> {
+                    softly.assertThat(response.getProfileImageUrl()).isNull();
+                    softly.assertThat(response.getProfileThumbnailUrl()).isNull();
+                });
+            }
         }
 
         @Test
-        @DisplayName("시작 날짜가 너무 과거일 때 INVALID_INPUT_VALUE 예외를 던진다")
-        void getOtherMemberCalendars_ThrowsInvalidInputValueForPastStartDate() {
+        @DisplayName("삭제된 선호 운동은 결과 목록에서 제외한다")
+        void filtersOutDeletedPreferredExercises() {
             // given
-            UUID otherMemberId = UUID.randomUUID();
-            LocalDate startDate = LocalDate.of(1945, 8, 14);
-            LocalDate endDate = LocalDate.now();
-            Member mockMember = createMember();
+            UUID myId = UUID.randomUUID();
+            UUID otherId = UUID.randomUUID();
+            // 활성 운동 1개, 삭제된 운동 1개가 섞인 멤버 생성
+            Member otherMember = createMemberWithMixedPreferredExercises(otherId);
 
-            given(memberRepository.findMemberProfileByMemberIdAndMemberDeletedAtNull(otherMemberId))
-                    .willReturn(Optional.of(mockMember));
+            try (MockedStatic<UserContextHolder> ignored = mockStatic(UserContextHolder.class)) {
+                given(UserContextHolder.getUserId()).willReturn(myId);
+                given(memberRepository.findMemberProfileByMemberIdAndMemberDeletedAtNull(otherId))
+                        .willReturn(Optional.of(otherMember));
+                given(memberRepository.countMemberExerciseInThisYear(otherId)).willReturn(10L);
+                given(memberRepository.countMemberExerciseInLastDays(otherId, 30)).willReturn(5L);
 
-            // when & then
-            assertThatThrownBy(() -> memberQueryService.getOtherMemberCalendars(otherMemberId, startDate, endDate))
-                    .isInstanceOf(CustomException.class)
-                    .hasFieldOrPropertyWithValue("errorCode", ErrorCode.INVALID_INPUT_VALUE);
+                // when
+                GetOtherMemberProfileResponse response = memberQueryService.getOtherMemberProfile(otherId);
+
+                // then
+                assertSoftly(softly -> {
+                    softly.assertThat(response.getPreferredExercises()).hasSize(1);
+                    softly.assertThat(response.getPreferredExercises().getFirst().getName()).isEqualTo("헬스");
+                    // "요가"는 삭제되었으므로 포함되지 않아야 함
+                });
+            }
         }
 
         @Test
-        @DisplayName("종료 날짜가 미래일 때 INVALID_INPUT_VALUE 예외를 던진다")
-        void getOtherMemberCalendars_ThrowsInvalidInputValueForFutureEndDate() {
-            // given
-            UUID otherMemberId = UUID.randomUUID();
-            LocalDate startDate = LocalDate.now().minusDays(10);
-            LocalDate endDate = LocalDate.now().plusDays(1);
-            Member mockMember = createMember();
+        @DisplayName("본인 ID로 조회 요청 시 예외를 던진다")
+        void throwsException_WhenRequestingSelf() {
+            UUID myId = UUID.randomUUID();
 
-            given(memberRepository.findMemberProfileByMemberIdAndMemberDeletedAtNull(otherMemberId))
-                    .willReturn(Optional.of(mockMember));
+            try (MockedStatic<UserContextHolder> ignored = mockStatic(UserContextHolder.class)) {
+                given(UserContextHolder.getUserId()).willReturn(myId);
 
-            // when & then
-            assertThatThrownBy(() -> memberQueryService.getOtherMemberCalendars(otherMemberId, startDate, endDate))
-                    .isInstanceOf(CustomException.class)
-                    .hasFieldOrPropertyWithValue("errorCode", ErrorCode.INVALID_INPUT_VALUE);
-        }
-
-        @Test
-        @DisplayName("시작 날짜가 종료 날짜보다 늦을 때 IMPOSSIBLE_INPUT_DATE 예외를 던진다")
-        void getOtherMemberCalendars_ThrowsImpossibleInputDate() {
-            // given
-            UUID otherMemberId = UUID.randomUUID();
-            LocalDate startDate = LocalDate.now();
-            LocalDate endDate = LocalDate.now().minusDays(1);
-            Member mockMember = createMember();
-
-            given(memberRepository.findMemberProfileByMemberIdAndMemberDeletedAtNull(otherMemberId))
-                    .willReturn(Optional.of(mockMember));
-
-            // when & then
-            assertThatThrownBy(() -> memberQueryService.getOtherMemberCalendars(otherMemberId, startDate, endDate))
-                    .isInstanceOf(CustomException.class)
-                    .hasFieldOrPropertyWithValue("errorCode", ErrorCode.IMPOSSIBLE_INPUT_DATE);
-        }
-
-        @Test
-        @DisplayName("본인 UUID로 다른 회원 운동 달력 조회 시 MEMBER_SELF_REQUEST_NOT_ALLOWED 예외를 던진다")
-        void getOtherMemberCalendars_SelfRequest_ThrowsException() {
-            UUID selfId = UUID.randomUUID();
-            LocalDate startDate = LocalDate.now().minusDays(10);
-            LocalDate endDate = LocalDate.now();
-
-            try (MockedStatic<UserContextHolder> ignored = BDDMockito.mockStatic(UserContextHolder.class)) {
-                BDDMockito.given(UserContextHolder.getUserId()).willReturn(selfId);
-
-                assertThatThrownBy(() -> memberQueryService.getOtherMemberCalendars(selfId, startDate, endDate))
+                assertThatThrownBy(() -> memberQueryService.getOtherMemberProfile(myId))
                         .isInstanceOf(CustomException.class)
                         .hasFieldOrPropertyWithValue("errorCode", ErrorCode.MEMBER_SELF_REQUEST_NOT_ALLOWED);
+            }
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 회원 조회 시 예외를 던진다")
+        void throwsException_WhenMemberNotFound() {
+            UUID myId = UUID.randomUUID();
+            UUID otherId = UUID.randomUUID();
+
+            try (MockedStatic<UserContextHolder> ignored = mockStatic(UserContextHolder.class)) {
+                given(UserContextHolder.getUserId()).willReturn(myId);
+                given(memberRepository.findMemberProfileByMemberIdAndMemberDeletedAtNull(otherId))
+                        .willReturn(Optional.empty());
+
+                assertThatThrownBy(() -> memberQueryService.getOtherMemberProfile(otherId))
+                        .isInstanceOf(CustomException.class)
+                        .hasFieldOrPropertyWithValue("errorCode", ErrorCode.MEMBER_NOT_FOUND);
             }
         }
     }

--- a/src/test/java/com/project200/undabang/member/service/impl/MemberQueryServiceImplTest.java
+++ b/src/test/java/com/project200/undabang/member/service/impl/MemberQueryServiceImplTest.java
@@ -347,7 +347,7 @@ class MemberQueryServiceImplTest {
 
             try (MockedStatic<UserContextHolder> ignored = mockStatic(UserContextHolder.class)) {
                 given(UserContextHolder.getUserId()).willReturn(userId);
-                given(memberRepository.findMemberProfileWithByMemberIdAndPreferredExerciseActive(userId))
+                given(memberRepository.findMemberProfileWithPreferredExerciseActiveByMemberId(userId))
                         .willReturn(Optional.of(record));
                 given(memberRepository.countMemberExerciseInThisYear(userId)).willReturn(10L);
                 given(memberRepository.countMemberExerciseInLastDays(userId, 30)).willReturn(5L);
@@ -380,7 +380,7 @@ class MemberQueryServiceImplTest {
 
             try (MockedStatic<UserContextHolder> ignored = mockStatic(UserContextHolder.class)) {
                 given(UserContextHolder.getUserId()).willReturn(userId);
-                given(memberRepository.findMemberProfileWithByMemberIdAndPreferredExerciseActive(userId))
+                given(memberRepository.findMemberProfileWithPreferredExerciseActiveByMemberId(userId))
                         .willReturn(Optional.of(record));
 
                 // when
@@ -397,7 +397,7 @@ class MemberQueryServiceImplTest {
             UUID userId = UUID.randomUUID();
             try (MockedStatic<UserContextHolder> ignored = mockStatic(UserContextHolder.class)) {
                 given(UserContextHolder.getUserId()).willReturn(userId);
-                given(memberRepository.findMemberProfileWithByMemberIdAndPreferredExerciseActive(userId))
+                given(memberRepository.findMemberProfileWithPreferredExerciseActiveByMemberId(userId))
                         .willReturn(Optional.empty());
 
                 assertThatThrownBy(() -> memberQueryService.getMemberProfile())
@@ -413,7 +413,7 @@ class MemberQueryServiceImplTest {
             try (MockedStatic<UserContextHolder> ignored = mockStatic(UserContextHolder.class)) {
                 given(UserContextHolder.getUserId()).willReturn(userId);
 
-                given(memberRepository.findMemberProfileWithByMemberIdAndPreferredExerciseActive(userId))
+                given(memberRepository.findMemberProfileWithPreferredExerciseActiveByMemberId(userId))
                         .willReturn(Optional.empty());
 
                 assertThatThrownBy(() -> memberQueryService.getMemberProfile())
@@ -439,7 +439,7 @@ class MemberQueryServiceImplTest {
 
             try (MockedStatic<UserContextHolder> ignored = mockStatic(UserContextHolder.class)) {
                 given(UserContextHolder.getUserId()).willReturn(myId);
-                given(memberRepository.findMemberProfileWithByMemberIdAndPreferredExerciseActive(otherId))
+                given(memberRepository.findMemberProfileWithPreferredExerciseActiveByMemberId(otherId))
                         .willReturn(Optional.of(otherRecord));
 
                 given(memberRepository.countMemberExerciseInThisYear(otherId)).willReturn(20L);
@@ -476,7 +476,7 @@ class MemberQueryServiceImplTest {
                 given(UserContextHolder.getUserId()).willReturn(myId);
 
                 // [수정] Record 반환 메서드 Mocking
-                given(memberRepository.findMemberProfileWithByMemberIdAndPreferredExerciseActive(otherId))
+                given(memberRepository.findMemberProfileWithPreferredExerciseActiveByMemberId(otherId))
                         .willReturn(Optional.of(record));
 
                 // 통계 메서드 Mocking
@@ -505,7 +505,7 @@ class MemberQueryServiceImplTest {
 
             try (MockedStatic<UserContextHolder> ignored = mockStatic(UserContextHolder.class)) {
                 given(UserContextHolder.getUserId()).willReturn(myId);
-                given(memberRepository.findMemberProfileWithByMemberIdAndPreferredExerciseActive(otherId))
+                given(memberRepository.findMemberProfileWithPreferredExerciseActiveByMemberId(otherId))
                         .willReturn(Optional.of(record));
                 given(memberRepository.countMemberExerciseInThisYear(otherId)).willReturn(10L);
                 given(memberRepository.countMemberExerciseInLastDays(otherId, 30)).willReturn(5L);
@@ -531,7 +531,7 @@ class MemberQueryServiceImplTest {
             try (MockedStatic<UserContextHolder> ignored = mockStatic(UserContextHolder.class)) {
                 given(UserContextHolder.getUserId()).willReturn(myId);
 
-                given(memberRepository.findMemberProfileWithByMemberIdAndPreferredExerciseActive(otherId))
+                given(memberRepository.findMemberProfileWithPreferredExerciseActiveByMemberId(otherId))
                         .willReturn(Optional.of(memberRecord));
 
                 given(memberRepository.countMemberExerciseInThisYear(otherId)).willReturn(10L);
@@ -571,7 +571,7 @@ class MemberQueryServiceImplTest {
             try (MockedStatic<UserContextHolder> ignored = mockStatic(UserContextHolder.class)) {
                 given(UserContextHolder.getUserId()).willReturn(myId);
 
-                given(memberRepository.findMemberProfileWithByMemberIdAndPreferredExerciseActive(otherId))
+                given(memberRepository.findMemberProfileWithPreferredExerciseActiveByMemberId(otherId))
                         .willReturn(Optional.empty());
 
                 assertThatThrownBy(() -> memberQueryService.getOtherMemberProfile(otherId))


### PR DESCRIPTION
## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

기존에 개발된 회원의 프로필 조회 기능이 EntityGraph를 사용하여 개발되어 있었습니다.
EntityGraph를 사용하여 개발된 만큼, SoftDelete를 사용한 삭제 여부에 관계없이 모든 관계된 엔티티를 조회하여 삭제된 선호운동이 조회되는 문제가 발생했습니다.

이를 해결하기 위해 
커밋 **eb428708888a65a73528747478f4a75d46f19b40**에서는 Java Service에서 NotNull인 데이터만 조회하려 하였으나, 삭제를 1000번 수행한 경우, 쓸모없는 데이터가 많이 조회되는 경우가 있었습니다.

그래서 QueryDsl의 Transform 기능을 사용하여 부모/자식 DTO를 생성하여 DB에서 직접 삭제되지 않은 선호운동을 조회하도록 하였습니다.

또한 테스트코드도 서비스 코드가 수정한 부분에 맞추어 수정하였습니다.

### 스크린샷 (선택)
**API 응답 사진:** (API 응답 스크린샷을 첨부해주세요.)
<img width="856" height="485" alt="image" src="https://github.com/user-attachments/assets/e64773ba-5442-4614-9d96-0747a994691f" />

**테스트 커버리지 사진:** (테스트 커버리지 스크린샷을 첨부해주세요.)
<img width="797" height="364" alt="image" src="https://github.com/user-attachments/assets/1e687ffe-3b9a-48e6-886c-415676b1f8c1" />

## #️⃣연관된 이슈

Closes #482 
