### PR TITLE
[Fix] 자신이 보유한 운동장소 조회시 위도와 경도 값 매핑 오류 수정

### DIFF
--- a/src/main/java/com/project200/undabang/member/dto/response/GetExerciseLocationsResponse.java
+++ b/src/main/java/com/project200/undabang/member/dto/response/GetExerciseLocationsResponse.java
@@ -45,10 +45,8 @@ public class GetExerciseLocationsResponse {
                 .id(exerciseLocation.getExerciseLocationId())
                 .name(exerciseLocation.getExerciseLocationName())
                 .address(exerciseLocation.getExerciseLocationAddress())
-                // Point 의 X 좌표는 경도와 매핑됨
-                .latitude(exerciseLocation.getExerciseLocationPoint().getX())
-                // Point 의 Y 좌표는 위도와 매핑됨
-                .longitude(exerciseLocation.getExerciseLocationPoint().getY())
+                .latitude(exerciseLocation.getExerciseLocationPoint().getY())
+                .longitude(exerciseLocation.getExerciseLocationPoint().getX())
                 .build();
     }
 }

--- a/src/main/java/com/project200/undabang/member/service/impl/ExerciseLocationQueryServiceImpl.java
+++ b/src/main/java/com/project200/undabang/member/service/impl/ExerciseLocationQueryServiceImpl.java
@@ -56,8 +56,7 @@ public class ExerciseLocationQueryServiceImpl implements ExerciseLocationQuerySe
     public List<GetExerciseLocationsResponse> getExerciseLocations() {
         Member member = getMember(UserContextHolder.getUserId());
 
-        List<ExerciseLocation> exerciseLocationList = exerciseLocationRepository
-                .findAllByMemberAndExerciseLocationDeletedAtNull(member);
+        List<ExerciseLocation> exerciseLocationList = exerciseLocationRepository.findAllByMemberAndExerciseLocationDeletedAtNull(member);
 
         return exerciseLocationList.stream()
                 .map(GetExerciseLocationsResponse::from)

--- a/src/test/java/com/project200/undabang/member/service/impl/ExerciseLocationQueryServiceImplTest.java
+++ b/src/test/java/com/project200/undabang/member/service/impl/ExerciseLocationQueryServiceImplTest.java
@@ -76,8 +76,8 @@ class ExerciseLocationQueryServiceImplTest {
                 assertThat(results)
                         .extracting("name", "latitude", "longitude")
                         .containsExactlyInAnyOrder(
-                                tuple("헬스장 A", 127.1, 37.1),
-                                tuple("헬스장 B", 127.2, 37.2));
+                                tuple("헬스장 A", 37.1, 127.1),
+                                tuple("헬스장 B", 37.2, 127.2));
 
                 verify(memberRepository, times(1)).findById(memberId);
                 verify(exerciseLocationRepository, times(1)).findAllByMemberAndExerciseLocationDeletedAtNull(member);
@@ -198,7 +198,7 @@ class ExerciseLocationQueryServiceImplTest {
     }
 
     private ExerciseLocation createExerciseLocation(Long id, String name, double lat, double lon) {
-        Point point = geometryFactory.createPoint(new Coordinate(lat, lon));
+        Point point = geometryFactory.createPoint(new Coordinate(lon, lat));
         point.setSRID(4326);
         return ExerciseLocation.builder()
                 .exerciseLocationId(id)

--- a/src/test/java/com/project200/undabang/member/service/impl/ExerciseLocationQueryServiceImplTest.java
+++ b/src/test/java/com/project200/undabang/member/service/impl/ExerciseLocationQueryServiceImplTest.java
@@ -76,8 +76,8 @@ class ExerciseLocationQueryServiceImplTest {
                 assertThat(results)
                         .extracting("name", "latitude", "longitude")
                         .containsExactlyInAnyOrder(
-                                tuple("헬스장 A", 37.1, 127.1),
-                                tuple("헬스장 B", 37.2, 127.2));
+                                tuple("헬스장 A", 127.1, 37.1),
+                                tuple("헬스장 B", 127.2, 37.2));
 
                 verify(memberRepository, times(1)).findById(memberId);
                 verify(exerciseLocationRepository, times(1)).findAllByMemberAndExerciseLocationDeletedAtNull(member);


### PR DESCRIPTION
## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

자신이 보유한 운동장소 조회시 위도와 경도가 뒤집혀 응답값에 들어가는 오류를 수정하였습니다.

### 스크린샷 (선택)
**API 응답 사진:** (API 응답 스크린샷을 첨부해주세요.)
<img width="404" height="530" alt="image" src="https://github.com/user-attachments/assets/c9617a33-be97-4bac-be3f-4ac864b67523" />

**테스트 커버리지 사진:** (테스트 커버리지 스크린샷을 첨부해주세요.)
<img width="798" height="384" alt="image" src="https://github.com/user-attachments/assets/5a68359a-0e0b-4412-b660-c7d6a50fa43c" />

Closes #508 
