### PR TITLE
[Feat] 실시간으로 나가거나 차단한 경우 상대방에게 알려주는 기능 추가

### DIFF
--- a/src/docs/asciidoc/chat/웹소켓-전환-티켓-발급-API.adoc
+++ b/src/docs/asciidoc/chat/웹소켓-전환-티켓-발급-API.adoc
@@ -51,6 +51,16 @@ response body
     "data": "해당 회원님과는 메시지를 주고받을 수 없습니다."
 }
 
+다른 회원이 실시간으로 차단한 경우
+response body
+{
+    "succeed": false,
+    "type": "SYSTEM_BANNED",
+    "message": "차단된 회원과는 대화할 수 없습니다.",
+    "data": null
+}
+
+
 다른 회원이 채팅방을 나간 경우
 {
     "succeed": false,
@@ -58,6 +68,15 @@ response body
     "message": "CHATROOM_OTHER_MEMBER_INACTIVE",
     "data": "다른 회원님이 나간 채팅방입니다."
 }
+
+다른 회원이 채팅방을 실시간으로 나간 경우
+{
+    "succeed": false,
+    "type": "SYSTEM_LEAVE",
+    "message": "{{Nickname}} 님이 채팅방을 나갔습니다.",
+    "data": null
+}
+
 ```
 
 === 개발 이력

--- a/src/main/java/com/project200/undabang/chat/dto/event/ChatroomMemberStatusEvent.java
+++ b/src/main/java/com/project200/undabang/chat/dto/event/ChatroomMemberStatusEvent.java
@@ -1,0 +1,9 @@
+package com.project200.undabang.chat.dto.event;
+
+import com.project200.undabang.chat.dto.response.SaveMessageResponse;
+
+public record ChatroomMemberStatusEvent(Long chatroomId, String chatContent) {
+    public static ChatroomMemberStatusEvent of(Long chatroomId, String chatContent) {
+        return new ChatroomMemberStatusEvent(chatroomId, chatContent);
+    }
+}

--- a/src/main/java/com/project200/undabang/chat/dto/event/ChatroomMemberStatusEvent.java
+++ b/src/main/java/com/project200/undabang/chat/dto/event/ChatroomMemberStatusEvent.java
@@ -1,7 +1,5 @@
 package com.project200.undabang.chat.dto.event;
 
-import com.project200.undabang.chat.dto.response.SaveMessageResponse;
-
 public record ChatroomMemberStatusEvent(Long chatroomId, String chatContent) {
     public static ChatroomMemberStatusEvent of(Long chatroomId, String chatContent) {
         return new ChatroomMemberStatusEvent(chatroomId, chatContent);

--- a/src/main/java/com/project200/undabang/chat/event/ChatStatusEventListener.java
+++ b/src/main/java/com/project200/undabang/chat/event/ChatStatusEventListener.java
@@ -19,7 +19,7 @@ public class ChatStatusEventListener {
 
     @Async("generalPurposeAsyncExecutor")
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
-    public void handleChatroomDeleted(ChatroomMemberStatusEvent event) {
+    public void handleChatroomMemberStatusChange(ChatroomMemberStatusEvent event) {
         try {
             webSocketHandler.broadCastToAllChatroom(event.chatroomId(), WebSocketResponse.system(event.chatContent()));
 

--- a/src/main/java/com/project200/undabang/chat/event/ChatStatusEventListener.java
+++ b/src/main/java/com/project200/undabang/chat/event/ChatStatusEventListener.java
@@ -1,10 +1,8 @@
 package com.project200.undabang.chat.event;
 
 import com.project200.undabang.chat.dto.event.ChatroomMemberStatusEvent;
-import com.project200.undabang.chat.repository.ChatroomRepository;
 import com.project200.undabang.common.web.response.WebSocketResponse;
 import com.project200.undabang.common.websocket.handler.WebSocketHandler;
-import com.project200.undabang.member.dto.event.MemberBlockedEvent;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.annotation.Async;
@@ -18,7 +16,6 @@ import org.springframework.transaction.event.TransactionalEventListener;
 public class ChatStatusEventListener {
 
     private final WebSocketHandler webSocketHandler;
-    private final ChatroomRepository chatroomRepository;
 
     @Async("generalPurposeAsyncExecutor")
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
@@ -26,20 +23,6 @@ public class ChatStatusEventListener {
         try {
             webSocketHandler.broadCastToAllChatroom(event.chatroomId(), WebSocketResponse.system(event.chatContent()));
 
-        } catch (Exception e) {
-            log.error("채팅방 상태 변경 시스템 메시지 전송 실패.", e);
-        }
-    }
-
-    @Async("generalPurposeAsyncExecutor")
-    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
-    public void handleMemberBlocked(MemberBlockedEvent event) {
-        try {
-            chatroomRepository.findChatroomBetweenMembers(event.blocked(), event.blocker())
-                    .ifPresent(chatroom -> {
-                        WebSocketResponse response = WebSocketResponse.system();
-                        webSocketHandler.broadCastToAllChatroom(chatroom.getId(), response);
-                    });
         } catch (Exception e) {
             log.error("채팅방 상태 변경 시스템 메시지 전송 실패.", e);
         }

--- a/src/main/java/com/project200/undabang/chat/event/ChatStatusEventListener.java
+++ b/src/main/java/com/project200/undabang/chat/event/ChatStatusEventListener.java
@@ -1,0 +1,47 @@
+package com.project200.undabang.chat.event;
+
+import com.project200.undabang.chat.dto.event.ChatroomMemberStatusEvent;
+import com.project200.undabang.chat.repository.ChatroomRepository;
+import com.project200.undabang.common.web.response.WebSocketResponse;
+import com.project200.undabang.common.websocket.handler.WebSocketHandler;
+import com.project200.undabang.member.dto.event.MemberBlockedEvent;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class ChatStatusEventListener {
+
+    private final WebSocketHandler webSocketHandler;
+    private final ChatroomRepository chatroomRepository;
+
+    @Async("generalPurposeAsyncExecutor")
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void handleChatroomDeleted(ChatroomMemberStatusEvent event) {
+        try {
+            webSocketHandler.broadCastToAllChatroom(event.chatroomId(), WebSocketResponse.system(event.chatContent()));
+
+        } catch (Exception e) {
+            log.error("채팅방 상태 변경 시스템 메시지 전송 실패.", e);
+        }
+    }
+
+    @Async("generalPurposeAsyncExecutor")
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void handleMemberBlocked(MemberBlockedEvent event) {
+        try {
+            chatroomRepository.findChatroomBetweenMembers(event.blocked(), event.blocker())
+                    .ifPresent(chatroom -> {
+                        WebSocketResponse response = WebSocketResponse.system();
+                        webSocketHandler.broadCastToAllChatroom(chatroom.getId(), response);
+                    });
+        } catch (Exception e) {
+            log.error("채팅방 상태 변경 시스템 메시지 전송 실패.", e);
+        }
+    }
+}

--- a/src/main/java/com/project200/undabang/chat/repository/ChatroomMemberRepository.java
+++ b/src/main/java/com/project200/undabang/chat/repository/ChatroomMemberRepository.java
@@ -12,6 +12,5 @@ public interface ChatroomMemberRepository extends JpaRepository<ChatroomMember, 
     Optional<ChatroomMember> findByChatroomAndMember(Chatroom chatroom, Member member);
     long countByChatroomAndChatroomMemberStatus(Chatroom chatroom, ChatroomMemberStatus chatroomMemberStatus);
     Optional<ChatroomMember> findByChatroom_IdAndMember(Long id, Member member);
-
     boolean existsByChatroom_IdAndMemberAndChatroomMemberStatus(Long id, Member member, ChatroomMemberStatus chatroomMemberStatus);
 }

--- a/src/main/java/com/project200/undabang/chat/service/impl/ChatCommandServiceImpl.java
+++ b/src/main/java/com/project200/undabang/chat/service/impl/ChatCommandServiceImpl.java
@@ -1,6 +1,7 @@
 package com.project200.undabang.chat.service.impl;
 
 import com.project200.undabang.chat.dto.event.ChatMessageCreatedEvent;
+import com.project200.undabang.chat.dto.event.ChatroomMemberStatusEvent;
 import com.project200.undabang.chat.dto.record.SaveMessageRecord;
 import com.project200.undabang.chat.dto.request.CreateChatroomRequest;
 import com.project200.undabang.chat.dto.request.CreateMessageRequest;
@@ -151,7 +152,9 @@ public class ChatCommandServiceImpl implements ChatCommandService {
         }
 
         Chat systemChat = Chat.ofRoomCreation(SystemMessage.USER_LEFT_CHAT_ROOM.format(member.getMemberNickname()), chatroom);
-        chatRepository.save(systemChat);
+        Chat savedChat = chatRepository.save(systemChat);
+
+        eventPublisher.publishEvent(ChatroomMemberStatusEvent.of(chatroom.getId(), savedChat.getChatContent()));
     }
 
     /**

--- a/src/main/java/com/project200/undabang/common/web/response/WebSocketResponse.java
+++ b/src/main/java/com/project200/undabang/common/web/response/WebSocketResponse.java
@@ -21,10 +21,6 @@ public class WebSocketResponse<T> {
     /**
      * 성공 상태의 WebSocketResponse 객체를 생성합니다.
      * 데이터와 함께 성공적인 응답을 나타내는 객체를 반환합니다.
-     *
-     * @param <T>  응답 데이터의 타입
-     * @param data 응답에 포함될 데이터
-     * @return 주어진 데이터를 포함하는 성공적인 WebSocketResponse 객체
      */
     public static <T> WebSocketResponse<T> success(T data) {
         return new WebSocketResponse<>(true, WebSocketType.TALK, null, data);
@@ -33,11 +29,6 @@ public class WebSocketResponse<T> {
     /**
      * 성공 상태의 WebSocketResponse 객체를 생성합니다.
      * 주어진 WebSocketType과 데이터를 기반으로 성공적인 응답을 나타내는 객체를 반환합니다.
-     *
-     * @param <T> 응답 데이터의 타입
-     * @param type WebSocket 응답 타입
-     * @param data 응답에 포함될 데이터
-     * @return 주어진 WebSocketType과 데이터를 포함하는 성공적인 WebSocketResponse 객체
      */
     public static <T> WebSocketResponse<T> success(WebSocketType type, T data) {
         return new WebSocketResponse<>(true, type, null, data);
@@ -46,9 +37,6 @@ public class WebSocketResponse<T> {
     /**
      * WebSocket 연결 상태를 유지하기 위한 heartbeat 응답을 생성합니다.
      * 이 메소드는 WebSocket 연결의 안정성과 지속적인 유지를 확인하기 위해 사용됩니다.
-     *
-     * @param <T> 응답 데이터의 타입
-     * @return 상태 확인 응답(WebSocketType.PONG)을 포함하는 WebSocketResponse 객체
      */
     public static <T> WebSocketResponse<T> heartbeat() {
         return new WebSocketResponse<>(true, WebSocketType.PONG, null, null);
@@ -57,9 +45,6 @@ public class WebSocketResponse<T> {
     /**
      * 에러 상태의 WebSocketResponse 객체를 생성합니다.
      * 주어진 에러 메시지를 포함하여 실패 응답 객체를 반환합니다.
-     *
-     * @param message 에러 메시지 내용
-     * @return 실패 상태와 주어진 메시지를 포함하는 WebSocketResponse 객체
      */
     public static WebSocketResponse<String> error(String message) {
         return new WebSocketResponse<>(false, WebSocketType.ERROR, null, message);
@@ -68,26 +53,24 @@ public class WebSocketResponse<T> {
     /**
      * 주어진 WebSocketType과 ErrorCode를 기반으로 에러 상태를 나타내는 WebSocketResponse 객체를 생성합니다.
      * 이 메소드는 실패한 웹소켓 응답에 대한 정보를 전달하는 데 사용됩니다.
-     *
-     * @param type 웹소켓 응답 타입 (예: TALK, ERROR, PING, PONG)
-     * @param errorCode 에러 코드와 메시지를 포함하는 ErrorCode 객체
-     * @return 에러 상태와 주어진 타입 및 에러 정보를 포함하는 WebSocketResponse 객체
      */
     public static WebSocketResponse<String> error(WebSocketType type, ErrorCode errorCode) {
         return new WebSocketResponse<>(false, type, errorCode.getCode(), errorCode.getMessage());
     }
 
     /**
-     * 시스템 알림용 응답을 생성합니다. (성공 상태)
-     * 데이터(data) 필드 대신 메시지(message) 필드에 내용을 담아 보냅니다.
-     *
-     * @param content 전달할 시스템 메시지 내용 (예: "OOO님이 나갔습니다")
-     * @return succeed=true, type=SYSTEM, message=내용, data=null
+     * 시스템 메시지(WebSocketType.SYSTEM_LEAVE)를 나타내는 WebSocketResponse 객체를 생성합니다.
+     * 이 메소드는 특정 시스템 이벤트(예: 채팅방 퇴장 알림)를 클라이언트에 전달하는 데 사용됩니다.
      */
     public static WebSocketResponse<Void> system(String content) {
         return new WebSocketResponse<>(true, WebSocketType.SYSTEM_LEAVE, content, null);
     }
 
+    /**
+     * 차단된 회원과의 대화 불가를 알리는 시스템 알림용 응답을 생성합니다. (성공 상태)
+     * 회원 차단으로 인해 더 이상 메시지를 주고받을 수 없음을 알리는 시스템 메시지 전송에 사용합니다.
+     * 데이터(data) 필드는 사용하지 않고, 메시지(message) 필드에 고정된 안내 문구를 담아 보냅니다.
+     */
     public static WebSocketResponse<Void> system() {
         return new WebSocketResponse<>(true, WebSocketType.SYSTEM_BANNED, "차단된 회원과는 대화할 수 없습니다.", null);
     }

--- a/src/main/java/com/project200/undabang/common/web/response/WebSocketResponse.java
+++ b/src/main/java/com/project200/undabang/common/web/response/WebSocketResponse.java
@@ -76,4 +76,19 @@ public class WebSocketResponse<T> {
     public static WebSocketResponse<String> error(WebSocketType type, ErrorCode errorCode) {
         return new WebSocketResponse<>(false, type, errorCode.getCode(), errorCode.getMessage());
     }
+
+    /**
+     * 시스템 알림용 응답을 생성합니다. (성공 상태)
+     * 데이터(data) 필드 대신 메시지(message) 필드에 내용을 담아 보냅니다.
+     *
+     * @param content 전달할 시스템 메시지 내용 (예: "OOO님이 나갔습니다")
+     * @return succeed=true, type=SYSTEM, message=내용, data=null
+     */
+    public static WebSocketResponse<Void> system(String content) {
+        return new WebSocketResponse<>(true, WebSocketType.SYSTEM_LEAVE, content, null);
+    }
+
+    public static WebSocketResponse<Void> system() {
+        return new WebSocketResponse<>(true, WebSocketType.SYSTEM_BANNED, "차단된 회원과는 대화할 수 없습니다.", null);
+    }
 }

--- a/src/main/java/com/project200/undabang/common/web/response/WebSocketType.java
+++ b/src/main/java/com/project200/undabang/common/web/response/WebSocketType.java
@@ -4,5 +4,7 @@ public enum WebSocketType {
     TALK,
     ERROR,
     PING,
-    PONG
+    PONG,
+    SYSTEM_LEAVE,
+    SYSTEM_BANNED
 }

--- a/src/main/java/com/project200/undabang/common/websocket/handler/WebSocketHandler.java
+++ b/src/main/java/com/project200/undabang/common/websocket/handler/WebSocketHandler.java
@@ -129,7 +129,7 @@ public class WebSocketHandler extends TextWebSocketHandler {
      * 지정된 채팅방에 속한 모든 WebSocket 세션에 메시지를 브로드캐스트하는 메서드입니다.
      * 주어진 응답 객체를 JSON으로 변환하여 모든 세션에 전송합니다.
      */
-    private void broadCastToAllChatroom(Long roomId, WebSocketResponse<?> response) {
+    public void broadCastToAllChatroom(Long roomId, WebSocketResponse<?> response) {
         Map<String, WebSocketSession> sessions = sessionManager.getSessions(roomId);
 
         if (sessions == null || sessions.isEmpty()) {

--- a/src/main/java/com/project200/undabang/member/dto/event/MemberBlockedEvent.java
+++ b/src/main/java/com/project200/undabang/member/dto/event/MemberBlockedEvent.java
@@ -3,7 +3,7 @@ package com.project200.undabang.member.dto.event;
 import com.project200.undabang.member.entity.Member;
 
 public record MemberBlockedEvent(Member blocked, Member blocker) {
-    public static MemberBlockedEvent of(Member Blocked, Member Blocker) {
-        return new MemberBlockedEvent(Blocked, Blocker);
+    public static MemberBlockedEvent of(Member blocked, Member blocker) {
+        return new MemberBlockedEvent(blocked, blocker);
     }
 }

--- a/src/main/java/com/project200/undabang/member/dto/event/MemberBlockedEvent.java
+++ b/src/main/java/com/project200/undabang/member/dto/event/MemberBlockedEvent.java
@@ -1,0 +1,9 @@
+package com.project200.undabang.member.dto.event;
+
+import com.project200.undabang.member.entity.Member;
+
+public record MemberBlockedEvent(Member blocked, Member blocker) {
+    public static MemberBlockedEvent of(Member Blocked, Member Blocker) {
+        return new MemberBlockedEvent(Blocked, Blocker);
+    }
+}

--- a/src/main/java/com/project200/undabang/member/event/MemberBlockEventListener.java
+++ b/src/main/java/com/project200/undabang/member/event/MemberBlockEventListener.java
@@ -1,0 +1,35 @@
+package com.project200.undabang.member.event;
+
+import com.project200.undabang.chat.repository.ChatroomRepository;
+import com.project200.undabang.common.web.response.WebSocketResponse;
+import com.project200.undabang.common.websocket.handler.WebSocketHandler;
+import com.project200.undabang.member.dto.event.MemberBlockedEvent;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class MemberBlockEventListener {
+
+    private final WebSocketHandler webSocketHandler;
+    private final ChatroomRepository chatroomRepository;
+
+    @Async("generalPurposeAsyncExecutor")
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void handleMemberBlocked(MemberBlockedEvent event) {
+        try {
+            chatroomRepository.findChatroomBetweenMembers(event.blocked(), event.blocker())
+                    .ifPresent(chatroom -> {
+                        WebSocketResponse response = WebSocketResponse.system();
+                        webSocketHandler.broadCastToAllChatroom(chatroom.getId(), response);
+                    });
+        } catch (Exception e) {
+            log.error("채팅방 상태 변경 시스템 메시지 전송 실패.", e);
+        }
+    }
+}

--- a/src/main/java/com/project200/undabang/member/event/MemberBlockEventListener.java
+++ b/src/main/java/com/project200/undabang/member/event/MemberBlockEventListener.java
@@ -29,7 +29,7 @@ public class MemberBlockEventListener {
                         webSocketHandler.broadCastToAllChatroom(chatroom.getId(), response);
                     });
         } catch (Exception e) {
-            log.error("채팅방 상태 변경 시스템 메시지 전송 실패.", e);
+            log.error("회원 차단 메시지 전송 실패.", e);
         }
     }
 }

--- a/src/main/java/com/project200/undabang/member/service/MemberBlockCommandService.java
+++ b/src/main/java/com/project200/undabang/member/service/MemberBlockCommandService.java
@@ -6,6 +6,5 @@ import java.util.UUID;
 
 public interface MemberBlockCommandService {
     CreateMemberBlockResponse createMemberBlock(UUID blockMemberId);
-
     void unBlockMember(UUID blockMemberId);
 }

--- a/src/main/java/com/project200/undabang/member/service/impl/MemberBlockCommandServiceImpl.java
+++ b/src/main/java/com/project200/undabang/member/service/impl/MemberBlockCommandServiceImpl.java
@@ -85,7 +85,7 @@ public class MemberBlockCommandServiceImpl implements MemberBlockCommandService 
             throw new CustomException(ErrorCode.MEMBER_BLOCK_DUPLICATED);
         }
 
-        // 차단 상태라면 다시 활성화해줌
+        // 차단 해제 상태 였다면 다시 활성화해줌
         memberBlock.reBlock();
         return memberBlock;
     }
@@ -95,7 +95,7 @@ public class MemberBlockCommandServiceImpl implements MemberBlockCommandService 
      */
     private MemberBlock validateAndSaveMemberBlock(Member member, Member blockedMember) {
         return memberBlockRepository.findByBlockerAndBlocked(member, blockedMember)
-                .map(this::handleMemberBlockExist) // 이미 존재할 경우 예외 반환
+                .map(this::handleMemberBlockExist) // 기존 차단 정보가 있을 경우, 활성 차단이면 예외를 반환하고, 해제된 차단이면 재활성화
                 .orElseGet(() -> memberBlockRepository.save(MemberBlock.of(member, blockedMember)));
     }
 

--- a/src/main/java/com/project200/undabang/member/service/impl/MemberBlockCommandServiceImpl.java
+++ b/src/main/java/com/project200/undabang/member/service/impl/MemberBlockCommandServiceImpl.java
@@ -1,9 +1,5 @@
 package com.project200.undabang.member.service.impl;
 
-import com.project200.undabang.chat.dto.event.ChatroomMemberStatusEvent;
-import com.project200.undabang.chat.entity.ChatroomMember;
-import com.project200.undabang.chat.repository.ChatroomMemberRepository;
-import com.project200.undabang.chat.repository.ChatroomRepository;
 import com.project200.undabang.common.context.UserContextHolder;
 import com.project200.undabang.common.web.exception.CustomException;
 import com.project200.undabang.common.web.exception.ErrorCode;
@@ -20,7 +16,6 @@ import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.Optional;
 import java.util.UUID;
 
 @Slf4j
@@ -45,14 +40,7 @@ public class MemberBlockCommandServiceImpl implements MemberBlockCommandService 
         Member member = getMember(memberId);
         Member blockedMember = getMember(blockMemberId);
 
-        Optional<MemberBlock> optionalMemberBlock = memberBlockRepository.findByBlockerAndBlocked(member, blockedMember);
-
-        if (optionalMemberBlock.isPresent()) {
-            return handleMemberBlockExist(optionalMemberBlock.get());
-        }
-
-        MemberBlock savedMemberBlock = memberBlockRepository.save(MemberBlock.of(member, blockedMember));
-
+        MemberBlock savedMemberBlock = validateAndSaveMemberBlock(member, blockedMember);
         eventPublisher.publishEvent(MemberBlockedEvent.of(blockedMember, member));
 
         return CreateMemberBlockResponse.of(savedMemberBlock.getId());
@@ -90,18 +78,25 @@ public class MemberBlockCommandServiceImpl implements MemberBlockCommandService 
     }
 
     /**
-     * 기존의 MemberBlock이 존재할 경우 해당 상태를 처리하고 응답을 반환하는 메서드.
-     * 존재할 경우 409 Duplicated
-     * 존재하지만, 삭제한 경우 deletedAt = null 업데이트
+     * 주어진 MemberBlock 객체가 이미 존재하는지 확인하고, 기존 차단 상태를 처리하거나 재활성화하는 메서드.
      */
-    private CreateMemberBlockResponse handleMemberBlockExist(MemberBlock memberBlock) {
-
+    private MemberBlock handleMemberBlockExist(MemberBlock memberBlock) {
         if (memberBlock.getMemberBlockDeletedAt() == null) {
             throw new CustomException(ErrorCode.MEMBER_BLOCK_DUPLICATED);
-        } else {
-            memberBlock.reBlock();
-            return CreateMemberBlockResponse.of(memberBlock.getId());
         }
+
+        // 차단 상태라면 다시 활성화해줌
+        memberBlock.reBlock();
+        return memberBlock;
+    }
+
+    /**
+     * 회원 차단 정보를 검증하고 저장하는 메서드. 차단 정보가 이미 존재하는 경우 이를 처리하거나, 새롭게 차단 정보를 생성하여 저장합니다.
+     */
+    private MemberBlock validateAndSaveMemberBlock(Member member, Member blockedMember) {
+        return memberBlockRepository.findByBlockerAndBlocked(member, blockedMember)
+                .map(this::handleMemberBlockExist) // 이미 존재할 경우 예외 반환
+                .orElseGet(() -> memberBlockRepository.save(MemberBlock.of(member, blockedMember)));
     }
 
     /**

--- a/src/main/java/com/project200/undabang/member/service/impl/MemberBlockCommandServiceImpl.java
+++ b/src/main/java/com/project200/undabang/member/service/impl/MemberBlockCommandServiceImpl.java
@@ -1,8 +1,13 @@
 package com.project200.undabang.member.service.impl;
 
+import com.project200.undabang.chat.dto.event.ChatroomMemberStatusEvent;
+import com.project200.undabang.chat.entity.ChatroomMember;
+import com.project200.undabang.chat.repository.ChatroomMemberRepository;
+import com.project200.undabang.chat.repository.ChatroomRepository;
 import com.project200.undabang.common.context.UserContextHolder;
 import com.project200.undabang.common.web.exception.CustomException;
 import com.project200.undabang.common.web.exception.ErrorCode;
+import com.project200.undabang.member.dto.event.MemberBlockedEvent;
 import com.project200.undabang.member.dto.response.CreateMemberBlockResponse;
 import com.project200.undabang.member.entity.Member;
 import com.project200.undabang.member.entity.MemberBlock;
@@ -11,6 +16,7 @@ import com.project200.undabang.member.repository.MemberRepository;
 import com.project200.undabang.member.service.MemberBlockCommandService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -23,6 +29,7 @@ import java.util.UUID;
 public class MemberBlockCommandServiceImpl implements MemberBlockCommandService {
     private final MemberBlockRepository memberBlockRepository;
     private final MemberRepository memberRepository;
+    private final ApplicationEventPublisher eventPublisher;
 
     /**
      * 회원 차단(Block) 요청을 생성하는 메서드.
@@ -45,6 +52,9 @@ public class MemberBlockCommandServiceImpl implements MemberBlockCommandService 
         }
 
         MemberBlock savedMemberBlock = memberBlockRepository.save(MemberBlock.of(member, blockedMember));
+
+        eventPublisher.publishEvent(MemberBlockedEvent.of(blockedMember, member));
+
         return CreateMemberBlockResponse.of(savedMemberBlock.getId());
     }
 

--- a/src/test/java/com/project200/undabang/chat/event/ChatStatusEventListenerTest.java
+++ b/src/test/java/com/project200/undabang/chat/event/ChatStatusEventListenerTest.java
@@ -1,0 +1,117 @@
+package com.project200.undabang.chat.event;
+
+import com.project200.undabang.chat.dto.event.ChatroomMemberStatusEvent;
+import com.project200.undabang.common.web.response.WebSocketType;
+import com.project200.undabang.common.websocket.handler.WebSocketHandler;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Primary;
+import org.springframework.core.task.SyncTaskExecutor;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.transaction.support.TransactionTemplate;
+
+import java.util.concurrent.Executor;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+
+@SpringBootTest(properties = "spring.main.allow-bean-definition-overriding=true")
+class ChatStatusEventListenerTest {
+
+    @Autowired
+    private ApplicationEventPublisher eventPublisher;
+
+    @Autowired
+    private TransactionTemplate transactionTemplate;
+
+    @MockitoBean
+    private WebSocketHandler webSocketHandler;
+
+    @BeforeEach
+    void setUp() {
+        reset(webSocketHandler);
+    }
+
+    @TestConfiguration
+    static class AsyncTestConfig {
+        @Bean(name = "generalPurposeAsyncExecutor")
+        @Primary
+        public Executor generalPurposeAsyncExecutor() {
+            return new SyncTaskExecutor();
+        }
+    }
+
+    @Nested
+    @DisplayName("handleChatroomDeleted 메소드는")
+    class HandleChatroomDeletedTest {
+
+        @Test
+        @DisplayName("트랜잭션 커밋 후 채팅방 상태 변경 시스템 메시지를 전송한다")
+        void afterTransactionCommit() {
+            // given
+            Long chatroomId = 1L;
+            String content = "채팅방이 삭제되었습니다.";
+            ChatroomMemberStatusEvent event = new ChatroomMemberStatusEvent(chatroomId, content);
+
+            // when
+            transactionTemplate.execute(status -> {
+                eventPublisher.publishEvent(event);
+                return null;
+            });
+
+            // then
+            verify(webSocketHandler, times(1))
+                    .broadCastToAllChatroom(eq(chatroomId), argThat(response ->
+                            response.getType() == WebSocketType.SYSTEM_LEAVE // 혹은 로직에 맞는 타입 확인
+                                    && response.getMessage().equals(content)
+                    ));
+        }
+
+        @Test
+        @DisplayName("트랜잭션이 롤백되면 알림을 전송하지 않는다")
+        void rollbackTransaction() {
+            // given
+            ChatroomMemberStatusEvent event = new ChatroomMemberStatusEvent(1L, "롤백 테스트");
+
+            // when
+            try {
+                transactionTemplate.execute(status -> {
+                    eventPublisher.publishEvent(event);
+                    status.setRollbackOnly(); // 롤백 유도
+                    return null;
+                });
+            } catch (Exception ignored) {
+            }
+
+            // then
+            verify(webSocketHandler, never()).broadCastToAllChatroom(any(), any());
+        }
+
+        @Test
+        @DisplayName("전송 중 예외가 발생해도 로그를 남기고 종료된다")
+        void handlesExceptionGracefully() {
+            // given
+            ChatroomMemberStatusEvent event = new ChatroomMemberStatusEvent(1L, "예외 테스트");
+
+            doThrow(new RuntimeException("Socket Error"))
+                    .when(webSocketHandler).broadCastToAllChatroom(any(), any());
+
+            // when & then
+            assertDoesNotThrow(() -> transactionTemplate.execute(status -> {
+                eventPublisher.publishEvent(event);
+                return null;
+            }));
+
+            verify(webSocketHandler, times(1)).broadCastToAllChatroom(any(), any());
+        }
+    }
+}

--- a/src/test/java/com/project200/undabang/chat/service/impl/ChatCommandServiceImplConcurrencyTest.java
+++ b/src/test/java/com/project200/undabang/chat/service/impl/ChatCommandServiceImplConcurrencyTest.java
@@ -68,46 +68,6 @@ class ChatCommandServiceImplConcurrencyTest {
     @MockitoBean
     private PolicyService policyService;
 
-    private Member createAndSaveMember(String nickname, String email) {
-        Member member = Member.builder()
-                .memberId(UUID.randomUUID())
-                .memberNickname(nickname)
-                .memberEmail(email)
-                .memberBday(LocalDate.of(2000, 1, 1))
-                .build();
-        return memberRepository.save(member);
-    }
-
-    private ExerciseLocation createAndSaveExerciseLocation(Member member, double lat, double lon) {
-        Point point = geometryFactory.createPoint(new Coordinate(lon, lat));
-        ExerciseLocation location = ExerciseLocation.builder()
-                .member(member)
-                .exerciseLocationName("테스트 운동장소")
-                .exerciseLocationAddress("서울시 테스트구 테스트동")
-                .exerciseLocationPoint(point)
-                .build();
-        return exerciseLocationRepository.save(location);
-    }
-
-    private Chatroom setupLeftChatroom(Member memberA, Member memberB) {
-        Chatroom chatroom = chatroomRepository.save(Chatroom.createChatroom());
-        ChatroomMember cmA = ChatroomMember.of(chatroom, memberA);
-        cmA.updateMemberStatus(ChatroomMemberStatus.LEFT);
-        ChatroomMember cmB = ChatroomMember.of(chatroom, memberB);
-        cmB.updateMemberStatus(ChatroomMemberStatus.LEFT);
-        chatroomMemberRepository.saveAll(List.of(cmA, cmB));
-        return chatroom;
-    }
-
-    private CreateChatroomRequest createChatroomRequest(Member targetMember, ExerciseLocation targetLocation) {
-        return new CreateChatroomRequest(
-                targetMember.getMemberId(),
-                targetLocation.getExerciseLocationId(),
-                targetLocation.getExerciseLocationPoint().getY(), // Latitude
-                targetLocation.getExerciseLocationPoint().getX()  // Longitude
-        );
-    }
-
     @Nested
     @DisplayName("채팅방 생성 동시성 환경에서")
     class ConcurrencyTest {
@@ -180,5 +140,45 @@ class ChatCommandServiceImplConcurrencyTest {
             assertThat(updatedMemberA.getChatroomMemberStatus()).isEqualTo(ChatroomMemberStatus.ACTIVE);
             assertThat(updatedMemberB.getChatroomMemberStatus()).isEqualTo(ChatroomMemberStatus.ACTIVE);
         }
+    }
+
+    private Member createAndSaveMember(String nickname, String email) {
+        Member member = Member.builder()
+                .memberId(UUID.randomUUID())
+                .memberNickname(nickname)
+                .memberEmail(email)
+                .memberBday(LocalDate.of(2000, 1, 1))
+                .build();
+        return memberRepository.save(member);
+    }
+
+    private ExerciseLocation createAndSaveExerciseLocation(Member member, double lat, double lon) {
+        Point point = geometryFactory.createPoint(new Coordinate(lon, lat));
+        ExerciseLocation location = ExerciseLocation.builder()
+                .member(member)
+                .exerciseLocationName("테스트 운동장소")
+                .exerciseLocationAddress("서울시 테스트구 테스트동")
+                .exerciseLocationPoint(point)
+                .build();
+        return exerciseLocationRepository.save(location);
+    }
+
+    private Chatroom setupLeftChatroom(Member memberA, Member memberB) {
+        Chatroom chatroom = chatroomRepository.save(Chatroom.createChatroom());
+        ChatroomMember cmA = ChatroomMember.of(chatroom, memberA);
+        cmA.updateMemberStatus(ChatroomMemberStatus.LEFT);
+        ChatroomMember cmB = ChatroomMember.of(chatroom, memberB);
+        cmB.updateMemberStatus(ChatroomMemberStatus.LEFT);
+        chatroomMemberRepository.saveAll(List.of(cmA, cmB));
+        return chatroom;
+    }
+
+    private CreateChatroomRequest createChatroomRequest(Member targetMember, ExerciseLocation targetLocation) {
+        return new CreateChatroomRequest(
+                targetMember.getMemberId(),
+                targetLocation.getExerciseLocationId(),
+                targetLocation.getExerciseLocationPoint().getY(), // Latitude
+                targetLocation.getExerciseLocationPoint().getX()  // Longitude
+        );
     }
 }

--- a/src/test/java/com/project200/undabang/chat/service/impl/ChatCommandServiceImplTest.java
+++ b/src/test/java/com/project200/undabang/chat/service/impl/ChatCommandServiceImplTest.java
@@ -1,6 +1,7 @@
 package com.project200.undabang.chat.service.impl;
 
 import com.project200.undabang.chat.dto.event.ChatMessageCreatedEvent;
+import com.project200.undabang.chat.dto.event.ChatroomMemberStatusEvent;
 import com.project200.undabang.chat.dto.record.SaveMessageRecord;
 import com.project200.undabang.chat.dto.request.CreateChatroomRequest;
 import com.project200.undabang.chat.dto.request.CreateMessageRequest;
@@ -71,7 +72,6 @@ class ChatCommandServiceImplTest {
 
     @Mock
     private MemberBlockRepository memberBlockRepository;
-
 
     @Mock
     private ApplicationEventPublisher eventPublisher;
@@ -365,146 +365,11 @@ class ChatCommandServiceImplTest {
         }
     }
 
-    @Nested
-    @DisplayName("deleteChatroom 메소드는")
-    class Describe_deleteChatroom {
-
-        private final Long chatroomId = 1L;
-
-        @Test
-        @DisplayName("성공: 활성 멤버가 채팅방을 나가면 상태를 LEFT로 변경하고 시스템 메시지를 저장한다")
-        void it_leaves_chatroom_successfully() {
-            // given
-            Member member = createMember();
-            Chatroom chatroom = spy(createChatroom(chatroomId));
-            ChatroomMember chatroomMember = spy(createChatroomMember(chatroom, member, ChatroomMemberStatus.ACTIVE));
-
-            try (MockedStatic<UserContextHolder> ignored = mockStatic(UserContextHolder.class)) {
-                ignored.when(UserContextHolder::getUserId).thenReturn(member.getMemberId());
-                given(memberRepository.findById(member.getMemberId())).willReturn(Optional.of(member));
-                given(chatroomMemberRepository.findByChatroom_IdAndMember(chatroomId, member)).willReturn(Optional.of(chatroomMember));
-                given(chatroomMemberRepository.countByChatroomAndChatroomMemberStatus(chatroom, ChatroomMemberStatus.ACTIVE)).willReturn(1L);
-
-                // when
-                chatCommandService.leaveChatroom(chatroomId);
-
-                // then
-                then(chatroomMember).should(times(1)).updateMemberStatus(ChatroomMemberStatus.LEFT);
-                then(chatroom).should(never()).deleteChatroom();
-                verify(chatRepository, times(1)).save(any(Chat.class));
-            }
-        }
-
-        @Test
-        @DisplayName("성공: 마지막 활성 멤버가 나가면 채팅방도 논리적으로 삭제한다")
-        void it_deletes_chatroom_when_last_member_leaves() {
-            // given
-            Member member = createMember();
-            Chatroom chatroom = spy(createChatroom(chatroomId));
-            ChatroomMember chatroomMember = createChatroomMember(chatroom, member, ChatroomMemberStatus.ACTIVE);
-
-            try (MockedStatic<UserContextHolder> ignored = mockStatic(UserContextHolder.class)) {
-                ignored.when(UserContextHolder::getUserId).thenReturn(member.getMemberId());
-                given(memberRepository.findById(member.getMemberId())).willReturn(Optional.of(member));
-                given(chatroomMemberRepository.findByChatroom_IdAndMember(chatroomId, member)).willReturn(Optional.of(chatroomMember));
-                given(chatroomMemberRepository.countByChatroomAndChatroomMemberStatus(chatroom, ChatroomMemberStatus.ACTIVE)).willReturn(0L);
-
-                // when
-                chatCommandService.leaveChatroom(chatroomId);
-
-                // then
-                then(chatroom).should(times(1)).deleteChatroom();
-                verify(chatRepository, times(1)).save(any(Chat.class));
-            }
-        }
-
-        @Test
-        @DisplayName("성공: 이미 나간 멤버가 다시 나가기를 요청하면 아무 작업도 하지 않고 성공 처리한다")
-        void it_does_nothing_if_member_already_left() {
-            // given
-            Member member = createMember();
-            Chatroom chatroom = createChatroom(chatroomId);
-            ChatroomMember chatroomMember = createChatroomMember(chatroom, member, ChatroomMemberStatus.LEFT);
-
-            try (MockedStatic<UserContextHolder> ignored = mockStatic(UserContextHolder.class)) {
-                ignored.when(UserContextHolder::getUserId).thenReturn(member.getMemberId());
-                given(memberRepository.findById(member.getMemberId())).willReturn(Optional.of(member));
-                given(chatroomMemberRepository.findByChatroom_IdAndMember(chatroomId, member)).willReturn(Optional.of(chatroomMember));
-
-                // when
-                chatCommandService.leaveChatroom(chatroomId);
-
-                // then
-                verify(chatroomMemberRepository, never()).countByChatroomAndChatroomMemberStatus(any(Chatroom.class), any(ChatroomMemberStatus.class));
-                verify(chatRepository, never()).save(any(Chat.class));
-            }
-        }
-
-        @Test
-        @DisplayName("실패: 채팅방 멤버가 아닐 경우 예외를 발생시킨다")
-        void it_throws_exception_if_not_a_member() {
-            // given
-            Member member = createMember();
-
-            try (MockedStatic<UserContextHolder> ignored = mockStatic(UserContextHolder.class)) {
-                ignored.when(UserContextHolder::getUserId).thenReturn(member.getMemberId());
-                given(memberRepository.findById(member.getMemberId())).willReturn(Optional.of(member));
-                given(chatroomMemberRepository.findByChatroom_IdAndMember(chatroomId, member)).willReturn(Optional.empty());
-
-                // when & then
-                assertThatThrownBy(() -> chatCommandService.leaveChatroom(chatroomId))
-                        .isInstanceOf(CustomException.class)
-                        .hasMessage(ErrorCode.CHATROOM_MEMBERS_NOT_FOUND.getMessage());
-            }
-        }
-    }
-
     private Member createMember() {
         return Member.builder()
                 .memberId(UUID.randomUUID())
                 .memberNickname("user_" + UUID.randomUUID().toString().substring(0, 8))
                 .build();
-    }
-
-    private Chatroom createChatroom(Long id) {
-        return Chatroom.builder()
-                .id(id)
-                .build();
-    }
-
-    private ChatroomMember createChatroomMember(Chatroom chatroom, Member member, ChatroomMemberStatus status) {
-        return ChatroomMember.builder()
-                .chatroom(chatroom)
-                .member(member)
-                .chatroomMemberStatus(status)
-                .build();
-    }
-
-    private ChatroomMember createChatroomMemberWithId(Long id, Chatroom chatroom, Member member, ChatroomMemberStatus status) {
-        return ChatroomMember.builder()
-                .chatroomMemberId(id)
-                .chatroom(chatroom)
-                .member(member)
-                .chatroomMemberStatus(status)
-                .build();
-    }
-
-    private ExerciseLocation createMockLocation(Double lat, Double lon) {
-        ExerciseLocation mockLocation = mock(ExerciseLocation.class);
-
-        Point realPoint = geometryFactory.createPoint(new Coordinate(lon, lat));
-
-        lenient().when(mockLocation.getExerciseLocationPoint()).thenReturn(realPoint);
-
-        return mockLocation;
-    }
-
-    private void mockMemberLocking(Member member1, Member member2) {
-        List<UUID> sortedIds = Stream.of(member1.getMemberId(), member2.getMemberId()).sorted().toList();
-        List<Member> sortedMembers = Stream.of(member1, member2)
-                .sorted((m1, m2) -> m1.getMemberId().compareTo(m2.getMemberId()))
-                .toList();
-        given(memberRepository.findAllByIdWithPessimisticLock(sortedIds)).willReturn(sortedMembers);
     }
 
     @Nested
@@ -764,6 +629,167 @@ class ChatCommandServiceImplTest {
                 then(currentChatroomMember).should().updateMemberStatus(ChatroomMemberStatus.ACTIVE);
                 then(targetChatroomMember).should().updateMemberStatus(ChatroomMemberStatus.ACTIVE);
                 then(memberRepository).should(never()).findAllByIdWithPessimisticLock(anyList());
+            }
+        }
+    }
+
+    // --- Helper Methods (Moved to Bottom) ---
+
+    private Chatroom createChatroom(Long id) {
+        return Chatroom.builder()
+                .id(id)
+                .build();
+    }
+
+    private ChatroomMember createChatroomMember(Chatroom chatroom, Member member, ChatroomMemberStatus status) {
+        return ChatroomMember.builder()
+                .chatroom(chatroom)
+                .member(member)
+                .chatroomMemberStatus(status)
+                .build();
+    }
+
+    private ChatroomMember createChatroomMemberWithId(Long id, Chatroom chatroom, Member member, ChatroomMemberStatus status) {
+        return ChatroomMember.builder()
+                .chatroomMemberId(id)
+                .chatroom(chatroom)
+                .member(member)
+                .chatroomMemberStatus(status)
+                .build();
+    }
+
+    private ExerciseLocation createMockLocation(Double lat, Double lon) {
+        ExerciseLocation mockLocation = mock(ExerciseLocation.class);
+
+        Point realPoint = geometryFactory.createPoint(new Coordinate(lon, lat));
+
+        lenient().when(mockLocation.getExerciseLocationPoint()).thenReturn(realPoint);
+
+        return mockLocation;
+    }
+
+    private void mockMemberLocking(Member member1, Member member2) {
+        List<UUID> sortedIds = Stream.of(member1.getMemberId(), member2.getMemberId()).sorted().toList();
+        List<Member> sortedMembers = Stream.of(member1, member2)
+                .sorted((m1, m2) -> m1.getMemberId().compareTo(m2.getMemberId()))
+                .toList();
+        given(memberRepository.findAllByIdWithPessimisticLock(sortedIds)).willReturn(sortedMembers);
+    }
+
+    @Nested
+    @DisplayName("deleteChatroom 메소드는")
+    class Describe_deleteChatroom {
+
+        private final Long chatroomId = 1L;
+
+        @Test
+        @DisplayName("성공: 활성 멤버가 채팅방을 나가면 상태를 LEFT로 변경하고 시스템 메시지를 저장하며, 이벤트를 발행한다")
+        void it_leaves_chatroom_successfully() {
+            // given
+            Member member = createMember();
+            Chatroom chatroom = spy(createChatroom(chatroomId));
+            ChatroomMember chatroomMember = spy(createChatroomMember(chatroom, member, ChatroomMemberStatus.ACTIVE));
+            String systemMessageContent = "사용자님이 나갔습니다";
+
+            // 시스템 메시지용 Mock Chat 객체 생성
+            Chat savedSystemChat = mock(Chat.class);
+            given(savedSystemChat.getChatContent()).willReturn(systemMessageContent);
+
+            try (MockedStatic<UserContextHolder> ignored = mockStatic(UserContextHolder.class)) {
+                ignored.when(UserContextHolder::getUserId).thenReturn(member.getMemberId());
+                given(memberRepository.findById(member.getMemberId())).willReturn(Optional.of(member));
+                given(chatroomMemberRepository.findByChatroom_IdAndMember(chatroomId, member)).willReturn(Optional.of(chatroomMember));
+                given(chatroomMemberRepository.countByChatroomAndChatroomMemberStatus(chatroom, ChatroomMemberStatus.ACTIVE)).willReturn(1L);
+
+                // 시스템 메시지 저장 시 Mock 객체 반환
+                given(chatRepository.save(any(Chat.class))).willReturn(savedSystemChat);
+
+                // when
+                chatCommandService.leaveChatroom(chatroomId);
+
+                // then
+                then(chatroomMember).should(times(1)).updateMemberStatus(ChatroomMemberStatus.LEFT);
+                then(chatroom).should(never()).deleteChatroom();
+                verify(chatRepository, times(1)).save(any(Chat.class));
+
+                // [추가된 부분] 이벤트 발행 검증
+                ArgumentCaptor<ChatroomMemberStatusEvent> eventCaptor = ArgumentCaptor.forClass(ChatroomMemberStatusEvent.class);
+                verify(eventPublisher).publishEvent(eventCaptor.capture());
+
+                ChatroomMemberStatusEvent capturedEvent = eventCaptor.getValue();
+                assertThat(capturedEvent.chatroomId()).isEqualTo(chatroomId);
+                assertThat(capturedEvent.chatContent()).isEqualTo(systemMessageContent);
+            }
+        }
+
+        @Test
+        @DisplayName("성공: 마지막 활성 멤버가 나가면 채팅방도 논리적으로 삭제한다")
+        void it_deletes_chatroom_when_last_member_leaves() {
+            // given
+            Member member = createMember();
+            Chatroom chatroom = spy(createChatroom(chatroomId));
+            ChatroomMember chatroomMember = createChatroomMember(chatroom, member, ChatroomMemberStatus.ACTIVE);
+
+            Chat savedSystemChat = mock(Chat.class);
+            given(savedSystemChat.getChatContent()).willReturn("나감");
+
+            try (MockedStatic<UserContextHolder> ignored = mockStatic(UserContextHolder.class)) {
+                ignored.when(UserContextHolder::getUserId).thenReturn(member.getMemberId());
+                given(memberRepository.findById(member.getMemberId())).willReturn(Optional.of(member));
+                given(chatroomMemberRepository.findByChatroom_IdAndMember(chatroomId, member)).willReturn(Optional.of(chatroomMember));
+                given(chatroomMemberRepository.countByChatroomAndChatroomMemberStatus(chatroom, ChatroomMemberStatus.ACTIVE)).willReturn(0L);
+                given(chatRepository.save(any(Chat.class))).willReturn(savedSystemChat);
+
+                // when
+                chatCommandService.leaveChatroom(chatroomId);
+
+                // then
+                then(chatroom).should(times(1)).deleteChatroom();
+                verify(chatRepository, times(1)).save(any(Chat.class));
+
+                // 이벤트 발행 검증 (삭제 시에도 나감 메시지는 전송됨)
+                verify(eventPublisher).publishEvent(any(ChatroomMemberStatusEvent.class));
+            }
+        }
+
+        @Test
+        @DisplayName("성공: 이미 나간 멤버가 다시 나가기를 요청하면 아무 작업도 하지 않고 성공 처리한다")
+        void it_does_nothing_if_member_already_left() {
+            // given
+            Member member = createMember();
+            Chatroom chatroom = createChatroom(chatroomId);
+            ChatroomMember chatroomMember = createChatroomMember(chatroom, member, ChatroomMemberStatus.LEFT);
+
+            try (MockedStatic<UserContextHolder> ignored = mockStatic(UserContextHolder.class)) {
+                ignored.when(UserContextHolder::getUserId).thenReturn(member.getMemberId());
+                given(memberRepository.findById(member.getMemberId())).willReturn(Optional.of(member));
+                given(chatroomMemberRepository.findByChatroom_IdAndMember(chatroomId, member)).willReturn(Optional.of(chatroomMember));
+
+                // when
+                chatCommandService.leaveChatroom(chatroomId);
+
+                // then
+                verify(chatroomMemberRepository, never()).countByChatroomAndChatroomMemberStatus(any(Chatroom.class), any(ChatroomMemberStatus.class));
+                verify(chatRepository, never()).save(any(Chat.class));
+                verify(eventPublisher, never()).publishEvent(any());
+            }
+        }
+
+        @Test
+        @DisplayName("실패: 채팅방 멤버가 아닐 경우 예외를 발생시킨다")
+        void it_throws_exception_if_not_a_member() {
+            // given
+            Member member = createMember();
+
+            try (MockedStatic<UserContextHolder> ignored = mockStatic(UserContextHolder.class)) {
+                ignored.when(UserContextHolder::getUserId).thenReturn(member.getMemberId());
+                given(memberRepository.findById(member.getMemberId())).willReturn(Optional.of(member));
+                given(chatroomMemberRepository.findByChatroom_IdAndMember(chatroomId, member)).willReturn(Optional.empty());
+
+                // when & then
+                assertThatThrownBy(() -> chatCommandService.leaveChatroom(chatroomId))
+                        .isInstanceOf(CustomException.class)
+                        .hasMessage(ErrorCode.CHATROOM_MEMBERS_NOT_FOUND.getMessage());
             }
         }
     }

--- a/src/test/java/com/project200/undabang/member/event/MemberBlockEventListenerTest.java
+++ b/src/test/java/com/project200/undabang/member/event/MemberBlockEventListenerTest.java
@@ -1,0 +1,187 @@
+package com.project200.undabang.member.event;
+
+import com.project200.undabang.chat.entity.Chatroom;
+import com.project200.undabang.chat.repository.ChatroomRepository;
+import com.project200.undabang.common.web.response.WebSocketType;
+import com.project200.undabang.common.websocket.handler.WebSocketHandler;
+import com.project200.undabang.member.dto.event.MemberBlockedEvent;
+import com.project200.undabang.member.entity.Member;
+import com.project200.undabang.member.enums.MemberGender;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Primary;
+import org.springframework.core.task.SyncTaskExecutor;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.transaction.support.TransactionTemplate;
+
+import java.time.LocalDate;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.concurrent.Executor;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+@SpringBootTest(properties = "spring.main.allow-bean-definition-overriding=true")
+class MemberBlockEventListenerTest {
+
+    @Autowired
+    private ApplicationEventPublisher eventPublisher;
+
+    @Autowired
+    private TransactionTemplate transactionTemplate;
+
+    @MockitoBean
+    private WebSocketHandler webSocketHandler;
+
+    @MockitoBean
+    private ChatroomRepository chatroomRepository;
+
+    @BeforeEach
+    void setUp() {
+        reset(webSocketHandler, chatroomRepository);
+    }
+
+    private Member createMember(UUID memberId, String nickname) {
+        return Member.builder()
+                .memberId(memberId)
+                .memberNickname(nickname)
+                .memberEmail(nickname + "@test.com")
+                .memberGender(MemberGender.MALE)
+                .memberBday(LocalDate.of(1995, 1, 1))
+                .memberScore((byte) 36)
+                .memberWarnedCount((byte) 0)
+                .build();
+    }
+
+    @TestConfiguration
+    static class AsyncTestConfig {
+        @Bean(name = "generalPurposeAsyncExecutor")
+        @Primary
+        public Executor generalPurposeAsyncExecutor() {
+            return new SyncTaskExecutor();
+        }
+    }
+
+    @Nested
+    @DisplayName("handleMemberBlocked 메소드는")
+    class HandleMemberBlockedTest {
+
+        @Test
+        @DisplayName("트랜잭션 커밋 후 두 회원 사이의 채팅방이 존재하면 차단 알림(SYSTEM_BANNED)을 전송한다")
+        void sendNotificationWhenChatroomExists() {
+            // given
+            // 1. Member 객체 생성
+            Member blocker = createMember(UUID.randomUUID(), "blockerUser");
+            Member blocked = createMember(UUID.randomUUID(), "blockedUser");
+
+            // 2. 이벤트 생성 (ID가 아니라 Member 객체를 직접 주입)
+            MemberBlockedEvent event = MemberBlockedEvent.of(blocked, blocker);
+
+            // 3. 채팅방 Mock 설정
+            Long existingChatroomId = 100L;
+            Chatroom mockChatroom = mock(Chatroom.class);
+            when(mockChatroom.getId()).thenReturn(existingChatroomId);
+
+            // 4. 레포지토리 Mocking (인자가 Member 객체임)
+            when(chatroomRepository.findChatroomBetweenMembers(blocked, blocker))
+                    .thenReturn(Optional.of(mockChatroom));
+
+            // when
+            transactionTemplate.execute(status -> {
+                eventPublisher.publishEvent(event);
+                return null;
+            });
+
+            // then
+            verify(chatroomRepository, times(1)).findChatroomBetweenMembers(blocked, blocker);
+
+            verify(webSocketHandler, times(1))
+                    .broadCastToAllChatroom(eq(existingChatroomId), argThat(response ->
+                            response.getType() == WebSocketType.SYSTEM_BANNED
+                    ));
+        }
+
+        @Test
+        @DisplayName("채팅방이 존재하지 않으면(Optional.empty) 알림을 보내지 않고 종료한다")
+        void doNothingWhenChatroomNotFound() {
+            // given
+            Member blocker = createMember(UUID.randomUUID(), "blockerUser");
+            Member blocked = createMember(UUID.randomUUID(), "blockedUser");
+            MemberBlockedEvent event = MemberBlockedEvent.of(blocked, blocker);
+
+            // 채팅방 없음 설정
+            when(chatroomRepository.findChatroomBetweenMembers(blocked, blocker))
+                    .thenReturn(Optional.empty());
+
+            // when
+            transactionTemplate.execute(status -> {
+                eventPublisher.publishEvent(event);
+                return null;
+            });
+
+            // then
+            verify(chatroomRepository, times(1)).findChatroomBetweenMembers(any(Member.class), any(Member.class));
+            verify(webSocketHandler, never()).broadCastToAllChatroom(any(), any());
+        }
+
+        @Test
+        @DisplayName("트랜잭션이 롤백되면 리스너가 실행되지 않는다")
+        void rollbackTransaction() {
+            // given
+            Member blocker = createMember(UUID.randomUUID(), "blocker");
+            Member blocked = createMember(UUID.randomUUID(), "blocked");
+            MemberBlockedEvent event = MemberBlockedEvent.of(blocked, blocker);
+
+            // when
+            try {
+                transactionTemplate.execute(status -> {
+                    eventPublisher.publishEvent(event);
+                    status.setRollbackOnly(); // 강제 롤백
+                    return null;
+                });
+            } catch (Exception ignored) {
+            }
+
+            // then
+            verify(chatroomRepository, never()).findChatroomBetweenMembers(any(), any());
+            verify(webSocketHandler, never()).broadCastToAllChatroom(any(), any());
+        }
+
+        @Test
+        @DisplayName("알림 전송 중 예외가 발생해도 로그를 남기고 안전하게 종료된다")
+        void handlesExceptionGracefully() {
+            // given
+            Member blocker = createMember(UUID.randomUUID(), "blockerUser");
+            Member blocked = createMember(UUID.randomUUID(), "blockedUser");
+            MemberBlockedEvent event = MemberBlockedEvent.of(blocked, blocker);
+
+            Chatroom mockChatroom = mock(Chatroom.class);
+            when(mockChatroom.getId()).thenReturn(1L);
+
+            when(chatroomRepository.findChatroomBetweenMembers(blocked, blocker))
+                    .thenReturn(Optional.of(mockChatroom));
+
+            // WebSocketHandler가 예외를 던지도록 설정
+            doThrow(new RuntimeException("WebSocket Error"))
+                    .when(webSocketHandler).broadCastToAllChatroom(any(), any());
+
+            // when & then
+            assertDoesNotThrow(() -> transactionTemplate.execute(status -> {
+                eventPublisher.publishEvent(event);
+                return null;
+            }));
+
+            // 예외가 발생했어도 호출 시도는 1번 했어야 함
+            verify(webSocketHandler, times(1)).broadCastToAllChatroom(any(), any());
+        }
+    }
+}

--- a/src/test/java/com/project200/undabang/member/service/impl/ExerciseLocationCommandServiceImplTest.java
+++ b/src/test/java/com/project200/undabang/member/service/impl/ExerciseLocationCommandServiceImplTest.java
@@ -46,16 +46,39 @@ class ExerciseLocationCommandServiceImplTest {
     @Mock
     private PolicyService policyService;
 
+    private CreateExerciseLocationRequest createExerciseLocationRequest(String name, String address, Double lat, Double lon) {
+        return new CreateExerciseLocationRequest(name, address, lat, lon);
+    }
+
+    private UpdateExerciseLocationRequest updateRequest(String newName) {
+        return new UpdateExerciseLocationRequest(newName);
+    }
+
+    private Member createMember(UUID memberId, String nickname) {
+        return Member.builder()
+                .memberId(memberId)
+                .memberNickname(nickname)
+                .build();
+    }
+
+    private ExerciseLocation createExerciseLocation(Long locationId, Member member, String name) {
+        return ExerciseLocation.builder()
+                .exerciseLocationId(locationId)
+                .member(member)
+                .exerciseLocationName(name)
+                .build();
+    }
+
     @Nested
     @DisplayName("createExerciseLocation 메소드는")
     class Describe_createExerciseLocation {
 
         @Nested
-        @DisplayName("유효한 생성 요청이 주어졌을 때")
+        @DisplayName("유효한 생성 요청이 주어지면")
         class Context_with_valid_request {
 
             @Test
-            @DisplayName("모든 유효성 검사를 통과하면, 운동 위치를 생성하고 응답을 반환한다")
+            @DisplayName("운동 위치를 생성하고 생성된 위치의 응답을 반환한다")
             void it_creates_location_and_returns_response() {
                 // given
                 final UUID MEMBER_ID = UUID.randomUUID();
@@ -93,11 +116,11 @@ class ExerciseLocationCommandServiceImplTest {
         }
 
         @Nested
-        @DisplayName("유효하지 않은 생성 요청이 주어졌을 때")
-        class Context_with_invalid_request {
+        @DisplayName("이미 존재하는 이름으로 요청하면")
+        class Context_with_duplicate_name {
 
             @Test
-            @DisplayName("이미 존재하는 이름이면, CustomException을 던진다")
+            @DisplayName("CustomException(NAME_DUPLICATED)을 던진다")
             void it_throws_exception_for_duplicate_name() {
                 // given
                 final UUID MEMBER_ID = UUID.randomUUID();
@@ -109,6 +132,7 @@ class ExerciseLocationCommandServiceImplTest {
                     when(memberRepository.findById(MEMBER_ID)).thenReturn(Optional.of(member));
                     when(exerciseLocationRepository.existsByMemberAndExerciseLocationNameAndExerciseLocationDeletedAtNull(member, request.getName())).thenReturn(true);
 
+                    // when & then
                     assertThatThrownBy(() -> exerciseLocationCommandService.createExerciseLocation(request))
                             .isInstanceOf(CustomException.class)
                             .hasFieldOrPropertyWithValue("errorCode", ErrorCode.EXERCISE_LOCATION_NAME_DUPLICATED);
@@ -116,9 +140,14 @@ class ExerciseLocationCommandServiceImplTest {
                     verify(exerciseLocationRepository, never()).save(any());
                 }
             }
+        }
+
+        @Nested
+        @DisplayName("최대 생성 개수를 초과하면")
+        class Context_with_max_count_violation {
 
             @Test
-            @DisplayName("최대 생성 개수를 초과하면, CustomException을 던진다")
+            @DisplayName("CustomException(MAX_COUNT_VIOLATION)을 던진다")
             void it_throws_exception_for_max_count_violation() {
                 // given
                 final UUID MEMBER_ID = UUID.randomUUID();
@@ -133,6 +162,7 @@ class ExerciseLocationCommandServiceImplTest {
                     when(policyService.getPolicyValueAsInt(any(PolicyKey.class))).thenReturn(MAX_COUNT);
                     when(exerciseLocationRepository.countByMemberAndExerciseLocationDeletedAtNull(member)).thenReturn((long) MAX_COUNT);
 
+                    // when & then
                     assertThatThrownBy(() -> exerciseLocationCommandService.createExerciseLocation(request))
                             .isInstanceOf(CustomException.class)
                             .hasFieldOrPropertyWithValue("errorCode", ErrorCode.EXERCISE_LOCATION_MAX_COUNT_VIOLATION);
@@ -140,9 +170,14 @@ class ExerciseLocationCommandServiceImplTest {
                     verify(exerciseLocationRepository, never()).save(any());
                 }
             }
+        }
+
+        @Nested
+        @DisplayName("요청한 회원을 찾을 수 없으면")
+        class Context_with_member_not_found {
 
             @Test
-            @DisplayName("회원을 찾을 수 없으면, CustomException을 던진다")
+            @DisplayName("CustomException(MEMBER_NOT_FOUND)을 던진다")
             void it_throws_exception_when_member_not_found() {
                 // given
                 final UUID NON_EXISTENT_MEMBER_ID = UUID.randomUUID();
@@ -152,6 +187,7 @@ class ExerciseLocationCommandServiceImplTest {
                     mockedUserContext.when(UserContextHolder::getUserId).thenReturn(NON_EXISTENT_MEMBER_ID);
                     when(memberRepository.findById(NON_EXISTENT_MEMBER_ID)).thenReturn(Optional.empty());
 
+                    // when & then
                     assertThatThrownBy(() -> exerciseLocationCommandService.createExerciseLocation(request))
                             .isInstanceOf(CustomException.class)
                             .hasFieldOrPropertyWithValue("errorCode", ErrorCode.MEMBER_NOT_FOUND);
@@ -164,169 +200,170 @@ class ExerciseLocationCommandServiceImplTest {
         }
     }
 
-    private CreateExerciseLocationRequest createExerciseLocationRequest(String name, String address, Double lat, Double lon) {
-        return new CreateExerciseLocationRequest(name, address, lat, lon);
-    }
-
-    private UpdateExerciseLocationRequest updateRequest(String newName) {
-        return new UpdateExerciseLocationRequest(newName);
-    }
-
-    private Member createMember(UUID memberId, String nickname) {
-        return Member.builder()
-                .memberId(memberId)
-                .memberNickname(nickname)
-                .build();
-    }
-
-    private ExerciseLocation createExerciseLocation(Long locationId, Member member, String name) {
-        return ExerciseLocation.builder()
-                .exerciseLocationId(locationId)
-                .member(member)
-                .exerciseLocationName(name)
-                .build();
-    }
-
     @Nested
     @DisplayName("updateExerciseLocation 메소드는")
     class Describe_updateExerciseLocation {
 
-        @Test
-        @DisplayName("해당 회원의 삭제되지 않은 운동장소가 존재하면 이름을 수정하고 응답을 반환한다")
-        void it_updates_location_name_and_returns_response() {
-            // given
-            final UUID MEMBER_ID = UUID.randomUUID();
-            final Long LOCATION_ID = 1L;
-            final String OLD_NAME = "기존 헬스장";
-            final String NEW_NAME = "수정된 헬스장";
-            Member member = createMember(MEMBER_ID, "testUser");
-            ExerciseLocation location = createExerciseLocation(LOCATION_ID, member, OLD_NAME);
+        @Nested
+        @DisplayName("해당 회원의 삭제되지 않은 운동장소가 존재하고 이름이 변경되었다면")
+        class Context_with_valid_request_and_name_change {
 
-            try (MockedStatic<UserContextHolder> mockedUserContext = mockStatic(UserContextHolder.class)) {
-                mockedUserContext.when(UserContextHolder::getUserId).thenReturn(MEMBER_ID);
-                when(memberRepository.findById(MEMBER_ID)).thenReturn(Optional.of(member));
-                when(exerciseLocationRepository.findByExerciseLocationIdAndExerciseLocationDeletedAtNull(LOCATION_ID))
-                        .thenReturn(Optional.of(location));
-                when(exerciseLocationRepository.existsByMemberAndExerciseLocationNameAndExerciseLocationDeletedAtNull(member, NEW_NAME))
-                        .thenReturn(false);
+            @Test
+            @DisplayName("이름을 수정하고 업데이트된 응답을 반환한다")
+            void it_updates_location_name_and_returns_response() {
+                // given
+                final UUID MEMBER_ID = UUID.randomUUID();
+                final Long LOCATION_ID = 1L;
+                final String OLD_NAME = "기존 헬스장";
+                final String NEW_NAME = "수정된 헬스장";
+                Member member = createMember(MEMBER_ID, "testUser");
+                ExerciseLocation location = createExerciseLocation(LOCATION_ID, member, OLD_NAME);
 
-                UpdateExerciseLocationRequest request = updateRequest(NEW_NAME);
+                try (MockedStatic<UserContextHolder> mockedUserContext = mockStatic(UserContextHolder.class)) {
+                    mockedUserContext.when(UserContextHolder::getUserId).thenReturn(MEMBER_ID);
+                    when(memberRepository.findById(MEMBER_ID)).thenReturn(Optional.of(member));
+                    when(exerciseLocationRepository.findByExerciseLocationIdAndExerciseLocationDeletedAtNull(LOCATION_ID))
+                            .thenReturn(Optional.of(location));
+                    when(exerciseLocationRepository.existsByMemberAndExerciseLocationNameAndExerciseLocationDeletedAtNull(member, NEW_NAME))
+                            .thenReturn(false);
 
-                // when
-                UpdateExerciseLocationResponse response = exerciseLocationCommandService.updateExerciseLocation(LOCATION_ID, request);
+                    UpdateExerciseLocationRequest request = updateRequest(NEW_NAME);
 
-                // then
-                assertThat(response).isNotNull();
-                assertThat(response.getId()).isEqualTo(LOCATION_ID);
-                assertThat(location.getExerciseLocationName()).isEqualTo(NEW_NAME);
+                    // when
+                    UpdateExerciseLocationResponse response = exerciseLocationCommandService.updateExerciseLocation(LOCATION_ID, request);
+
+                    // then
+                    assertThat(response).isNotNull();
+                    assertThat(response.getId()).isEqualTo(LOCATION_ID);
+                    assertThat(location.getExerciseLocationName()).isEqualTo(NEW_NAME);
+                }
             }
         }
 
-        @Test
-        @DisplayName("이름이 변경되지 않았을 경우, 중복 검사를 수행하지 않고 성공적으로 응답한다")
-        void it_does_not_validate_duplicate_when_name_is_unchanged() {
-            // given
-            final UUID MEMBER_ID = UUID.randomUUID();
-            final Long LOCATION_ID = 1L;
-            final String SAME_NAME = "기존 헬스장";
-            Member member = createMember(MEMBER_ID, "testUser");
-            ExerciseLocation location = createExerciseLocation(LOCATION_ID, member, SAME_NAME);
+        @Nested
+        @DisplayName("이름이 변경되지 않았다면")
+        class Context_with_unchanged_name {
 
-            try (MockedStatic<UserContextHolder> mockedUserContext = mockStatic(UserContextHolder.class)) {
-                mockedUserContext.when(UserContextHolder::getUserId).thenReturn(MEMBER_ID);
-                when(memberRepository.findById(MEMBER_ID)).thenReturn(Optional.of(member));
-                when(exerciseLocationRepository.findByExerciseLocationIdAndExerciseLocationDeletedAtNull(LOCATION_ID))
-                        .thenReturn(Optional.of(location));
+            @Test
+            @DisplayName("중복 검사를 수행하지 않고 성공 응답을 반환한다")
+            void it_does_not_validate_duplicate_when_name_is_unchanged() {
+                // given
+                final UUID MEMBER_ID = UUID.randomUUID();
+                final Long LOCATION_ID = 1L;
+                final String SAME_NAME = "기존 헬스장";
+                Member member = createMember(MEMBER_ID, "testUser");
+                ExerciseLocation location = createExerciseLocation(LOCATION_ID, member, SAME_NAME);
 
-                UpdateExerciseLocationRequest request = updateRequest(SAME_NAME);
+                try (MockedStatic<UserContextHolder> mockedUserContext = mockStatic(UserContextHolder.class)) {
+                    mockedUserContext.when(UserContextHolder::getUserId).thenReturn(MEMBER_ID);
+                    when(memberRepository.findById(MEMBER_ID)).thenReturn(Optional.of(member));
+                    when(exerciseLocationRepository.findByExerciseLocationIdAndExerciseLocationDeletedAtNull(LOCATION_ID))
+                            .thenReturn(Optional.of(location));
 
-                // when
-                UpdateExerciseLocationResponse response = exerciseLocationCommandService.updateExerciseLocation(LOCATION_ID, request);
+                    UpdateExerciseLocationRequest request = updateRequest(SAME_NAME);
 
-                // then
-                assertThat(response).isNotNull();
-                assertThat(response.getId()).isEqualTo(LOCATION_ID);
-                assertThat(location.getExerciseLocationName()).isEqualTo(SAME_NAME);
+                    // when
+                    UpdateExerciseLocationResponse response = exerciseLocationCommandService.updateExerciseLocation(LOCATION_ID, request);
 
-                verify(exerciseLocationRepository, never()).existsByMemberAndExerciseLocationNameAndExerciseLocationDeletedAtNull(any(Member.class), anyString());
+                    // then
+                    assertThat(response).isNotNull();
+                    assertThat(response.getId()).isEqualTo(LOCATION_ID);
+                    assertThat(location.getExerciseLocationName()).isEqualTo(SAME_NAME);
+
+                    verify(exerciseLocationRepository, never()).existsByMemberAndExerciseLocationNameAndExerciseLocationDeletedAtNull(any(Member.class), anyString());
+                }
             }
         }
 
+        @Nested
+        @DisplayName("운동장소가 없거나 이미 삭제된 경우")
+        class Context_with_non_existent_location {
 
-        @Test
-        @DisplayName("운동장소가 없거나 삭제된 경우 CustomException(NOT_FOUND)을 던진다")
-        void it_throws_not_found_exception_when_location_is_not_found_or_deleted() {
-            // given
-            final UUID MEMBER_ID = UUID.randomUUID();
-            final Long NON_EXISTENT_LOCATION_ID = 999L;
-            Member member = createMember(MEMBER_ID, "testUser");
+            @Test
+            @DisplayName("CustomException(NOT_FOUND)을 던진다")
+            void it_throws_not_found_exception() {
+                // given
+                final UUID MEMBER_ID = UUID.randomUUID();
+                final Long NON_EXISTENT_LOCATION_ID = 999L;
+                Member member = createMember(MEMBER_ID, "testUser");
 
-            try (MockedStatic<UserContextHolder> mockedUserContext = mockStatic(UserContextHolder.class)) {
-                mockedUserContext.when(UserContextHolder::getUserId).thenReturn(MEMBER_ID);
-                when(memberRepository.findById(MEMBER_ID)).thenReturn(Optional.of(member));
-                when(exerciseLocationRepository.findByExerciseLocationIdAndExerciseLocationDeletedAtNull(NON_EXISTENT_LOCATION_ID))
-                        .thenReturn(Optional.empty());
+                try (MockedStatic<UserContextHolder> mockedUserContext = mockStatic(UserContextHolder.class)) {
+                    mockedUserContext.when(UserContextHolder::getUserId).thenReturn(MEMBER_ID);
+                    when(memberRepository.findById(MEMBER_ID)).thenReturn(Optional.of(member));
+                    when(exerciseLocationRepository.findByExerciseLocationIdAndExerciseLocationDeletedAtNull(NON_EXISTENT_LOCATION_ID))
+                            .thenReturn(Optional.empty());
 
-                UpdateExerciseLocationRequest request = updateRequest("새 이름");
+                    UpdateExerciseLocationRequest request = updateRequest("새 이름");
 
-                // when & then
-                assertThatThrownBy(() -> exerciseLocationCommandService.updateExerciseLocation(NON_EXISTENT_LOCATION_ID, request))
-                        .isInstanceOf(CustomException.class)
-                        .hasFieldOrPropertyWithValue("errorCode", ErrorCode.EXERCISE_LOCATION_NOT_FOUND);
+                    // when & then
+                    assertThatThrownBy(() -> exerciseLocationCommandService.updateExerciseLocation(NON_EXISTENT_LOCATION_ID, request))
+                            .isInstanceOf(CustomException.class)
+                            .hasFieldOrPropertyWithValue("errorCode", ErrorCode.EXERCISE_LOCATION_NOT_FOUND);
+                }
             }
         }
 
-        @Test
-        @DisplayName("자신이 소유한 운동장소가 아니면 CustomException(AUTHORIZATION_DENIED)을 던진다")
-        void it_throws_authorization_denied_exception_when_not_owner() {
-            // given
-            final UUID MEMBER_ID = UUID.randomUUID();
-            final UUID OTHER_MEMBER_ID = UUID.randomUUID();
-            final Long LOCATION_ID = 1L;
-            Member member = createMember(MEMBER_ID, "testUser");
-            Member otherMember = createMember(OTHER_MEMBER_ID, "otherUser");
-            ExerciseLocation locationOfOtherMember = createExerciseLocation(LOCATION_ID, otherMember, "다른 사람의 헬스장");
+        @Nested
+        @DisplayName("자신이 소유한 운동장소가 아니면")
+        class Context_with_other_member_location {
 
-            try (MockedStatic<UserContextHolder> mockedUserContext = mockStatic(UserContextHolder.class)) {
-                mockedUserContext.when(UserContextHolder::getUserId).thenReturn(MEMBER_ID);
-                when(memberRepository.findById(MEMBER_ID)).thenReturn(Optional.of(member));
-                when(exerciseLocationRepository.findByExerciseLocationIdAndExerciseLocationDeletedAtNull(LOCATION_ID))
-                        .thenReturn(Optional.of(locationOfOtherMember));
+            @Test
+            @DisplayName("CustomException(AUTHORIZATION_DENIED)을 던진다")
+            void it_throws_authorization_denied_exception() {
+                // given
+                final UUID MEMBER_ID = UUID.randomUUID();
+                final UUID OTHER_MEMBER_ID = UUID.randomUUID();
+                final Long LOCATION_ID = 1L;
+                Member member = createMember(MEMBER_ID, "testUser");
+                Member otherMember = createMember(OTHER_MEMBER_ID, "otherUser");
+                ExerciseLocation locationOfOtherMember = createExerciseLocation(LOCATION_ID, otherMember, "다른 사람의 헬스장");
 
-                UpdateExerciseLocationRequest request = updateRequest("새 이름");
+                try (MockedStatic<UserContextHolder> mockedUserContext = mockStatic(UserContextHolder.class)) {
+                    mockedUserContext.when(UserContextHolder::getUserId).thenReturn(MEMBER_ID);
+                    when(memberRepository.findById(MEMBER_ID)).thenReturn(Optional.of(member));
+                    when(exerciseLocationRepository.findByExerciseLocationIdAndExerciseLocationDeletedAtNull(LOCATION_ID))
+                            .thenReturn(Optional.of(locationOfOtherMember));
 
-                // when & then
-                assertThatThrownBy(() -> exerciseLocationCommandService.updateExerciseLocation(LOCATION_ID, request))
-                        .isInstanceOf(CustomException.class)
-                        .hasFieldOrPropertyWithValue("errorCode", ErrorCode.AUTHORIZATION_DENIED);
+                    UpdateExerciseLocationRequest request = updateRequest("새 이름");
+
+                    // when & then
+                    assertThatThrownBy(() -> exerciseLocationCommandService.updateExerciseLocation(LOCATION_ID, request))
+                            .isInstanceOf(CustomException.class)
+                            .hasFieldOrPropertyWithValue("errorCode", ErrorCode.AUTHORIZATION_DENIED);
+                }
             }
         }
 
-        @Test
-        @DisplayName("수정하려는 이름이 이미 존재하면 CustomException(NAME_DUPLICATED)을 던진다")
-        void it_throws_name_duplicated_exception_when_new_name_already_exists() {
-            // given
-            final UUID MEMBER_ID = UUID.randomUUID();
-            final Long LOCATION_ID = 1L;
-            final String OLD_NAME = "기존 헬스장";
-            final String DUPLICATE_NAME = "이미 있는 헬스장";
-            Member member = createMember(MEMBER_ID, "testUser");
-            ExerciseLocation location = createExerciseLocation(LOCATION_ID, member, OLD_NAME);
+        @Nested
+        @DisplayName("수정하려는 이름이 이미 존재하면")
+        class Context_with_duplicate_new_name {
 
-            try (MockedStatic<UserContextHolder> mockedUserContext = mockStatic(UserContextHolder.class)) {
-                mockedUserContext.when(UserContextHolder::getUserId).thenReturn(MEMBER_ID);
-                when(memberRepository.findById(MEMBER_ID)).thenReturn(Optional.of(member));
-                when(exerciseLocationRepository.findByExerciseLocationIdAndExerciseLocationDeletedAtNull(LOCATION_ID))
-                        .thenReturn(Optional.of(location));
-                when(exerciseLocationRepository.existsByMemberAndExerciseLocationNameAndExerciseLocationDeletedAtNull(member, DUPLICATE_NAME))
-                        .thenReturn(true);
+            @Test
+            @DisplayName("CustomException(NAME_DUPLICATED)을 던진다")
+            void it_throws_name_duplicated_exception() {
+                // given
+                final UUID MEMBER_ID = UUID.randomUUID();
+                final Long LOCATION_ID = 1L;
+                final String OLD_NAME = "기존 헬스장";
+                final String DUPLICATE_NAME = "이미 있는 헬스장";
+                Member member = createMember(MEMBER_ID, "testUser");
+                ExerciseLocation location = createExerciseLocation(LOCATION_ID, member, OLD_NAME);
 
-                UpdateExerciseLocationRequest request = updateRequest(DUPLICATE_NAME);
+                try (MockedStatic<UserContextHolder> mockedUserContext = mockStatic(UserContextHolder.class)) {
+                    mockedUserContext.when(UserContextHolder::getUserId).thenReturn(MEMBER_ID);
+                    when(memberRepository.findById(MEMBER_ID)).thenReturn(Optional.of(member));
+                    when(exerciseLocationRepository.findByExerciseLocationIdAndExerciseLocationDeletedAtNull(LOCATION_ID))
+                            .thenReturn(Optional.of(location));
+                    when(exerciseLocationRepository.existsByMemberAndExerciseLocationNameAndExerciseLocationDeletedAtNull(member, DUPLICATE_NAME))
+                            .thenReturn(true);
 
-                // when & then
-                assertThatThrownBy(() -> exerciseLocationCommandService.updateExerciseLocation(LOCATION_ID, request))
-                        .isInstanceOf(CustomException.class)
-                        .hasFieldOrPropertyWithValue("errorCode", ErrorCode.EXERCISE_LOCATION_NAME_DUPLICATED);
+                    UpdateExerciseLocationRequest request = updateRequest(DUPLICATE_NAME);
+
+                    // when & then
+                    assertThatThrownBy(() -> exerciseLocationCommandService.updateExerciseLocation(LOCATION_ID, request))
+                            .isInstanceOf(CustomException.class)
+                            .hasFieldOrPropertyWithValue("errorCode", ErrorCode.EXERCISE_LOCATION_NAME_DUPLICATED);
+                }
             }
         }
     }
@@ -335,71 +372,88 @@ class ExerciseLocationCommandServiceImplTest {
     @DisplayName("deleteExerciseLocation 메소드는")
     class Describe_deleteExerciseLocation {
 
-        @Test
-        @DisplayName("자신이 소유한 운동장소를 성공적으로 삭제 처리한다")
-        void it_soft_deletes_the_exercise_location() {
-            // given
-            final UUID MEMBER_ID = UUID.randomUUID();
-            final Long LOCATION_ID = 1L;
-            Member member = createMember(MEMBER_ID, "testUser");
-            ExerciseLocation location = createExerciseLocation(LOCATION_ID, member, "삭제할 헬스장");
+        @Nested
+        @DisplayName("존재하는 본인의 운동장소 ID가 주어지면")
+        class Context_with_valid_id {
 
-            try (MockedStatic<UserContextHolder> mockedUserContext = mockStatic(UserContextHolder.class)) {
-                mockedUserContext.when(UserContextHolder::getUserId).thenReturn(MEMBER_ID);
-                when(memberRepository.findById(MEMBER_ID)).thenReturn(Optional.of(member));
-                when(exerciseLocationRepository.findByExerciseLocationIdAndExerciseLocationDeletedAtNull(LOCATION_ID))
-                        .thenReturn(Optional.of(location));
+            @Test
+            @DisplayName("해당 운동장소를 성공적으로 삭제 처리한다")
+            void it_soft_deletes_the_exercise_location() {
+                // given
+                final UUID MEMBER_ID = UUID.randomUUID();
+                final Long LOCATION_ID = 1L;
+                Member member = createMember(MEMBER_ID, "testUser");
+                ExerciseLocation location = createExerciseLocation(LOCATION_ID, member, "삭제할 헬스장");
 
-                // when
-                exerciseLocationCommandService.deleteExerciseLocation(LOCATION_ID);
+                try (MockedStatic<UserContextHolder> mockedUserContext = mockStatic(UserContextHolder.class)) {
+                    mockedUserContext.when(UserContextHolder::getUserId).thenReturn(MEMBER_ID);
+                    when(memberRepository.findById(MEMBER_ID)).thenReturn(Optional.of(member));
+                    when(exerciseLocationRepository.findByExerciseLocationIdAndExerciseLocationDeletedAtNull(LOCATION_ID))
+                            .thenReturn(Optional.of(location));
 
-                // then
-                verify(exerciseLocationRepository, times(1)).findByExerciseLocationIdAndExerciseLocationDeletedAtNull(LOCATION_ID);
+                    // when
+                    exerciseLocationCommandService.deleteExerciseLocation(LOCATION_ID);
+
+                    // then
+                    verify(exerciseLocationRepository, times(1)).findByExerciseLocationIdAndExerciseLocationDeletedAtNull(LOCATION_ID);
+                    // 실제 엔티티의 삭제 메서드가 호출되었는지 확인하려면 spy 등을 쓸 수 있으나,
+                    // 여기서는 repository 호출 여부와 에러가 발생하지 않음을 확인
+                }
             }
         }
 
-        @Test
-        @DisplayName("삭제할 운동장소가 존재하지 않으면 CustomException(NOT_FOUND)을 던진다")
-        void it_throws_not_found_exception_when_location_does_not_exist() {
-            // given
-            final UUID MEMBER_ID = UUID.randomUUID();
-            final Long NON_EXISTENT_LOCATION_ID = 999L;
-            Member member = createMember(MEMBER_ID, "testUser");
+        @Nested
+        @DisplayName("삭제할 운동장소가 존재하지 않으면")
+        class Context_with_non_existent_location {
 
-            try (MockedStatic<UserContextHolder> mockedUserContext = mockStatic(UserContextHolder.class)) {
-                mockedUserContext.when(UserContextHolder::getUserId).thenReturn(MEMBER_ID);
-                when(memberRepository.findById(MEMBER_ID)).thenReturn(Optional.of(member));
-                when(exerciseLocationRepository.findByExerciseLocationIdAndExerciseLocationDeletedAtNull(NON_EXISTENT_LOCATION_ID))
-                        .thenReturn(Optional.empty());
+            @Test
+            @DisplayName("CustomException(NOT_FOUND)을 던진다")
+            void it_throws_not_found_exception() {
+                // given
+                final UUID MEMBER_ID = UUID.randomUUID();
+                final Long NON_EXISTENT_LOCATION_ID = 999L;
+                Member member = createMember(MEMBER_ID, "testUser");
 
-                // when & then
-                assertThatThrownBy(() -> exerciseLocationCommandService.deleteExerciseLocation(NON_EXISTENT_LOCATION_ID))
-                        .isInstanceOf(CustomException.class)
-                        .hasFieldOrPropertyWithValue("errorCode", ErrorCode.EXERCISE_LOCATION_NOT_FOUND);
+                try (MockedStatic<UserContextHolder> mockedUserContext = mockStatic(UserContextHolder.class)) {
+                    mockedUserContext.when(UserContextHolder::getUserId).thenReturn(MEMBER_ID);
+                    when(memberRepository.findById(MEMBER_ID)).thenReturn(Optional.of(member));
+                    when(exerciseLocationRepository.findByExerciseLocationIdAndExerciseLocationDeletedAtNull(NON_EXISTENT_LOCATION_ID))
+                            .thenReturn(Optional.empty());
+
+                    // when & then
+                    assertThatThrownBy(() -> exerciseLocationCommandService.deleteExerciseLocation(NON_EXISTENT_LOCATION_ID))
+                            .isInstanceOf(CustomException.class)
+                            .hasFieldOrPropertyWithValue("errorCode", ErrorCode.EXERCISE_LOCATION_NOT_FOUND);
+                }
             }
         }
 
-        @Test
-        @DisplayName("자신이 소유한 운동장소가 아니면 CustomException(AUTHORIZATION_DENIED)을 던진다")
-        void it_throws_authorization_denied_exception_when_not_owner() {
-            // given
-            final UUID MEMBER_ID = UUID.randomUUID();
-            final UUID OTHER_MEMBER_ID = UUID.randomUUID();
-            final Long LOCATION_ID = 1L;
-            Member member = createMember(MEMBER_ID, "testUser");
-            Member otherMember = createMember(OTHER_MEMBER_ID, "otherUser");
-            ExerciseLocation locationOfOtherMember = createExerciseLocation(LOCATION_ID, otherMember, "다른 사람의 헬스장");
+        @Nested
+        @DisplayName("자신이 소유한 운동장소가 아니면")
+        class Context_with_other_member_location {
 
-            try (MockedStatic<UserContextHolder> mockedUserContext = mockStatic(UserContextHolder.class)) {
-                mockedUserContext.when(UserContextHolder::getUserId).thenReturn(MEMBER_ID);
-                when(memberRepository.findById(MEMBER_ID)).thenReturn(Optional.of(member));
-                when(exerciseLocationRepository.findByExerciseLocationIdAndExerciseLocationDeletedAtNull(LOCATION_ID))
-                        .thenReturn(Optional.of(locationOfOtherMember));
+            @Test
+            @DisplayName("CustomException(AUTHORIZATION_DENIED)을 던진다")
+            void it_throws_authorization_denied_exception() {
+                // given
+                final UUID MEMBER_ID = UUID.randomUUID();
+                final UUID OTHER_MEMBER_ID = UUID.randomUUID();
+                final Long LOCATION_ID = 1L;
+                Member member = createMember(MEMBER_ID, "testUser");
+                Member otherMember = createMember(OTHER_MEMBER_ID, "otherUser");
+                ExerciseLocation locationOfOtherMember = createExerciseLocation(LOCATION_ID, otherMember, "다른 사람의 헬스장");
 
-                // when & then
-                assertThatThrownBy(() -> exerciseLocationCommandService.deleteExerciseLocation(LOCATION_ID))
-                        .isInstanceOf(CustomException.class)
-                        .hasFieldOrPropertyWithValue("errorCode", ErrorCode.AUTHORIZATION_DENIED);
+                try (MockedStatic<UserContextHolder> mockedUserContext = mockStatic(UserContextHolder.class)) {
+                    mockedUserContext.when(UserContextHolder::getUserId).thenReturn(MEMBER_ID);
+                    when(memberRepository.findById(MEMBER_ID)).thenReturn(Optional.of(member));
+                    when(exerciseLocationRepository.findByExerciseLocationIdAndExerciseLocationDeletedAtNull(LOCATION_ID))
+                            .thenReturn(Optional.of(locationOfOtherMember));
+
+                    // when & then
+                    assertThatThrownBy(() -> exerciseLocationCommandService.deleteExerciseLocation(LOCATION_ID))
+                            .isInstanceOf(CustomException.class)
+                            .hasFieldOrPropertyWithValue("errorCode", ErrorCode.AUTHORIZATION_DENIED);
+                }
             }
         }
     }

--- a/src/test/java/com/project200/undabang/member/service/impl/MemberBlockCommandServiceImplTest.java
+++ b/src/test/java/com/project200/undabang/member/service/impl/MemberBlockCommandServiceImplTest.java
@@ -3,6 +3,7 @@ package com.project200.undabang.member.service.impl;
 import com.project200.undabang.common.context.UserContextHolder;
 import com.project200.undabang.common.web.exception.CustomException;
 import com.project200.undabang.common.web.exception.ErrorCode;
+import com.project200.undabang.member.dto.event.MemberBlockedEvent;
 import com.project200.undabang.member.dto.response.CreateMemberBlockResponse;
 import com.project200.undabang.member.entity.Member;
 import com.project200.undabang.member.entity.MemberBlock;
@@ -16,6 +17,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockedStatic;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationEventPublisher;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -23,7 +25,7 @@ import java.util.Optional;
 import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 
@@ -38,6 +40,9 @@ class MemberBlockCommandServiceImplTest {
 
     @Mock
     private MemberRepository memberRepository;
+
+    @Mock
+    private ApplicationEventPublisher eventPublisher;
 
     private Member createMember(UUID id, String nickname) {
         return Member.builder()
@@ -59,180 +64,212 @@ class MemberBlockCommandServiceImplTest {
     }
 
     @Nested
-    @DisplayName("CreateMemberBlock 메소드는")
-    class Describe_CreateMemberBlock {
+    @DisplayName("createMemberBlock 메소드는")
+    class Describe_createMemberBlock {
 
-        private final UUID MEMBER_ID = UUID.randomUUID();
-        private final UUID BLOCKED_MEMBER_ID = UUID.randomUUID();
+        @Nested
+        @DisplayName("유효한 차단 요청이 주어지고, 기존 차단 이력이 없다면")
+        class Context_with_valid_new_block_request {
 
-        @Test
-        @DisplayName("성공적으로 새로운 차단을 생성한다")
-        void it_creates_a_new_block_successfully() {
-            // given
-            Member blocker = createMember(MEMBER_ID, "차단하는사람");
-            Member blocked = createMember(BLOCKED_MEMBER_ID, "차단당하는사람");
+            @Test
+            @DisplayName("새로운 차단 정보를 저장하고 이벤트를 발행한다")
+            void it_creates_new_block_and_publishes_event() {
+                // given
+                final UUID MEMBER_ID = UUID.randomUUID();
+                final UUID BLOCKED_MEMBER_ID = UUID.randomUUID();
+                Member blocker = createMember(MEMBER_ID, "차단하는사람");
+                Member blocked = createMember(BLOCKED_MEMBER_ID, "차단당하는사람");
 
-            MemberBlock savedBlockMock = mock(MemberBlock.class);
-            when(savedBlockMock.getId()).thenReturn(1L);
+                MemberBlock savedBlockMock = mock(MemberBlock.class);
+                when(savedBlockMock.getId()).thenReturn(1L);
 
-            when(memberRepository.findById(MEMBER_ID)).thenReturn(Optional.of(blocker));
-            when(memberRepository.findById(BLOCKED_MEMBER_ID)).thenReturn(Optional.of(blocked));
-            when(memberBlockRepository.findByBlockerAndBlocked(blocker, blocked)).thenReturn(Optional.empty());
-            when(memberBlockRepository.save(any(MemberBlock.class))).thenReturn(savedBlockMock);
+                try (MockedStatic<UserContextHolder> mocked = mockStatic(UserContextHolder.class)) {
+                    mocked.when(UserContextHolder::getUserId).thenReturn(MEMBER_ID);
+                    when(memberRepository.findById(MEMBER_ID)).thenReturn(Optional.of(blocker));
+                    when(memberRepository.findById(BLOCKED_MEMBER_ID)).thenReturn(Optional.of(blocked));
+                    when(memberBlockRepository.findByBlockerAndBlocked(blocker, blocked)).thenReturn(Optional.empty());
+                    when(memberBlockRepository.save(any(MemberBlock.class))).thenReturn(savedBlockMock);
 
-            // when
-            CreateMemberBlockResponse response;
-            try (MockedStatic<UserContextHolder> mocked = mockStatic(UserContextHolder.class)) {
-                mocked.when(UserContextHolder::getUserId).thenReturn(MEMBER_ID);
-                response = memberBlockCommandService.createMemberBlock(BLOCKED_MEMBER_ID);
-            }
+                    // when
+                    CreateMemberBlockResponse response = memberBlockCommandService.createMemberBlock(BLOCKED_MEMBER_ID);
 
-            // then
-            assertThat(response).isNotNull();
-            assertThat(response.getMemberBlockId()).isEqualTo(1L);
-            verify(memberBlockRepository, times(1)).save(any(MemberBlock.class));
-        }
+                    // then
+                    assertThat(response).isNotNull();
+                    assertThat(response.getMemberBlockId()).isEqualTo(1L);
 
-        @Test
-        @DisplayName("이미 차단된 사용자를 다시 차단하려고 하면 예외를 발생시킨다")
-        void it_throws_exception_when_blocking_an_already_blocked_member() {
-            // given
-            Member blocker = createMember(MEMBER_ID, "차단하는사람");
-            Member blocked = createMember(BLOCKED_MEMBER_ID, "차단당하는사람");
-
-            MemberBlock existingBlock = MemberBlock.of(blocker, blocked);
-
-            when(memberRepository.findById(MEMBER_ID)).thenReturn(Optional.of(blocker));
-            when(memberRepository.findById(BLOCKED_MEMBER_ID)).thenReturn(Optional.of(blocked));
-            when(memberBlockRepository.findByBlockerAndBlocked(blocker, blocked)).thenReturn(Optional.of(existingBlock));
-
-            // when & then
-            try (MockedStatic<UserContextHolder> mocked = mockStatic(UserContextHolder.class)) {
-                mocked.when(UserContextHolder::getUserId).thenReturn(MEMBER_ID);
-
-                CustomException exception = assertThrows(CustomException.class, () ->
-                        memberBlockCommandService.createMemberBlock(BLOCKED_MEMBER_ID)
-                );
-
-                assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.MEMBER_BLOCK_DUPLICATED);
+                    verify(memberBlockRepository, times(1)).save(any(MemberBlock.class));
+                    verify(eventPublisher, times(1)).publishEvent(any(MemberBlockedEvent.class));
+                }
             }
         }
 
-        @Test
-        @DisplayName("차단 해제했던 사용자를 다시 차단한다 (재차단)")
-        void it_reblocks_a_previously_unblocked_member() {
-            // given
-            long memberBlockId = 1L;
-            Member blocker = createMember(MEMBER_ID, "차단하는사람");
-            Member blocked = createMember(BLOCKED_MEMBER_ID, "차단당하는사람");
+        @Nested
+        @DisplayName("과거에 차단했다가 해제한 이력이 있다면 (재차단)")
+        class Context_with_history_of_unblock {
 
-            MemberBlock existingBlock = createSoftDeleteMemberBlock(memberBlockId, blocker, blocked);
+            @Test
+            @DisplayName("기존 차단 정보를 다시 활성화하고 이벤트를 발행한다")
+            void it_reactivates_existing_block_and_publishes_event() {
+                // given
+                final UUID MEMBER_ID = UUID.randomUUID();
+                final UUID BLOCKED_MEMBER_ID = UUID.randomUUID();
+                Member blocker = createMember(MEMBER_ID, "차단하는사람");
+                Member blocked = createMember(BLOCKED_MEMBER_ID, "차단당하는사람");
+                MemberBlock existingBlock = createSoftDeleteMemberBlock(1L, blocker, blocked);
 
-            when(memberRepository.findById(MEMBER_ID)).thenReturn(Optional.of(blocker));
-            when(memberRepository.findById(BLOCKED_MEMBER_ID)).thenReturn(Optional.of(blocked));
-            when(memberBlockRepository.findByBlockerAndBlocked(blocker, blocked)).thenReturn(Optional.of(existingBlock));
+                try (MockedStatic<UserContextHolder> mocked = mockStatic(UserContextHolder.class)) {
+                    mocked.when(UserContextHolder::getUserId).thenReturn(MEMBER_ID);
+                    when(memberRepository.findById(MEMBER_ID)).thenReturn(Optional.of(blocker));
+                    when(memberRepository.findById(BLOCKED_MEMBER_ID)).thenReturn(Optional.of(blocked));
+                    when(memberBlockRepository.findByBlockerAndBlocked(blocker, blocked)).thenReturn(Optional.of(existingBlock));
 
-            // when
-            CreateMemberBlockResponse response;
-            try (MockedStatic<UserContextHolder> mocked = mockStatic(UserContextHolder.class)) {
-                mocked.when(UserContextHolder::getUserId).thenReturn(MEMBER_ID);
-                response = memberBlockCommandService.createMemberBlock(BLOCKED_MEMBER_ID);
-            }
+                    // when
+                    CreateMemberBlockResponse response = memberBlockCommandService.createMemberBlock(BLOCKED_MEMBER_ID);
 
-            // then
-            assertThat(response).isNotNull();
-            assertThat(existingBlock.getMemberBlockDeletedAt()).isNull(); // reBlock() 호출로 상태가 변경되었는지 검증
-        }
+                    // then
+                    assertThat(response).isNotNull();
+                    assertThat(existingBlock.getMemberBlockDeletedAt()).isNull(); // reBlock() 확인
 
-        @Test
-        @DisplayName("자기 자신을 차단하려고 하면 예외를 발생시킨다")
-        void it_throws_exception_when_blocking_oneself() {
-            // given
-            UUID SAME_ID = UUID.randomUUID();
-
-            // when & then
-            try (MockedStatic<UserContextHolder> mocked = mockStatic(UserContextHolder.class)) {
-                mocked.when(UserContextHolder::getUserId).thenReturn(SAME_ID);
-
-                CustomException exception = assertThrows(CustomException.class, () ->
-                        memberBlockCommandService.createMemberBlock(SAME_ID)
-                );
-
-                assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.MEMBER_SELF_REQUEST_NOT_ALLOWED);
+                    verify(memberBlockRepository, never()).save(any(MemberBlock.class)); // save가 아닌 update(dirty checking)
+                    verify(eventPublisher, times(1)).publishEvent(any(MemberBlockedEvent.class));
+                }
             }
         }
 
-        @Test
-        @DisplayName("차단하려는 대상 회원이 존재하지 않으면 예외를 발생시킨다")
-        void it_throws_exception_when_blocked_member_not_found() {
-            // given
-            Member blocker = createMember(MEMBER_ID, "차단하는사람");
-            when(memberRepository.findById(MEMBER_ID)).thenReturn(Optional.of(blocker));
-            when(memberRepository.findById(BLOCKED_MEMBER_ID)).thenReturn(Optional.empty());
+        @Nested
+        @DisplayName("이미 차단된 상태라면")
+        class Context_already_blocked {
 
-            // when & then
-            try (MockedStatic<UserContextHolder> mocked = mockStatic(UserContextHolder.class)) {
-                mocked.when(UserContextHolder::getUserId).thenReturn(MEMBER_ID);
+            @Test
+            @DisplayName("CustomException(MEMBER_BLOCK_DUPLICATED)을 던진다")
+            void it_throws_duplicate_exception() {
+                // given
+                final UUID MEMBER_ID = UUID.randomUUID();
+                final UUID BLOCKED_MEMBER_ID = UUID.randomUUID();
+                Member blocker = createMember(MEMBER_ID, "차단하는사람");
+                Member blocked = createMember(BLOCKED_MEMBER_ID, "차단당하는사람");
+                MemberBlock existingBlock = MemberBlock.of(blocker, blocked);
 
-                CustomException exception = assertThrows(CustomException.class, () ->
-                        memberBlockCommandService.createMemberBlock(BLOCKED_MEMBER_ID)
-                );
+                try (MockedStatic<UserContextHolder> mocked = mockStatic(UserContextHolder.class)) {
+                    mocked.when(UserContextHolder::getUserId).thenReturn(MEMBER_ID);
+                    when(memberRepository.findById(MEMBER_ID)).thenReturn(Optional.of(blocker));
+                    when(memberRepository.findById(BLOCKED_MEMBER_ID)).thenReturn(Optional.of(blocked));
+                    when(memberBlockRepository.findByBlockerAndBlocked(blocker, blocked)).thenReturn(Optional.of(existingBlock));
 
-                assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.MEMBER_NOT_FOUND);
+                    // when & then
+                    assertThatThrownBy(() -> memberBlockCommandService.createMemberBlock(BLOCKED_MEMBER_ID))
+                            .isInstanceOf(CustomException.class)
+                            .hasFieldOrPropertyWithValue("errorCode", ErrorCode.MEMBER_BLOCK_DUPLICATED);
+                }
+            }
+        }
+
+        @Nested
+        @DisplayName("자기 자신을 차단하려고 하면")
+        class Context_self_blocking {
+
+            @Test
+            @DisplayName("CustomException(SELF_REQUEST_NOT_ALLOWED)을 던진다")
+            void it_throws_self_request_exception() {
+                // given
+                final UUID MEMBER_ID = UUID.randomUUID();
+
+                try (MockedStatic<UserContextHolder> mocked = mockStatic(UserContextHolder.class)) {
+                    mocked.when(UserContextHolder::getUserId).thenReturn(MEMBER_ID);
+
+                    // when & then
+                    assertThatThrownBy(() -> memberBlockCommandService.createMemberBlock(MEMBER_ID))
+                            .isInstanceOf(CustomException.class)
+                            .hasFieldOrPropertyWithValue("errorCode", ErrorCode.MEMBER_SELF_REQUEST_NOT_ALLOWED);
+                }
+            }
+        }
+
+        @Nested
+        @DisplayName("차단할 회원이 존재하지 않으면")
+        class Context_target_not_found {
+
+            @Test
+            @DisplayName("CustomException(MEMBER_NOT_FOUND)을 던진다")
+            void it_throws_member_not_found_exception() {
+                // given
+                final UUID MEMBER_ID = UUID.randomUUID();
+                final UUID BLOCKED_MEMBER_ID = UUID.randomUUID();
+                Member blocker = createMember(MEMBER_ID, "차단하는사람");
+
+                try (MockedStatic<UserContextHolder> mocked = mockStatic(UserContextHolder.class)) {
+                    mocked.when(UserContextHolder::getUserId).thenReturn(MEMBER_ID);
+                    when(memberRepository.findById(MEMBER_ID)).thenReturn(Optional.of(blocker));
+                    when(memberRepository.findById(BLOCKED_MEMBER_ID)).thenReturn(Optional.empty());
+
+                    // when & then
+                    assertThatThrownBy(() -> memberBlockCommandService.createMemberBlock(BLOCKED_MEMBER_ID))
+                            .isInstanceOf(CustomException.class)
+                            .hasFieldOrPropertyWithValue("errorCode", ErrorCode.MEMBER_NOT_FOUND);
+                }
             }
         }
     }
 
     @Nested
-    @DisplayName("deleteMemberBlock 메소드는")
-    class Describe_deleteMemberBlock {
-        private final UUID MEMBER_ID = UUID.randomUUID();
-        private final UUID BLOCKED_MEMBER_ID = UUID.randomUUID();
+    @DisplayName("unBlockMember 메소드는")
+    class Describe_unBlockMember {
 
-        @Test
-        @DisplayName("유효한 차단 기록을 성공적으로 해제한다")
-        void it_unblocks_a_member_successfully() {
-            // given
-            Member blocker = createMember(MEMBER_ID, "차단하는사람");
-            Member blocked = createMember(BLOCKED_MEMBER_ID, "차단당하는사람");
-            MemberBlock existingBlock = MemberBlock.of(blocker, blocked);
+        @Nested
+        @DisplayName("존재하는 차단 이력에 대해 해제 요청을 하면")
+        class Context_with_existing_block {
 
-            when(memberRepository.findById(MEMBER_ID)).thenReturn(Optional.of(blocker));
-            when(memberRepository.findById(BLOCKED_MEMBER_ID)).thenReturn(Optional.of(blocked));
-            when(memberBlockRepository.findByBlockerAndBlockedAndMemberBlockDeletedAtNull(blocker, blocked))
-                    .thenReturn(Optional.of(existingBlock));
+            @Test
+            @DisplayName("성공적으로 차단을 해제(Soft Delete)한다")
+            void it_unblocks_member_successfully() {
+                // given
+                final UUID MEMBER_ID = UUID.randomUUID();
+                final UUID BLOCKED_MEMBER_ID = UUID.randomUUID();
+                Member blocker = createMember(MEMBER_ID, "차단하는사람");
+                Member blocked = createMember(BLOCKED_MEMBER_ID, "차단당하는사람");
+                MemberBlock existingBlock = MemberBlock.of(blocker, blocked);
 
-            // when
-            try (MockedStatic<UserContextHolder> mocked = mockStatic(UserContextHolder.class)) {
-                mocked.when(UserContextHolder::getUserId).thenReturn(MEMBER_ID);
-                memberBlockCommandService.unBlockMember(BLOCKED_MEMBER_ID);
+                try (MockedStatic<UserContextHolder> mocked = mockStatic(UserContextHolder.class)) {
+                    mocked.when(UserContextHolder::getUserId).thenReturn(MEMBER_ID);
+                    when(memberRepository.findById(MEMBER_ID)).thenReturn(Optional.of(blocker));
+                    when(memberRepository.findById(BLOCKED_MEMBER_ID)).thenReturn(Optional.of(blocked));
+                    when(memberBlockRepository.findByBlockerAndBlockedAndMemberBlockDeletedAtNull(blocker, blocked))
+                            .thenReturn(Optional.of(existingBlock));
+
+                    // when
+                    memberBlockCommandService.unBlockMember(BLOCKED_MEMBER_ID);
+
+                    // then
+                    assertThat(existingBlock.getMemberBlockDeletedAt()).isNotNull();
+                }
             }
-
-            // then
-            assertThat(existingBlock.getMemberBlockDeletedAt()).isNotNull();
         }
 
-        @Test
-        @DisplayName("차단 기록이 존재하지 않을 때 해제하려고 하면 예외를 발생시킨다")
-        void it_throws_exception_when_block_not_found() {
-            // given
-            Member blocker = createMember(MEMBER_ID, "차단하는사람");
-            Member blocked = createMember(BLOCKED_MEMBER_ID, "차단당하는사람");
+        @Nested
+        @DisplayName("차단 이력이 존재하지 않는데 해제하려 하면")
+        class Context_with_no_block_history {
 
-            when(memberRepository.findById(MEMBER_ID)).thenReturn(Optional.of(blocker));
-            when(memberRepository.findById(BLOCKED_MEMBER_ID)).thenReturn(Optional.of(blocked));
-            when(memberBlockRepository.findByBlockerAndBlockedAndMemberBlockDeletedAtNull(blocker, blocked))
-                    .thenReturn(Optional.empty());
+            @Test
+            @DisplayName("CustomException(MEMBER_BLOCK_NOT_FOUND)를 던진다")
+            void it_throws_block_not_found_exception() {
+                // given
+                final UUID MEMBER_ID = UUID.randomUUID();
+                final UUID BLOCKED_MEMBER_ID = UUID.randomUUID();
+                Member blocker = createMember(MEMBER_ID, "차단하는사람");
+                Member blocked = createMember(BLOCKED_MEMBER_ID, "차단당하는사람");
 
-            // when & then
-            try (MockedStatic<UserContextHolder> mocked = mockStatic(UserContextHolder.class)) {
-                mocked.when(UserContextHolder::getUserId).thenReturn(MEMBER_ID);
+                try (MockedStatic<UserContextHolder> mocked = mockStatic(UserContextHolder.class)) {
+                    mocked.when(UserContextHolder::getUserId).thenReturn(MEMBER_ID);
+                    when(memberRepository.findById(MEMBER_ID)).thenReturn(Optional.of(blocker));
+                    when(memberRepository.findById(BLOCKED_MEMBER_ID)).thenReturn(Optional.of(blocked));
+                    when(memberBlockRepository.findByBlockerAndBlockedAndMemberBlockDeletedAtNull(blocker, blocked))
+                            .thenReturn(Optional.empty());
 
-                CustomException exception = assertThrows(CustomException.class, () ->
-                        memberBlockCommandService.unBlockMember(BLOCKED_MEMBER_ID)
-                );
-
-                assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.MEMBER_BLOCK_NOT_FOUND);
+                    // when & then
+                    assertThatThrownBy(() -> memberBlockCommandService.unBlockMember(BLOCKED_MEMBER_ID))
+                            .isInstanceOf(CustomException.class)
+                            .hasFieldOrPropertyWithValue("errorCode", ErrorCode.MEMBER_BLOCK_NOT_FOUND);
+                }
             }
         }
     }


### PR DESCRIPTION
## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

기존 개발한 웹소켓 기능과, 채팅방 나가기, 다른 회원 차단 기능을 이벤트 퍼블리셔를 활용하여 실시간으로 차단 당하거나 상대방이 나간경우 채팅방에 웹소켓 response로 공지하는 기능을 구현하였습니다.

또한 구현하면서 MemberBlockServiceImpl.java 의 코드를 리팩토링 하였습니다. 
해당 리팩토링을 통해 검증과 차단 저장을 헬퍼메소드로 공통화 하였습니다.


### 스크린샷 (선택)
**API 응답 사진:** (API 응답 스크린샷을 첨부해주세요.)
<img width="726" height="163" alt="image" src="https://github.com/user-attachments/assets/07c5fb3b-83a4-476c-9e47-62dcf617a645" />

**테스트 커버리지 사진:** (테스트 커버리지 스크린샷을 첨부해주세요.)
<img width="790" height="172" alt="image" src="https://github.com/user-attachments/assets/580f419b-3172-4d20-9359-a2538a29759e" />
<img width="801" height="378" alt="image" src="https://github.com/user-attachments/assets/5970a0f6-f8fa-4c45-86aa-396457e3492d" />

Closes #490
