### PR TITLE
[Feat] 특정 피드 상세 조회 기능 개발 [0.11.2]

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ plugins {
 }
 
 group = 'com.project200'
-version = '0.11.1-SNAPSHOT'
+version = '0.11.2-SNAPSHOT'
 
 java {
     toolchain {

--- a/src/docs/asciidoc/feed/특정-피드-상세-조회-API.adoc
+++ b/src/docs/asciidoc/feed/특정-피드-상세-조회-API.adoc
@@ -1,0 +1,33 @@
+== 특정 피드 상세 조회 API
+
+=== 설명
+
+- #GET# `/api/v1/feeds/{feedId}`
+- 회원이 특정 피드를 상세 조회하는 API 입니다.
+
+=== 개발 이력
+
+- Sprint 23 (2026-01-28): 기능 개발이 완료되었습니다.
+
+=== 개발 참고 사항
+
+- <<공통-개발-참고-사항,공통 개발 참고 사항>>을 참고하세요.
+
+=== 코드 샘플
+
+operation::get-specific-feed/get-specific-feed_-success[snippets="curl-request,http-request,http-response"]
+
+=== 매개 변수
+
+operation::get-specific-feed/get-specific-feed_-success[snippets="request-headers,path-parameters,response-fields"]
+
+==== 응답 상태 코드
+
+|===
+|상태 코드|설명
+|200|요청이 성공적으로 처리되었습니다.
+|401|인증되지 않은 요청입니다. Access Token이 없거나 유효하지 않습니다
+|404|존재하지 않는 회원입니다. +
+존재하지 않는 피드입니다.
+|===
+

--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -248,3 +248,5 @@ include::overview/공통-개발-참고-사항.adoc[]
 === xref:피드-API.html[피드 API]
 
 - 전체 피드 목록 조회 API #GET# `/api/v1/feeds?prevFeedId={prevFeedId}`
+
+- 특정 피드 상세 조회 API #GET# `/api/v1/feeds/{feedId}`

--- a/src/docs/asciidoc/피드-API.adoc
+++ b/src/docs/asciidoc/피드-API.adoc
@@ -20,3 +20,5 @@
 include::overview/공통-개발-참고-사항.adoc[]
 
 include::feed/전체-피드-목록-조회-API.adoc[]
+
+include::feed/특정-피드-상세-조회-API.adoc[]

--- a/src/main/java/com/project200/undabang/common/web/exception/ErrorCode.java
+++ b/src/main/java/com/project200/undabang/common/web/exception/ErrorCode.java
@@ -96,7 +96,10 @@ public enum ErrorCode {
     PREFERRED_EXERCISE_MAX_COUNT_VIOLATION(409, "PREFERRED_EXERCISE_MAX_COUNT_VIOLATION", "선호 운동은 최대 5개까지만 등록할 수 있습니다."),
     PREFERRED_EXERCISE_DUPLICATED(409, "PREFERRED_EXERCISE_DUPLICATED", "이미 등록된 선호 운동 종목입니다."),
     PREFERRED_EXERCISE_NOT_FOUND(404, "PREFERRED_EXERCISE_NOT_FOUND", "존재하지 않는 운동 종류입니다."),
-    PREFERRED_EXERCISE_DUPLICATED_IN_REQUEST(400, "PREFERRED_EXERCISE_DUPLICATED_IN_REQUEST", "요청 내 선호 운동 종목이 중복되었습니다.");
+    PREFERRED_EXERCISE_DUPLICATED_IN_REQUEST(400, "PREFERRED_EXERCISE_DUPLICATED_IN_REQUEST", "요청 내 선호 운동 종목이 중복되었습니다."),
+
+    //피드 관련 에러
+    FEED_NOT_FOUND(404, "FEED_NOT_FOUND", "존재하지 않는 피드입니다.");
 
     private final HttpStatusCode status;
     private final String code;

--- a/src/main/java/com/project200/undabang/feed/controller/FeedQueryController.java
+++ b/src/main/java/com/project200/undabang/feed/controller/FeedQueryController.java
@@ -2,15 +2,13 @@ package com.project200.undabang.feed.controller;
 
 import com.project200.undabang.common.web.response.CommonResponse;
 import com.project200.undabang.feed.dto.response.GetAllMemberFeedsResponse;
+import com.project200.undabang.feed.dto.response.GetSpecificFeedResponse;
 import com.project200.undabang.feed.service.FeedQueryService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
@@ -24,5 +22,11 @@ public class FeedQueryController {
                                                                                        @PageableDefault(size = 10) Pageable pageable) {
 
         return ResponseEntity.ok(CommonResponse.success(feedQueryService.getAllMemberFeeds(prevFeedId, pageable)));
+    }
+
+    @GetMapping("/v1/feeds/{feedId}")
+    public ResponseEntity<CommonResponse<GetSpecificFeedResponse>> getSpecificFeed(@PathVariable Long feedId) {
+
+        return ResponseEntity.ok(CommonResponse.success(feedQueryService.getSpecificFeed(feedId)));
     }
 }

--- a/src/main/java/com/project200/undabang/feed/controller/FeedQueryController.java
+++ b/src/main/java/com/project200/undabang/feed/controller/FeedQueryController.java
@@ -17,6 +17,14 @@ public class FeedQueryController {
 
     private final FeedQueryService feedQueryService;
 
+    /**
+     * 모든 회원 피드를 조회합니다. 이전 피드 ID와 페이지 정보를 기반으로 결과를 필터링합니다.
+     *
+     * @param prevFeedId 이전 피드의 ID로, 해당 ID 이후의 피드를 조회합니다. 필수 값이 아니며, 제공되지 않을 경우 첫 번째 페이지부터 조회합니다.
+     * @param pageable   페이지 정보로, 페이지 크기나 정렬 옵션 등을 지정할 수 있습니다.
+     * @return {@code ResponseEntity<CommonResponse<GetAllMemberFeedsResponse>>} 형태로 응답하며,
+     * 요청된 조건에 맞는 피드 목록과 추가 페이지 여부를 포함합니다.
+     */
     @GetMapping("/v1/feeds")
     public ResponseEntity<CommonResponse<GetAllMemberFeedsResponse>> getAllMemberFeeds(@RequestParam(value = "prevFeedId", required = false) Long prevFeedId,
                                                                                        @PageableDefault(size = 10) Pageable pageable) {
@@ -24,6 +32,13 @@ public class FeedQueryController {
         return ResponseEntity.ok(CommonResponse.success(feedQueryService.getAllMemberFeeds(prevFeedId, pageable)));
     }
 
+    /**
+     * 특정 피드의 정보를 조회합니다.
+     *
+     * @param feedId 조회할 피드의 고유 ID입니다.
+     * @return {@code ResponseEntity<CommonResponse<GetSpecificFeedResponse>>} 형태로 응답하며,
+     *         특정 피드의 상세 정보를 포함합니다.
+     */
     @GetMapping("/v1/feeds/{feedId}")
     public ResponseEntity<CommonResponse<GetSpecificFeedResponse>> getSpecificFeed(@PathVariable Long feedId) {
 

--- a/src/main/java/com/project200/undabang/feed/dto/response/FeedDetailResponse.java
+++ b/src/main/java/com/project200/undabang/feed/dto/response/FeedDetailResponse.java
@@ -28,8 +28,8 @@ public class FeedDetailResponse {
     private boolean feedHasCommented;
     private UUID memberId;
     private String nickname;
-    private String profileUrl;
     private String thumbnailUrl;
+    private String profileUrl;
     private List<FeedPictureRecord> feedPictures;
 
     public static FeedDetailResponse from(FeedDetailRecord record, List<FeedPictureRecord> feedPictures) {
@@ -46,8 +46,8 @@ public class FeedDetailResponse {
                 .feedHasCommented(record.feedHasCommented())
                 .memberId(record.memberId())
                 .nickname(record.nickname())
-                .profileUrl(record.profileUrl())
                 .thumbnailUrl(record.thumbnailUrl())
+                .profileUrl(record.profileUrl())
                 .feedPictures(feedPictures)
                 .build();
     }

--- a/src/main/java/com/project200/undabang/feed/dto/response/GetSpecificFeedResponse.java
+++ b/src/main/java/com/project200/undabang/feed/dto/response/GetSpecificFeedResponse.java
@@ -28,8 +28,8 @@ public class GetSpecificFeedResponse {
     private boolean feedHasCommented;
     private UUID memberId;
     private String nickname;
-    private String profileUrl;
     private String thumbnailUrl;
+    private String profileUrl;
     private List<FeedPictureRecord> feedPictures;
 
     public static GetSpecificFeedResponse from(FeedDetailRecord record, List<FeedPictureRecord> feedPictures) {
@@ -46,8 +46,8 @@ public class GetSpecificFeedResponse {
                 .feedHasCommented(record.feedHasCommented())
                 .memberId(record.memberId())
                 .nickname(record.nickname())
-                .profileUrl(record.profileUrl())
                 .thumbnailUrl(record.thumbnailUrl())
+                .profileUrl(record.profileUrl())
                 .feedPictures(feedPictures)
                 .build();
     }

--- a/src/main/java/com/project200/undabang/feed/dto/response/GetSpecificFeedResponse.java
+++ b/src/main/java/com/project200/undabang/feed/dto/response/GetSpecificFeedResponse.java
@@ -1,0 +1,54 @@
+package com.project200.undabang.feed.dto.response;
+
+import com.project200.undabang.feed.dto.record.FeedDetailRecord;
+import com.project200.undabang.feed.dto.record.FeedPictureRecord;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class GetSpecificFeedResponse {
+    private long feedId;
+    private String feedContent;
+    private int feedLikesCount;
+    private int feedCommentsCount;
+    private long feedTypeId;
+    private String feedTypeName;
+    private String feedTypeDesc;
+    private LocalDateTime feedCreatedAt;
+    private boolean feedIsLiked;
+    private boolean feedHasCommented;
+    private UUID memberId;
+    private String nickname;
+    private String profileUrl;
+    private String thumbnailUrl;
+    private List<FeedPictureRecord> feedPictures;
+
+    public static GetSpecificFeedResponse from(FeedDetailRecord record, List<FeedPictureRecord> feedPictures) {
+        return GetSpecificFeedResponse.builder()
+                .feedId(record.feedId())
+                .feedContent(record.feedContent())
+                .feedLikesCount(record.feedLikesCount())
+                .feedCommentsCount(record.feedCommentsCount())
+                .feedTypeId(record.feedTypeId())
+                .feedTypeName(record.feedTypeName())
+                .feedTypeDesc(record.feedTypeDesc())
+                .feedCreatedAt(record.feedCreatedAt())
+                .feedIsLiked(record.feedIsLiked())
+                .feedHasCommented(record.feedHasCommented())
+                .memberId(record.memberId())
+                .nickname(record.nickname())
+                .profileUrl(record.profileUrl())
+                .thumbnailUrl(record.thumbnailUrl())
+                .feedPictures(feedPictures)
+                .build();
+    }
+}

--- a/src/main/java/com/project200/undabang/feed/repository/FeedRepositoryCustom.java
+++ b/src/main/java/com/project200/undabang/feed/repository/FeedRepositoryCustom.java
@@ -1,10 +1,15 @@
 package com.project200.undabang.feed.repository;
 
 import com.project200.undabang.feed.dto.response.FeedDetailResponse;
+import com.project200.undabang.feed.dto.response.GetSpecificFeedResponse;
 import com.project200.undabang.member.entity.Member;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 
+import java.util.Optional;
+
 public interface FeedRepositoryCustom {
     Slice<FeedDetailResponse> getAllFeedList(Member currentMember, Long prevFeedId, Pageable pageable);
+
+    Optional<GetSpecificFeedResponse> getSpecificFeed(Member currentMember, Long feedId);
 }

--- a/src/main/java/com/project200/undabang/feed/repository/FeedRepositoryCustom.java
+++ b/src/main/java/com/project200/undabang/feed/repository/FeedRepositoryCustom.java
@@ -10,6 +10,5 @@ import java.util.Optional;
 
 public interface FeedRepositoryCustom {
     Slice<FeedDetailResponse> getAllFeedList(Member currentMember, Long prevFeedId, Pageable pageable);
-
     Optional<GetSpecificFeedResponse> getSpecificFeed(Member currentMember, Long feedId);
 }

--- a/src/main/java/com/project200/undabang/feed/repository/impl/FeedRepositoryImpl.java
+++ b/src/main/java/com/project200/undabang/feed/repository/impl/FeedRepositoryImpl.java
@@ -5,6 +5,7 @@ import com.project200.undabang.common.entity.QPicture;
 import com.project200.undabang.feed.dto.record.FeedDetailRecord;
 import com.project200.undabang.feed.dto.record.FeedPictureRecord;
 import com.project200.undabang.feed.dto.response.FeedDetailResponse;
+import com.project200.undabang.feed.dto.response.GetSpecificFeedResponse;
 import com.project200.undabang.feed.entity.QFeed;
 import com.project200.undabang.feed.entity.QFeedPicture;
 import com.project200.undabang.feed.entity.QFeedType;
@@ -28,6 +29,7 @@ import org.springframework.stereotype.Repository;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 @Repository
 @RequiredArgsConstructor
@@ -46,6 +48,57 @@ public class FeedRepositoryImpl implements FeedRepositoryCustom {
 
     private static final int EXTRA_FETCH_SIZE = 1; // hasNext 확인용 상수
 
+    /**
+     * 특정 피드 ID에 해당하는 피드 정보를 조회합니다.
+     */
+    @Override
+    public Optional<GetSpecificFeedResponse> getSpecificFeed(Member currentMember, Long feedId) {
+        FeedDetailRecord contentRecord = queryFactory
+                .select(Projections.constructor(FeedDetailRecord.class,
+                        feed.id,
+                        feed.feedContent,
+                        feed.likesCount,
+                        feed.commentsCount,
+                        feedType.feedTypeId,
+                        feedType.feedTypeName,
+                        feedType.feedTypeDesc,
+                        feed.createdAt,
+                        isLikedExpression(currentMember),
+                        hasCommentedExpression(currentMember),
+                        member.memberId,
+                        member.memberNickname,
+                        memberPicture.memberPicturesUrl,
+                        picture.pictureUrl))
+                .from(feed)
+                .join(feed.member, member)
+                .leftJoin(member.memberPicture, memberPicture)
+                .leftJoin(memberPicture.picture, picture)
+                .join(feed.feedType, feedType)
+                .where(feed.id.eq(feedId)) // 특정 피드만 조회
+                .fetchOne();
+
+        // 해당 피드 데이터가 없는경우 Optional.Empty를 반환
+        if (contentRecord == null) {
+            return Optional.empty();
+        }
+
+        List<FeedPictureRecord> feedPictureList = queryFactory
+                .select(Projections.constructor(FeedPictureRecord.class,
+                        feedPicture.id,
+                        feedPicture.picture.pictureUrl))
+                .from(feedPicture)
+                .join(feedPicture.picture, picture)
+                .where(
+                        feedPicture.feed.id.eq(contentRecord.feedId())
+                )
+                .fetch();
+
+        return Optional.of(GetSpecificFeedResponse.from(contentRecord, feedPictureList));
+    }
+
+    /**
+     * 모든 피드의 리스트를 조회하여 페이징된 결과를 반환합니다.
+     */
     @Override
     public Slice<FeedDetailResponse> getAllFeedList(Member currentMember, Long prevFeedId, Pageable pageable) {
 

--- a/src/main/java/com/project200/undabang/feed/repository/impl/FeedRepositoryImpl.java
+++ b/src/main/java/com/project200/undabang/feed/repository/impl/FeedRepositoryImpl.java
@@ -77,7 +77,7 @@ public class FeedRepositoryImpl implements FeedRepositoryCustom {
                 .where(feed.id.eq(feedId)) // 특정 피드만 조회
                 .fetchOne();
 
-        // 해당 피드 데이터가 없는경우 Optional.Empty를 반환
+        // 해당 피드 데이터가 없는 경우 Optional.empty()를 반환
         if (contentRecord == null) {
             return Optional.empty();
         }

--- a/src/main/java/com/project200/undabang/feed/repository/impl/FeedRepositoryImpl.java
+++ b/src/main/java/com/project200/undabang/feed/repository/impl/FeedRepositoryImpl.java
@@ -89,7 +89,7 @@ public class FeedRepositoryImpl implements FeedRepositoryCustom {
                 .from(feedPicture)
                 .join(feedPicture.picture, picture)
                 .where(
-                        feedPicture.feed.id.eq(contentRecord.feedId())
+                        feedPicture.feed.id.eq(feedId)
                 )
                 .fetch();
 

--- a/src/main/java/com/project200/undabang/feed/service/FeedQueryService.java
+++ b/src/main/java/com/project200/undabang/feed/service/FeedQueryService.java
@@ -1,8 +1,11 @@
 package com.project200.undabang.feed.service;
 
 import com.project200.undabang.feed.dto.response.GetAllMemberFeedsResponse;
+import com.project200.undabang.feed.dto.response.GetSpecificFeedResponse;
 import org.springframework.data.domain.Pageable;
 
 public interface FeedQueryService {
     GetAllMemberFeedsResponse getAllMemberFeeds(Long prevFeedId, Pageable pageable);
+
+    GetSpecificFeedResponse getSpecificFeed(Long feedId);
 }

--- a/src/main/java/com/project200/undabang/feed/service/FeedQueryService.java
+++ b/src/main/java/com/project200/undabang/feed/service/FeedQueryService.java
@@ -6,6 +6,5 @@ import org.springframework.data.domain.Pageable;
 
 public interface FeedQueryService {
     GetAllMemberFeedsResponse getAllMemberFeeds(Long prevFeedId, Pageable pageable);
-
     GetSpecificFeedResponse getSpecificFeed(Long feedId);
 }

--- a/src/main/java/com/project200/undabang/feed/service/impl/FeedQueryServiceImpl.java
+++ b/src/main/java/com/project200/undabang/feed/service/impl/FeedQueryServiceImpl.java
@@ -4,6 +4,7 @@ import com.project200.undabang.common.context.UserContextHolder;
 import com.project200.undabang.common.web.exception.CustomException;
 import com.project200.undabang.common.web.exception.ErrorCode;
 import com.project200.undabang.feed.dto.response.GetAllMemberFeedsResponse;
+import com.project200.undabang.feed.dto.response.GetSpecificFeedResponse;
 import com.project200.undabang.feed.repository.FeedRepository;
 import com.project200.undabang.feed.service.FeedQueryService;
 import com.project200.undabang.member.entity.Member;
@@ -23,6 +24,19 @@ public class FeedQueryServiceImpl implements FeedQueryService {
     private final FeedRepository feedRepository;
     private final MemberRepository memberRepository;
 
+    /**
+     * 주어진 피드 ID를 기반으로 특정 피드의 세부 정보를 조회합니다.
+     */
+    @Override
+    public GetSpecificFeedResponse getSpecificFeed(Long feedId) {
+        Member member = getMember(UserContextHolder.getUserId());
+
+        return feedRepository.getSpecificFeed(member, feedId).orElseThrow(() -> new CustomException(ErrorCode.FEED_NOT_FOUND));
+    }
+
+    /**
+     * 이전 피드 ID와 페이지 정보를 바탕으로 모든 피드 목록을 조회합니다.
+     */
     @Override
     public GetAllMemberFeedsResponse getAllMemberFeeds(Long prevFeedId, Pageable pageable) {
         Member member = getMember(UserContextHolder.getUserId());
@@ -30,6 +44,9 @@ public class FeedQueryServiceImpl implements FeedQueryService {
         return GetAllMemberFeedsResponse.of(feedRepository.getAllFeedList(member, prevFeedId, pageable));
     }
 
+    /**
+     * 주어진 회원 ID를 기반으로 회원 정보를 조회합니다.
+     */
     private Member getMember(UUID memberId) {
         return memberRepository.findById(memberId).orElseThrow(() -> new CustomException(ErrorCode.MEMBER_NOT_FOUND));
     }

--- a/src/test/java/com/project200/undabang/feed/controller/FeedQueryControllerTest.java
+++ b/src/test/java/com/project200/undabang/feed/controller/FeedQueryControllerTest.java
@@ -4,6 +4,7 @@ import com.project200.undabang.configuration.AbstractRestDocSupport;
 import com.project200.undabang.feed.dto.record.FeedPictureRecord;
 import com.project200.undabang.feed.dto.response.FeedDetailResponse;
 import com.project200.undabang.feed.dto.response.GetAllMemberFeedsResponse;
+import com.project200.undabang.feed.dto.response.GetSpecificFeedResponse;
 import com.project200.undabang.feed.service.FeedQueryService;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -12,6 +13,7 @@ import org.mockito.BDDMockito;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.MediaType;
+import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders;
 import org.springframework.restdocs.payload.JsonFieldType;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
@@ -30,8 +32,7 @@ import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuild
 import static org.springframework.restdocs.payload.JsonFieldType.*;
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
 import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
-import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
-import static org.springframework.restdocs.request.RequestDocumentation.queryParameters;
+import static org.springframework.restdocs.request.RequestDocumentation.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -40,6 +41,86 @@ class FeedQueryControllerTest extends AbstractRestDocSupport {
 
     @MockitoBean
     private FeedQueryService feedQueryService;
+
+    @Nested
+    @DisplayName("GET /api/v1/feeds/{feedId} API는")
+    class GetSpecificFeed {
+
+        @Test
+        @DisplayName("특정 피드의 상세 정보를 조회한다")
+        void getSpecificFeed_Success() throws Exception {
+            // given
+            UUID memberId = UUID.randomUUID();
+            Long feedId = 100L;
+
+            List<FeedPictureRecord> pictures = List.of(
+                    new FeedPictureRecord(501L, "https://example.com/img1.jpg"),
+                    new FeedPictureRecord(502L, "https://example.com/img2.jpg")
+            );
+
+            GetSpecificFeedResponse response = GetSpecificFeedResponse.builder()
+                    .feedId(feedId)
+                    .feedContent("피드 상세 조회 내용입니다.")
+                    .feedLikesCount(123)
+                    .feedCommentsCount(12)
+                    .feedTypeId(2L)
+                    .feedTypeName("러닝다방")
+                    .feedTypeDesc("러닝다방 설명")
+                    .feedIsLiked(true)         // 내가 좋아요 눌렀는지
+                    .feedHasCommented(false)   // 내가 댓글 달았는지
+                    .memberId(UUID.randomUUID())
+                    .nickname("러닝고수")
+                    .profileUrl("https://example.com/profile.jpg")
+                    .thumbnailUrl("https://example.com/thumb.jpg")
+                    .feedCreatedAt(LocalDateTime.now())
+                    .feedPictures(pictures)
+                    .build();
+
+            BDDMockito.given(feedQueryService.getSpecificFeed(eq(feedId))).willReturn(response);
+
+            // when & then
+            mockMvc.perform(RestDocumentationRequestBuilders.get("/api/v1/feeds/{feedId}", feedId)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .accept(MediaType.APPLICATION_JSON)
+                            .headers(getCommonApiHeaders(memberId)))
+                    .andExpectAll(
+                            status().isOk(),
+                            jsonPath("$.succeed").value(true),
+                            jsonPath("$.code").value("SUCCESS"),
+                            jsonPath("$.data.feedId").value(feedId),
+                            jsonPath("$.data.nickname").value("러닝고수"),
+                            jsonPath("$.data.feedPictures").isArray(),
+                            jsonPath("$.data.feedPictures[0].feedPictureUrl").value("https://example.com/img1.jpg")
+                    )
+                    .andDo(document.document(
+                            requestHeaders(HEADER_ACCESS_TOKEN),
+                            pathParameters(
+                                    parameterWithName("feedId").attributes(getTypeFormat(NUMBER)).description("조회할 피드의 고유 식별자(ID)입니다.")
+                            ),
+                            responseFields(commonResponseFields(
+                                    fieldWithPath("data.feedId").type(NUMBER).description("피드 식별자를 의미합니다."),
+                                    fieldWithPath("data.feedContent").type(STRING).description("피드 내용을 의미합니다."),
+                                    fieldWithPath("data.feedLikesCount").type(NUMBER).description("좋아요 수를 의미합니다."),
+                                    fieldWithPath("data.feedCommentsCount").type(NUMBER).description("댓글 수를 의미합니다."),
+                                    fieldWithPath("data.feedTypeId").type(NUMBER).description("피드 타입 식별자를 의미합니다."),
+                                    fieldWithPath("data.feedTypeName").type(STRING).description("피드 타입 이름을 의미합니다."),
+                                    fieldWithPath("data.feedTypeDesc").type(STRING).description("피드 타입 설명을 의미합니다."),
+                                    fieldWithPath("data.feedIsLiked").type(BOOLEAN).description("해당 회원이 피드에 좋아요를 누른 여부를 반환합니다."),
+                                    fieldWithPath("data.feedHasCommented").type(BOOLEAN).description("해당 회원이 피드에 댓글을 작성하였는지 여부를 반환합니다."),
+                                    fieldWithPath("data.memberId").type(STRING).description("작성자 회원 식별자를 의미합니다."),
+                                    fieldWithPath("data.nickname").type(STRING).description("작성자 닉네임을 의미합니다."),
+                                    fieldWithPath("data.profileUrl").type(STRING).description("작성자 프로필 URL을 의미합니다.").optional(),
+                                    fieldWithPath("data.thumbnailUrl").type(STRING).description("작성자 썸네일 URL을 의미합니다.").optional(),
+                                    fieldWithPath("data.feedCreatedAt").type(STRING).description("작성일시 정보를 나타냅니다."),
+                                    fieldWithPath("data.feedPictures").type(ARRAY).description("피드 사진 목록을 의미합니다."),
+                                    fieldWithPath("data.feedPictures[].feedPictureId").type(NUMBER).description("피드 사진 식별자를 의미합니다."),
+                                    fieldWithPath("data.feedPictures[].feedPictureUrl").type(STRING).description("피드 사진 URL을 의미합니다.")
+                            ))
+                    ));
+
+            BDDMockito.then(feedQueryService).should(BDDMockito.times(1)).getSpecificFeed(eq(feedId));
+        }
+    }
 
     @Nested
     @DisplayName("GET /api/v1/feeds API는")

--- a/src/test/java/com/project200/undabang/feed/repository/impl/FeedRepositoryImplTest.java
+++ b/src/test/java/com/project200/undabang/feed/repository/impl/FeedRepositoryImplTest.java
@@ -4,6 +4,7 @@ import com.project200.undabang.comment.entity.Comment;
 import com.project200.undabang.common.entity.Picture;
 import com.project200.undabang.configuration.TestQuerydslConfig;
 import com.project200.undabang.feed.dto.response.FeedDetailResponse;
+import com.project200.undabang.feed.dto.response.GetSpecificFeedResponse;
 import com.project200.undabang.feed.entity.Feed;
 import com.project200.undabang.feed.entity.FeedPicture;
 import com.project200.undabang.feed.entity.FeedType;
@@ -27,6 +28,7 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -40,6 +42,111 @@ class FeedRepositoryImplTest {
 
     @Autowired
     private FeedRepository feedRepository;
+
+    @Nested
+    @DisplayName("getSpecificFeed 메소드는")
+    class Describe_getSpecificFeed {
+
+        @Nested
+        @DisplayName("존재하는 피드 ID와 로그인한 사용자가 주어지면")
+        class Context_with_existing_feed_and_login_user {
+
+            @Test
+            @DisplayName("피드 상세 정보, 사진 목록, 좋아요/댓글 여부를 포함한 Optional 객체를 반환한다")
+            void it_returns_feed_detail_with_full_info() {
+                // given
+                Member author = createAndSaveMember("author");
+                Member viewer = createAndSaveMember("viewer"); // 조회자
+                FeedType type = createAndSaveFeedType("상세조회용");
+
+                // 피드 생성
+                Feed feed = createAndSaveFeed(author, type, "Detail View Test");
+
+                // 사진 2장 추가
+                createAndSaveFeedPicture(feed, "http://img1.com");
+                createAndSaveFeedPicture(feed, "http://img2.com");
+
+                // 조회자가 좋아요 & 댓글 작성
+                createAndSaveFeedLike(feed, viewer);
+                createAndSaveComment(feed, viewer, "Nice feed!");
+
+                flushAndClear();
+
+                // when
+                Optional<GetSpecificFeedResponse> result = feedRepository.getSpecificFeed(viewer, feed.getId());
+
+                // then
+                assertThat(result).isPresent();
+                GetSpecificFeedResponse response = result.get();
+
+                // 1. 기본 정보 검증
+                assertThat(response.getFeedId()).isEqualTo(feed.getId());
+                assertThat(response.getFeedContent()).isEqualTo("Detail View Test");
+                assertThat(response.getNickname()).isEqualTo("author");
+
+                // 2. 사진 목록 검증 (별도 쿼리 동작 확인)
+                assertThat(response.getFeedPictures()).hasSize(2);
+                assertThat(response.getFeedPictures())
+                        .extracting("feedPictureUrl")
+                        .containsExactlyInAnyOrder("http://img1.com", "http://img2.com");
+
+                // 3. 좋아요/댓글 여부 검증 (viewer 기준)
+                assertThat(response.isFeedIsLiked()).isTrue();
+                assertThat(response.isFeedHasCommented()).isTrue();
+            }
+        }
+
+        @Nested
+        @DisplayName("존재하는 피드지만 사진이 없고, 비로그인(Guest) 사용자가 조회하면")
+        class Context_with_existing_feed_and_guest_user {
+
+            @Test
+            @DisplayName("사진 목록은 비어있고, 좋아요/댓글 여부는 false인 Optional 객체를 반환한다")
+            void it_returns_feed_detail_without_interaction_info() {
+                // given
+                Member author = createAndSaveMember("writer");
+                FeedType type = createAndSaveFeedType("일반");
+                Feed feed = createAndSaveFeed(author, type, "Guest View Test");
+
+                // 사진 추가 X, 좋아요 X
+
+                flushAndClear();
+
+                // when (Member에 null 전달)
+                Optional<GetSpecificFeedResponse> result = feedRepository.getSpecificFeed(null, feed.getId());
+
+                // then
+                assertThat(result).isPresent();
+                GetSpecificFeedResponse response = result.get();
+
+                assertThat(response.getFeedId()).isEqualTo(feed.getId());
+                assertThat(response.getFeedPictures()).isEmpty(); // 사진 쿼리 결과 0건 확인
+                assertThat(response.isFeedIsLiked()).isFalse();         // 게스트는 무조건 false
+                assertThat(response.isFeedHasCommented()).isFalse();  // 게스트는 무조건 false
+            }
+        }
+
+        @Nested
+        @DisplayName("존재하지 않는 피드 ID가 주어지면")
+        class Context_with_non_existing_feed {
+
+            @Test
+            @DisplayName("비어있는 Optional을 반환한다")
+            void it_returns_empty_optional() {
+                // given
+                Member member = createAndSaveMember("tester");
+                Long nonExistingFeedId = 99999L;
+
+                flushAndClear();
+
+                // when
+                Optional<GetSpecificFeedResponse> result = feedRepository.getSpecificFeed(member, nonExistingFeedId);
+
+                // then
+                assertThat(result).isEmpty();
+            }
+        }
+    }
 
     @Nested
     @DisplayName("getAllFeedList 메소드는")

--- a/src/test/java/com/project200/undabang/feed/service/impl/FeedQueryServiceImplTest.java
+++ b/src/test/java/com/project200/undabang/feed/service/impl/FeedQueryServiceImplTest.java
@@ -5,6 +5,7 @@ import com.project200.undabang.common.web.exception.CustomException;
 import com.project200.undabang.common.web.exception.ErrorCode;
 import com.project200.undabang.feed.dto.response.FeedDetailResponse;
 import com.project200.undabang.feed.dto.response.GetAllMemberFeedsResponse;
+import com.project200.undabang.feed.dto.response.GetSpecificFeedResponse;
 import com.project200.undabang.feed.repository.FeedRepository;
 import com.project200.undabang.member.entity.Member;
 import com.project200.undabang.member.repository.MemberRepository;
@@ -43,6 +44,101 @@ class FeedQueryServiceImplTest {
 
     @Mock
     private MemberRepository memberRepository;
+
+    @Nested
+    @DisplayName("getSpecificFeed 메소드는")
+    class Describe_getSpecificFeed {
+
+        @Nested
+        @DisplayName("존재하는 회원과 존재하는 피드 ID가 주어지면")
+        class Context_with_existing_member_and_feed {
+
+            @Test
+            @DisplayName("리포지토리에서 조회한 상세 정보를 반환한다")
+            void it_returns_specific_feed_response() {
+                // given
+                Long feedId = 100L;
+                UUID userId = UUID.randomUUID();
+
+                Member mockMember = createMockMember(userId);
+                GetSpecificFeedResponse mockResponse = GetSpecificFeedResponse.builder()
+                        .feedId(feedId)
+                        .feedContent("Detail Content")
+                        .build();
+
+                try (MockedStatic<UserContextHolder> ignored = mockStatic(UserContextHolder.class)) {
+                    given(UserContextHolder.getUserId()).willReturn(userId);
+                    given(memberRepository.findById(userId)).willReturn(Optional.of(mockMember));
+                    given(feedRepository.getSpecificFeed(eq(mockMember), eq(feedId)))
+                            .willReturn(Optional.of(mockResponse));
+
+                    // when
+                    GetSpecificFeedResponse result = feedQueryService.getSpecificFeed(feedId);
+
+                    // then
+                    assertThat(result).isNotNull();
+                    assertThat(result.getFeedId()).isEqualTo(feedId);
+                    assertThat(result.getFeedContent()).isEqualTo("Detail Content");
+
+                    verify(feedRepository).getSpecificFeed(eq(mockMember), eq(feedId));
+                }
+            }
+        }
+
+        @Nested
+        @DisplayName("존재하지 않는 회원 ID(로그인 정보 오류 등)인 경우")
+        class Context_when_member_not_found {
+
+            @Test
+            @DisplayName("MEMBER_NOT_FOUND 예외를 던진다")
+            void it_throws_member_not_found_exception() {
+                // given
+                Long feedId = 100L;
+                UUID userId = UUID.randomUUID();
+
+                try (MockedStatic<UserContextHolder> ignored = mockStatic(UserContextHolder.class)) {
+                    given(UserContextHolder.getUserId()).willReturn(userId);
+                    // 회원 조회 실패 설정
+                    given(memberRepository.findById(userId)).willReturn(Optional.empty());
+
+                    // when & then
+                    assertThatThrownBy(() -> feedQueryService.getSpecificFeed(feedId))
+                            .isInstanceOf(CustomException.class)
+                            .hasFieldOrPropertyWithValue("errorCode", ErrorCode.MEMBER_NOT_FOUND);
+
+                    verify(feedRepository, never()).getSpecificFeed(any(), any());
+                }
+            }
+        }
+
+        @Nested
+        @DisplayName("회원은 존재하지만 피드 ID에 해당하는 데이터가 없는 경우")
+        class Context_when_feed_not_found {
+
+            @Test
+            @DisplayName("FEED_NOT_FOUND 예외를 던진다")
+            void it_throws_feed_not_found_exception() {
+                // given
+                Long feedId = 999L;
+                UUID userId = UUID.randomUUID();
+                Member mockMember = createMockMember(userId);
+
+                try (MockedStatic<UserContextHolder> ignored = mockStatic(UserContextHolder.class)) {
+                    given(UserContextHolder.getUserId()).willReturn(userId);
+                    given(memberRepository.findById(userId)).willReturn(Optional.of(mockMember));
+
+                    // 리포지토리가 빈 Optional 반환
+                    given(feedRepository.getSpecificFeed(eq(mockMember), eq(feedId)))
+                            .willReturn(Optional.empty());
+
+                    // when & then
+                    assertThatThrownBy(() -> feedQueryService.getSpecificFeed(feedId))
+                            .isInstanceOf(CustomException.class)
+                            .hasFieldOrPropertyWithValue("errorCode", ErrorCode.FEED_NOT_FOUND);
+                }
+            }
+        }
+    }
 
     @Nested
     @DisplayName("getAllMemberFeeds 메소드는")


### PR DESCRIPTION
## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

이전 개발한 모든 피드 목록 조회에서 하나의 피드를 선택하여 특정 피드 상세 조회 기능을 개발하였습니다.

이전 개발한 기능에서 특정 피드만 선택하면 되므로, 특별한 기능을 추가하지는 않았습니다. 
특이사항은 커밋 411496cc39d0d049d9dfb1acd09358eafc0da85c 에서 레포지토리에서 만약 해당 피드의 값이 없을 경우 Optional.Emtpy()를 반환하여 Service 코드에서 ErrorCode.FEED_NOT_FOUND를 반환하도록 설정하였습니다. 
피드 사진이 없는 경우는 빈 리스트가 반환되므로 문제가 없음을 확인하였습니다.

### 스크린샷 (선택)
**API 응답 사진:** (API 응답 스크린샷을 첨부해주세요.)
<img width="681" height="574" alt="image" src="https://github.com/user-attachments/assets/f1d0c2f9-7215-458f-b441-13df6a6306c1" />

**API 명세서 사진:** (API 명세서 스크린샷을 첨부해주세요.)
<img width="992" height="836" alt="image" src="https://github.com/user-attachments/assets/579b3120-989a-4b20-a9c9-82d750526689" />
<img width="1011" height="677" alt="image" src="https://github.com/user-attachments/assets/391b1245-a095-4dc5-8f8e-6786bcf6bcc7" />
<img width="1011" height="765" alt="image" src="https://github.com/user-attachments/assets/c1a97559-c21a-4e2a-8ed3-a53c2cd5e7fe" />
<img width="1017" height="815" alt="image" src="https://github.com/user-attachments/assets/ed62ec7e-e315-43ed-8697-5d6139b207ea" />
<img width="1029" height="803" alt="image" src="https://github.com/user-attachments/assets/2be9ba88-cbf5-40e5-a35a-2f4ce5780f7b" />
<img width="1024" height="686" alt="image" src="https://github.com/user-attachments/assets/713109f0-60a5-40d1-b9dd-07eec77e85cb" />
<img width="1057" height="316" alt="image" src="https://github.com/user-attachments/assets/58d99e21-6700-459c-b92f-57fb09dc66a5" />

**테스트 커버리지 사진:** (테스트 커버리지 스크린샷을 첨부해주세요.)
<img width="805" height="102" alt="image" src="https://github.com/user-attachments/assets/5dda17b0-24af-4d3d-afbb-6d6e633073da" />

Closes #500 
