### PR TITLE
[Feat] 마이페이지에서 자신이 등록한 피드 목록 조회 기능 개발 [0.11.3]

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ plugins {
 }
 
 group = 'com.project200'
-version = '0.11.2-SNAPSHOT'
+version = '0.11.3-SNAPSHOT'
 
 java {
     toolchain {

--- a/src/docs/asciidoc/feed/마이페이지-내가-작성한-피드-목록-조회-API.adoc
+++ b/src/docs/asciidoc/feed/마이페이지-내가-작성한-피드-목록-조회-API.adoc
@@ -1,0 +1,32 @@
+== 마이페이지에서 내가 작성한 피드 목록 조회 API
+
+=== 설명
+
+- #GET# `/api/v1/mypage/feeds`
+- 회원이 자신이 작성한 피드의 전체 목록을 조회하는 API 입니다.
+
+=== 개발 이력
+
+- Sprint 23 (2026-01-29): 기능 개발이 완료되었습니다.
+
+=== 개발 참고 사항
+
+- <<공통-개발-참고-사항,공통 개발 참고 사항>>을 참고하세요.
+
+=== 코드 샘플
+
+operation::get-my-page-feeds/get-my-page-feeds_-success[snippets="curl-request,http-request,http-response"]
+
+=== 매개 변수
+
+operation::get-my-page-feeds/get-my-page-feeds_-success[snippets="request-headers,response-fields"]
+
+==== 응답 상태 코드
+
+|===
+|상태 코드|설명
+|200|요청이 성공적으로 처리되었습니다.
+|401|인증되지 않은 요청입니다. Access Token이 없거나 유효하지 않습니다
+|404|존재하지 않는 회원입니다.
+|===
+

--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -250,3 +250,5 @@ include::overview/공통-개발-참고-사항.adoc[]
 - 전체 피드 목록 조회 API #GET# `/api/v1/feeds?prevFeedId={prevFeedId}`
 
 - 특정 피드 상세 조회 API #GET# `/api/v1/feeds/{feedId}`
+
+- 마이페이지에서 내가 작성한 피드 목록 조회 API #GET# `/api/v1/mypage/feeds`

--- a/src/docs/asciidoc/피드-API.adoc
+++ b/src/docs/asciidoc/피드-API.adoc
@@ -22,3 +22,5 @@ include::overview/공통-개발-참고-사항.adoc[]
 include::feed/전체-피드-목록-조회-API.adoc[]
 
 include::feed/특정-피드-상세-조회-API.adoc[]
+
+include::feed/마이페이지-내가-작성한-피드-목록-조회-API.adoc[]

--- a/src/main/java/com/project200/undabang/feed/controller/FeedQueryController.java
+++ b/src/main/java/com/project200/undabang/feed/controller/FeedQueryController.java
@@ -2,6 +2,7 @@ package com.project200.undabang.feed.controller;
 
 import com.project200.undabang.common.web.response.CommonResponse;
 import com.project200.undabang.feed.dto.response.GetAllMemberFeedsResponse;
+import com.project200.undabang.feed.dto.response.GetMyPageFeedsResponse;
 import com.project200.undabang.feed.dto.response.GetSpecificFeedResponse;
 import com.project200.undabang.feed.service.FeedQueryService;
 import lombok.RequiredArgsConstructor;
@@ -43,5 +44,12 @@ public class FeedQueryController {
     public ResponseEntity<CommonResponse<GetSpecificFeedResponse>> getSpecificFeed(@PathVariable Long feedId) {
 
         return ResponseEntity.ok(CommonResponse.success(feedQueryService.getSpecificFeed(feedId)));
+    }
+
+    @GetMapping("/v1/mypage/feeds")
+    public ResponseEntity<CommonResponse<GetMyPageFeedsResponse>> getAllMyFeeds(@RequestParam(value = "prevFeedId", required = false) Long prevFeedId,
+                                                                                @PageableDefault(size = 10) Pageable pageable) {
+
+        return ResponseEntity.ok(CommonResponse.success(feedQueryService.getMyPageFeeds(prevFeedId, pageable)));
     }
 }

--- a/src/main/java/com/project200/undabang/feed/controller/FeedQueryController.java
+++ b/src/main/java/com/project200/undabang/feed/controller/FeedQueryController.java
@@ -46,6 +46,14 @@ public class FeedQueryController {
         return ResponseEntity.ok(CommonResponse.success(feedQueryService.getSpecificFeed(feedId)));
     }
 
+    /**
+     * 사용자의 마이페이지 피드 목록을 조회합니다. 이전 피드 ID와 페이지 정보를 기반으로 결과를 필터링합니다.
+     *
+     * @param prevFeedId 이전 피드의 ID로, 해당 ID 이후의 피드를 조회합니다. 필수 값이 아니며, 제공되지 않을 경우 첫 번째 페이지부터 조회합니다.
+     * @param pageable   페이지 정보로, 페이지 크기나 정렬 옵션 등을 지정할 수 있습니다.
+     * @return {@code ResponseEntity<CommonResponse<GetMyPageFeedsResponse>>} 형태로 응답하며,
+     * 요청된 조건에 맞는 마이페이지 피드 목록과 추가 페이지 여부를 포함합니다.
+     */
     @GetMapping("/v1/mypage/feeds")
     public ResponseEntity<CommonResponse<GetMyPageFeedsResponse>> getAllMyFeeds(@RequestParam(value = "prevFeedId", required = false) Long prevFeedId,
                                                                                 @PageableDefault(size = 10) Pageable pageable) {

--- a/src/main/java/com/project200/undabang/feed/dto/record/GetMyPageFeedsRecord.java
+++ b/src/main/java/com/project200/undabang/feed/dto/record/GetMyPageFeedsRecord.java
@@ -1,0 +1,37 @@
+package com.project200.undabang.feed.dto.record;
+
+import com.project200.undabang.feed.dto.response.FeedDetailResponse;
+import lombok.Builder;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Builder
+public record GetMyPageFeedsRecord(long feedId,
+                                   String feedContent,
+                                   int feedLikesCount,
+                                   int feedCommentsCount,
+                                   long feedTypeId,
+                                   String feedTypeName,
+                                   String feedTypeDesc,
+                                   LocalDateTime feedCreatedAt,
+                                   boolean feedIsLiked,
+                                   boolean feedHasCommented,
+                                   List<FeedPictureRecord> feedPictures) {
+
+    public static GetMyPageFeedsRecord from(FeedDetailResponse response) {
+        return GetMyPageFeedsRecord.builder()
+                .feedId(response.getFeedId())
+                .feedContent(response.getFeedContent())
+                .feedLikesCount(response.getFeedLikesCount())
+                .feedCommentsCount(response.getFeedCommentsCount())
+                .feedTypeId(response.getFeedTypeId())
+                .feedTypeName(response.getFeedTypeName())
+                .feedTypeDesc(response.getFeedTypeDesc())
+                .feedCreatedAt(response.getFeedCreatedAt())
+                .feedIsLiked(response.isFeedIsLiked())
+                .feedHasCommented(response.isFeedHasCommented())
+                .feedPictures(response.getFeedPictures())
+                .build();
+    }
+}

--- a/src/main/java/com/project200/undabang/feed/dto/response/GetMyPageFeedsResponse.java
+++ b/src/main/java/com/project200/undabang/feed/dto/response/GetMyPageFeedsResponse.java
@@ -24,7 +24,7 @@ public class GetMyPageFeedsResponse {
     private String thumbnailUrl;
     private String profileUrl;
     private boolean hasNext;
-    List<GetMyPageFeedsRecord> feeds;
+    private List<GetMyPageFeedsRecord> feeds;
 
     public static GetMyPageFeedsResponse from(Member member, Slice<FeedDetailResponse> responseSliceList) {
         List<GetMyPageFeedsRecord> feeds = responseSliceList.getContent().stream().map(GetMyPageFeedsRecord::from).toList();

--- a/src/main/java/com/project200/undabang/feed/dto/response/GetMyPageFeedsResponse.java
+++ b/src/main/java/com/project200/undabang/feed/dto/response/GetMyPageFeedsResponse.java
@@ -1,0 +1,52 @@
+package com.project200.undabang.feed.dto.response;
+
+import com.project200.undabang.common.entity.Picture;
+import com.project200.undabang.feed.dto.record.GetMyPageFeedsRecord;
+import com.project200.undabang.member.entity.Member;
+import com.project200.undabang.member.entity.MemberPicture;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.domain.Slice;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class GetMyPageFeedsResponse {
+    private UUID memberId;
+    private String nickname;
+    private String thumbnailUrl;
+    private String profileUrl;
+    private boolean hasNext;
+    List<GetMyPageFeedsRecord> feeds;
+
+    public static GetMyPageFeedsResponse from(Member member, Slice<FeedDetailResponse> responseSliceList) {
+        List<GetMyPageFeedsRecord> feeds = responseSliceList.getContent().stream().map(GetMyPageFeedsRecord::from).toList();
+
+        Optional<MemberPicture> memberPictureOptional = Optional.ofNullable(member.getMemberPicture());
+
+        String thumbnailUrl = memberPictureOptional
+                .map(MemberPicture::getMemberPicturesUrl)
+                .orElse(null);
+
+        String profileUrl = memberPictureOptional
+                .map(MemberPicture::getPicture)
+                .map(Picture::getPictureUrl)
+                .orElse(null);
+
+        return GetMyPageFeedsResponse.builder()
+                .memberId(member.getMemberId())
+                .nickname(member.getMemberNickname())
+                .thumbnailUrl(thumbnailUrl)
+                .profileUrl(profileUrl)
+                .hasNext(responseSliceList.hasNext())
+                .feeds(feeds)
+                .build();
+    }
+}

--- a/src/main/java/com/project200/undabang/feed/repository/FeedRepositoryCustom.java
+++ b/src/main/java/com/project200/undabang/feed/repository/FeedRepositoryCustom.java
@@ -11,4 +11,6 @@ import java.util.Optional;
 public interface FeedRepositoryCustom {
     Slice<FeedDetailResponse> getAllFeedList(Member currentMember, Long prevFeedId, Pageable pageable);
     Optional<GetSpecificFeedResponse> getSpecificFeed(Member currentMember, Long feedId);
+
+    Slice<FeedDetailResponse> getMyPageFeedList(Member currentMember, Long prevFeedId, Pageable pageable);
 }

--- a/src/main/java/com/project200/undabang/feed/repository/impl/FeedRepositoryImpl.java
+++ b/src/main/java/com/project200/undabang/feed/repository/impl/FeedRepositoryImpl.java
@@ -49,6 +49,24 @@ public class FeedRepositoryImpl implements FeedRepositoryCustom {
     private static final int EXTRA_FETCH_SIZE = 1; // hasNext 확인용 상수
 
     /**
+     * 현재 사용자의 "마이 페이지"에 표시될 피드 리스트를 조회하여 반환합니다.
+     */
+    @Override
+    public Slice<FeedDetailResponse> getMyPageFeedList(Member currentMember, Long prevFeedId, Pageable pageable) {
+        BooleanExpression condition = feed.member.memberId.eq(currentMember.getMemberId());
+
+        return getFeedDetailSlice(currentMember, prevFeedId, pageable, condition);
+    }
+
+    /**
+     * 모든 피드의 리스트를 조회하여 페이징된 결과를 반환합니다.
+     */
+    @Override
+    public Slice<FeedDetailResponse> getAllFeedList(Member currentMember, Long prevFeedId, Pageable pageable) {
+        return getFeedDetailSlice(currentMember, prevFeedId, pageable, null);
+    }
+
+    /**
      * 특정 피드 ID에 해당하는 피드 정보를 조회합니다.
      */
     @Override
@@ -97,10 +115,15 @@ public class FeedRepositoryImpl implements FeedRepositoryCustom {
     }
 
     /**
-     * 모든 피드의 리스트를 조회하여 페이징된 결과를 반환합니다.
+     * 주어진 조건을 기반으로 피드 상세 정보를 페이징 처리하여 반환합니다.
+     *
+     * @param currentMember 현재 요청을 보낸 회원의 정보
+     * @param prevFeedId 이전에 조회한 마지막 피드의 ID
+     * @param pageable 페이징 정보를 담고 있는 객체
+     * @param condition 추가로 적용할 조건식
+     * @return 특정 조건과 페이징 정보를 기반으로 필터링된 피드 상세 응답의 슬라이스
      */
-    @Override
-    public Slice<FeedDetailResponse> getAllFeedList(Member currentMember, Long prevFeedId, Pageable pageable) {
+    private Slice<FeedDetailResponse> getFeedDetailSlice(Member currentMember, Long prevFeedId, Pageable pageable, BooleanExpression condition) {
 
         List<FeedDetailRecord> contentRecords = queryFactory
                 .select(Projections.constructor(FeedDetailRecord.class,
@@ -124,7 +147,8 @@ public class FeedRepositoryImpl implements FeedRepositoryCustom {
                 .leftJoin(memberPicture.picture, picture)
                 .join(feed.feedType, feedType)
                 .where(
-                        olderThanPrevFeedId(prevFeedId)
+                        olderThanPrevFeedId(prevFeedId),
+                        condition
                 )
                 .orderBy(feed.id.desc()) // 최근 피드부터 읽기 (정확히는 최근에 작성된 피드가 생성도 늦게 되었다고 가정)
                 .limit(pageable.getPageSize() + EXTRA_FETCH_SIZE) // 다음 피드가 존재하는지 구별하도록 10 + 1 로 설정

--- a/src/main/java/com/project200/undabang/feed/service/FeedQueryService.java
+++ b/src/main/java/com/project200/undabang/feed/service/FeedQueryService.java
@@ -1,10 +1,13 @@
 package com.project200.undabang.feed.service;
 
 import com.project200.undabang.feed.dto.response.GetAllMemberFeedsResponse;
+import com.project200.undabang.feed.dto.response.GetMyPageFeedsResponse;
 import com.project200.undabang.feed.dto.response.GetSpecificFeedResponse;
 import org.springframework.data.domain.Pageable;
 
 public interface FeedQueryService {
     GetAllMemberFeedsResponse getAllMemberFeeds(Long prevFeedId, Pageable pageable);
     GetSpecificFeedResponse getSpecificFeed(Long feedId);
+
+    GetMyPageFeedsResponse getMyPageFeeds(Long prevFeedId, Pageable pageable);
 }

--- a/src/main/java/com/project200/undabang/feed/service/FeedQueryService.java
+++ b/src/main/java/com/project200/undabang/feed/service/FeedQueryService.java
@@ -8,6 +8,5 @@ import org.springframework.data.domain.Pageable;
 public interface FeedQueryService {
     GetAllMemberFeedsResponse getAllMemberFeeds(Long prevFeedId, Pageable pageable);
     GetSpecificFeedResponse getSpecificFeed(Long feedId);
-
     GetMyPageFeedsResponse getMyPageFeeds(Long prevFeedId, Pageable pageable);
 }

--- a/src/main/java/com/project200/undabang/feed/service/impl/FeedQueryServiceImpl.java
+++ b/src/main/java/com/project200/undabang/feed/service/impl/FeedQueryServiceImpl.java
@@ -3,7 +3,9 @@ package com.project200.undabang.feed.service.impl;
 import com.project200.undabang.common.context.UserContextHolder;
 import com.project200.undabang.common.web.exception.CustomException;
 import com.project200.undabang.common.web.exception.ErrorCode;
+import com.project200.undabang.feed.dto.response.FeedDetailResponse;
 import com.project200.undabang.feed.dto.response.GetAllMemberFeedsResponse;
+import com.project200.undabang.feed.dto.response.GetMyPageFeedsResponse;
 import com.project200.undabang.feed.dto.response.GetSpecificFeedResponse;
 import com.project200.undabang.feed.repository.FeedRepository;
 import com.project200.undabang.feed.service.FeedQueryService;
@@ -11,6 +13,7 @@ import com.project200.undabang.member.entity.Member;
 import com.project200.undabang.member.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -23,6 +26,23 @@ public class FeedQueryServiceImpl implements FeedQueryService {
 
     private final FeedRepository feedRepository;
     private final MemberRepository memberRepository;
+
+    /**
+     * 이전 피드 ID와 페이지 정보(Pageable)를 기반으로 회원의 피드 목록을 마이페이지에서 조회합니다.
+     *
+     * @param prevFeedId 이전 피드의 ID로, 해당 ID를 기준으로 이후의 피드 목록을 조회합니다.
+     * @param pageable   페이지 정보를 포함하며, 페이징과 관련된 설정을 제공합니다.
+     * @return 마이페이지 피드 목록과 관련된 응답 객체 {@link GetMyPageFeedsResponse}.
+     */
+    @Override
+    public GetMyPageFeedsResponse getMyPageFeeds(Long prevFeedId, Pageable pageable) {
+        Member member = memberRepository.findMemberWithProfileImage(UserContextHolder.getUserId())
+                .orElseThrow(() -> new CustomException(ErrorCode.MEMBER_NOT_FOUND));
+
+        Slice<FeedDetailResponse> feedSliceList = feedRepository.getMyPageFeedList(member, prevFeedId, pageable);
+
+        return GetMyPageFeedsResponse.from(member, feedSliceList);
+    }
 
     /**
      * 주어진 피드 ID를 기반으로 특정 피드의 세부 정보를 조회합니다.

--- a/src/main/java/com/project200/undabang/feed/service/impl/FeedQueryServiceImpl.java
+++ b/src/main/java/com/project200/undabang/feed/service/impl/FeedQueryServiceImpl.java
@@ -29,10 +29,6 @@ public class FeedQueryServiceImpl implements FeedQueryService {
 
     /**
      * 이전 피드 ID와 페이지 정보(Pageable)를 기반으로 회원의 피드 목록을 마이페이지에서 조회합니다.
-     *
-     * @param prevFeedId 이전 피드의 ID로, 해당 ID를 기준으로 이후의 피드 목록을 조회합니다.
-     * @param pageable   페이지 정보를 포함하며, 페이징과 관련된 설정을 제공합니다.
-     * @return 마이페이지 피드 목록과 관련된 응답 객체 {@link GetMyPageFeedsResponse}.
      */
     @Override
     public GetMyPageFeedsResponse getMyPageFeeds(Long prevFeedId, Pageable pageable) {

--- a/src/test/java/com/project200/undabang/feed/controller/FeedQueryControllerTest.java
+++ b/src/test/java/com/project200/undabang/feed/controller/FeedQueryControllerTest.java
@@ -282,24 +282,24 @@ class FeedQueryControllerTest extends AbstractRestDocSupport {
                             ),
                             responseFields(commonResponseFields(
                                     fieldWithPath("data.memberId").type(STRING).description("조회 중인 회원(본인)의 식별자 정보 (UUID) 입니다."),
-                                    fieldWithPath("data.nickname").type(STRING).description("회원의 닉네임입니다."),
-                                    fieldWithPath("data.thumbnailUrl").type(STRING).description("회원의 썸네일 URL입니다.").optional(),
-                                    fieldWithPath("data.profileUrl").type(STRING).description("회원의 프로필 원본 URL입니다.").optional(),
+                                    fieldWithPath("data.nickname").type(STRING).description("회원의 닉네임을 의미합니다."),
+                                    fieldWithPath("data.thumbnailUrl").type(STRING).description("회원의 썸네일 URL 주소입니다.").optional(),
+                                    fieldWithPath("data.profileUrl").type(STRING).description("회원의 프로필 원본 URL 주소입니다.").optional(),
                                     fieldWithPath("data.hasNext").type(BOOLEAN).description("다음 페이지 존재 여부를 반환합니다."),
-                                    fieldWithPath("data.feeds").type(ARRAY).description("작성한 피드 목록 리스트입니다."),
+                                    fieldWithPath("data.feeds").type(ARRAY).description("회원이 작성한 피드 목록 리스트입니다."),
                                     fieldWithPath("data.feeds[].feedId").type(NUMBER).description("피드 식별자입니다."),
-                                    fieldWithPath("data.feeds[].feedContent").type(STRING).description("피드 내용입니다."),
-                                    fieldWithPath("data.feeds[].feedLikesCount").type(NUMBER).description("좋아요 수입니다."),
-                                    fieldWithPath("data.feeds[].feedCommentsCount").type(NUMBER).description("댓글 수입니다."),
+                                    fieldWithPath("data.feeds[].feedContent").type(STRING).description("피드 본문 내용을 의미합니다."),
+                                    fieldWithPath("data.feeds[].feedLikesCount").type(NUMBER).description("피드가 받은 좋아요의 총 갯수입니다."),
+                                    fieldWithPath("data.feeds[].feedCommentsCount").type(NUMBER).description("피드에 달린 댓글의 총 갯수입니다."),
                                     fieldWithPath("data.feeds[].feedTypeId").type(NUMBER).description("피드 타입 식별자입니다."),
                                     fieldWithPath("data.feeds[].feedTypeName").type(STRING).description("피드 타입 이름입니다."),
-                                    fieldWithPath("data.feeds[].feedTypeDesc").type(STRING).description("피드 타입 설명입니다."),
-                                    fieldWithPath("data.feeds[].feedCreatedAt").type(STRING).description("피드 작성일시입니다."),
-                                    fieldWithPath("data.feeds[].feedIsLiked").type(BOOLEAN).description("내가 이 피드에 좋아요를 눌렀는지 여부입니다."),
-                                    fieldWithPath("data.feeds[].feedHasCommented").type(BOOLEAN).description("내가 이 피드에 댓글을 달았는지 여부입니다."),
-                                    fieldWithPath("data.feeds[].feedPictures").type(ARRAY).description("피드 사진 목록입니다."),
-                                    fieldWithPath("data.feeds[].feedPictures[].feedPictureId").type(NUMBER).description("사진 식별자입니다."),
-                                    fieldWithPath("data.feeds[].feedPictures[].feedPictureUrl").type(STRING).description("사진 URL입니다.")
+                                    fieldWithPath("data.feeds[].feedTypeDesc").type(STRING).description("피드 타입에 대한 상세 설명입니다."),
+                                    fieldWithPath("data.feeds[].feedCreatedAt").type(STRING).description("피드 작성일시 정보입니다."),
+                                    fieldWithPath("data.feeds[].feedIsLiked").type(BOOLEAN).description("로그인한 회원이 이 피드에 좋아요를 눌렀는지 여부입니다."),
+                                    fieldWithPath("data.feeds[].feedHasCommented").type(BOOLEAN).description("로그인한 회원이 이 피드에 댓글을 작성했는지 여부입니다."),
+                                    fieldWithPath("data.feeds[].feedPictures").type(ARRAY).description("피드에 포함된 사진 목록입니다."),
+                                    fieldWithPath("data.feeds[].feedPictures[].feedPictureId").type(NUMBER).description("피드 사진 식별자입니다."),
+                                    fieldWithPath("data.feeds[].feedPictures[].feedPictureUrl").type(STRING).description("피드 사진 URL 주소입니다.")
                             ))
                     ));
 

--- a/src/test/java/com/project200/undabang/feed/controller/FeedQueryControllerTest.java
+++ b/src/test/java/com/project200/undabang/feed/controller/FeedQueryControllerTest.java
@@ -2,8 +2,10 @@ package com.project200.undabang.feed.controller;
 
 import com.project200.undabang.configuration.AbstractRestDocSupport;
 import com.project200.undabang.feed.dto.record.FeedPictureRecord;
+import com.project200.undabang.feed.dto.record.GetMyPageFeedsRecord;
 import com.project200.undabang.feed.dto.response.FeedDetailResponse;
 import com.project200.undabang.feed.dto.response.GetAllMemberFeedsResponse;
+import com.project200.undabang.feed.dto.response.GetMyPageFeedsResponse;
 import com.project200.undabang.feed.dto.response.GetSpecificFeedResponse;
 import com.project200.undabang.feed.service.FeedQueryService;
 import org.junit.jupiter.api.DisplayName;
@@ -210,6 +212,98 @@ class FeedQueryControllerTest extends AbstractRestDocSupport {
                     ));
 
             BDDMockito.then(feedQueryService).should(BDDMockito.times(1)).getAllMemberFeeds(eq(prevFeedId), any(Pageable.class));
+        }
+    }
+
+    @Nested
+    @DisplayName("GET /api/v1/mypage/feeds API는")
+    class GetMyPageFeeds {
+
+        @Test
+        @DisplayName("현재 사용자가 작성한 피드 목록을 프로필 정보와 함께 조회한다")
+        void getMyPageFeeds_Success() throws Exception {
+            // given
+            UUID memberId = UUID.randomUUID();
+            Long prevFeedId = 50L;
+            int pageSize = 10;
+
+            List<FeedPictureRecord> pictures = List.of(
+                    new FeedPictureRecord(1001L, "https://example.com/my_feed_img.jpg")
+            );
+
+            // 마이페이지 전용 피드 레코드 생성
+            GetMyPageFeedsRecord myFeed = GetMyPageFeedsRecord.builder()
+                    .feedId(49L)
+                    .feedContent("내가 작성한 피드 내용입니다.")
+                    .feedLikesCount(50)
+                    .feedCommentsCount(5)
+                    .feedTypeId(1L)
+                    .feedTypeName("수영다방")
+                    .feedTypeDesc("수영다방 설명")
+                    .feedCreatedAt(LocalDateTime.now())
+                    .feedIsLiked(true)
+                    .feedHasCommented(true)
+                    .feedPictures(pictures)
+                    .build();
+
+            // 최종 응답 객체 (헤더 정보 + 피드 목록)
+            GetMyPageFeedsResponse response = GetMyPageFeedsResponse.builder()
+                    .memberId(memberId)
+                    .nickname("운동하는개발자")
+                    .thumbnailUrl("https://example.com/my_thumb.jpg")
+                    .profileUrl("https://example.com/my_profile.jpg")
+                    .hasNext(false)
+                    .feeds(List.of(myFeed))
+                    .build();
+
+            BDDMockito.given(feedQueryService.getMyPageFeeds(eq(prevFeedId), any(Pageable.class)))
+                    .willReturn(response);
+
+            // when & then
+            mockMvc.perform(RestDocumentationRequestBuilders.get("/api/v1/mypage/feeds")
+                            .param("prevFeedId", String.valueOf(prevFeedId))
+                            .param("size", String.valueOf(pageSize))
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .accept(MediaType.APPLICATION_JSON)
+                            .headers(getCommonApiHeaders(memberId)))
+                    .andExpectAll(
+                            status().isOk(),
+                            jsonPath("$.succeed").value(true),
+                            jsonPath("$.data.memberId").value(memberId.toString()),
+                            jsonPath("$.data.nickname").value("운동하는개발자"),
+                            jsonPath("$.data.feeds").isArray(),
+                            jsonPath("$.data.feeds[0].feedContent").value("내가 작성한 피드 내용입니다.")
+                    )
+                    .andDo(document.document(
+                            requestHeaders(HEADER_ACCESS_TOKEN),
+                            queryParameters(
+                                    parameterWithName("prevFeedId").attributes(getTypeFormat(NUMBER)).description("이전 페이지의 마지막 피드 식별자입니다.").optional(),
+                                    parameterWithName("size").attributes(getTypeFormat(NUMBER)).description("조회할 페이지 크기입니다.").optional()
+                            ),
+                            responseFields(commonResponseFields(
+                                    fieldWithPath("data.memberId").type(STRING).description("조회 중인 회원(본인)의 식별자 정보 (UUID) 입니다."),
+                                    fieldWithPath("data.nickname").type(STRING).description("회원의 닉네임입니다."),
+                                    fieldWithPath("data.thumbnailUrl").type(STRING).description("회원의 썸네일 URL입니다.").optional(),
+                                    fieldWithPath("data.profileUrl").type(STRING).description("회원의 프로필 원본 URL입니다.").optional(),
+                                    fieldWithPath("data.hasNext").type(BOOLEAN).description("다음 페이지 존재 여부를 반환합니다."),
+                                    fieldWithPath("data.feeds").type(ARRAY).description("작성한 피드 목록 리스트입니다."),
+                                    fieldWithPath("data.feeds[].feedId").type(NUMBER).description("피드 식별자입니다."),
+                                    fieldWithPath("data.feeds[].feedContent").type(STRING).description("피드 내용입니다."),
+                                    fieldWithPath("data.feeds[].feedLikesCount").type(NUMBER).description("좋아요 수입니다."),
+                                    fieldWithPath("data.feeds[].feedCommentsCount").type(NUMBER).description("댓글 수입니다."),
+                                    fieldWithPath("data.feeds[].feedTypeId").type(NUMBER).description("피드 타입 식별자입니다."),
+                                    fieldWithPath("data.feeds[].feedTypeName").type(STRING).description("피드 타입 이름입니다."),
+                                    fieldWithPath("data.feeds[].feedTypeDesc").type(STRING).description("피드 타입 설명입니다."),
+                                    fieldWithPath("data.feeds[].feedCreatedAt").type(STRING).description("피드 작성일시입니다."),
+                                    fieldWithPath("data.feeds[].feedIsLiked").type(BOOLEAN).description("내가 이 피드에 좋아요를 눌렀는지 여부입니다."),
+                                    fieldWithPath("data.feeds[].feedHasCommented").type(BOOLEAN).description("내가 이 피드에 댓글을 달았는지 여부입니다."),
+                                    fieldWithPath("data.feeds[].feedPictures").type(ARRAY).description("피드 사진 목록입니다."),
+                                    fieldWithPath("data.feeds[].feedPictures[].feedPictureId").type(NUMBER).description("사진 식별자입니다."),
+                                    fieldWithPath("data.feeds[].feedPictures[].feedPictureUrl").type(STRING).description("사진 URL입니다.")
+                            ))
+                    ));
+
+            BDDMockito.then(feedQueryService).should(BDDMockito.times(1)).getMyPageFeeds(eq(prevFeedId), any(Pageable.class));
         }
     }
 }

--- a/src/test/java/com/project200/undabang/feed/repository/impl/FeedRepositoryImplTest.java
+++ b/src/test/java/com/project200/undabang/feed/repository/impl/FeedRepositoryImplTest.java
@@ -308,6 +308,96 @@ class FeedRepositoryImplTest {
         }
     }
 
+    @Nested
+    @DisplayName("getMyPageFeedList 메소드는")
+    class Describe_getMyPageFeedList {
+
+        @Nested
+        @DisplayName("특정 회원이 작성한 피드 목록을 요청하면")
+        class Context_with_member_specific_request {
+
+            @Test
+            @DisplayName("해당 회원의 피드만 최신순으로 조회하고, 타인의 피드는 포함하지 않는다")
+            void it_returns_only_target_member_feeds() {
+                // given
+                Member me = createAndSaveMember("me");
+                Member other = createAndSaveMember("other");
+                FeedType type = createAndSaveFeedType("일상");
+
+                // 내 피드 2개 생성
+                createAndSaveFeed(me, type, "My Feed 1");
+                createAndSaveFeed(me, type, "My Feed 2");
+
+                // 타인의 피드 1개 생성 (조회되면 안 됨)
+                createAndSaveFeed(other, type, "Other's Feed");
+
+                flushAndClear();
+
+                // when
+                Pageable pageable = PageRequest.of(0, 10);
+                Slice<FeedDetailResponse> result = feedRepository.getMyPageFeedList(me, null, pageable);
+
+                // then
+                assertThat(result.getContent()).hasSize(2);
+                assertThat(result.getContent())
+                        .extracting("feedContent")
+                        .containsExactly("My Feed 2", "My Feed 1"); // 최신순 정렬 확인
+                assertThat(result.getContent().stream()
+                        .allMatch(f -> f.getNickname().equals("me")))
+                        .isTrue(); // 작성자 필터링 확인
+            }
+        }
+
+        @Nested
+        @DisplayName("이전 피드 ID(prevFeedId)가 주어지면")
+        class Context_with_prev_feed_id {
+
+            @Test
+            @DisplayName("No-Offset 페이징을 적용하여 해당 ID보다 이전의 피드들을 반환한다")
+            void it_returns_feeds_older_than_prev_id() {
+                // given
+                Member me = createAndSaveMember("me");
+                FeedType type = createAndSaveFeedType("운동");
+
+                List<Long> ids = new ArrayList<>();
+                for (int i = 1; i <= 5; i++) {
+                    ids.add(createAndSaveFeed(me, type, "Feed " + i).getId());
+                }
+
+                flushAndClear();
+                Long cursorId = ids.get(3); // 4번째 피드 (ID가 생성 순서대로라고 가정 시)
+
+                // when (4번보다 작은 것 요청 -> 3, 2, 1 조회 예상)
+                Pageable pageable = PageRequest.of(0, 10);
+                Slice<FeedDetailResponse> result = feedRepository.getMyPageFeedList(me, cursorId, pageable);
+
+                // then
+                assertThat(result.getContent()).hasSize(3);
+                assertThat(result.getContent().get(0).getFeedId()).isLessThan(cursorId);
+            }
+        }
+
+        @Nested
+        @DisplayName("작성한 피드가 하나도 없는 회원을 조회하면")
+        class Context_with_no_feeds_member {
+
+            @Test
+            @DisplayName("빈 리스트를 반환하며 예외가 발생하지 않는다")
+            void it_returns_empty_slice() {
+                // given
+                Member me = createAndSaveMember("newbie");
+                flushAndClear();
+
+                // when
+                Slice<FeedDetailResponse> result = feedRepository.getMyPageFeedList(me, null, PageRequest.of(0, 10));
+
+                // then
+                assertThat(result.getContent()).isEmpty();
+                assertThat(result.hasNext()).isFalse();
+            }
+        }
+    }
+
     private Member createAndSaveMember(String nickname) {
         Member member = Member.builder()
                 .memberId(UUID.randomUUID()) // ID 직접 생성

--- a/src/test/java/com/project200/undabang/feed/service/impl/FeedQueryServiceImplTest.java
+++ b/src/test/java/com/project200/undabang/feed/service/impl/FeedQueryServiceImplTest.java
@@ -1,13 +1,16 @@
 package com.project200.undabang.feed.service.impl;
 
 import com.project200.undabang.common.context.UserContextHolder;
+import com.project200.undabang.common.entity.Picture;
 import com.project200.undabang.common.web.exception.CustomException;
 import com.project200.undabang.common.web.exception.ErrorCode;
 import com.project200.undabang.feed.dto.response.FeedDetailResponse;
 import com.project200.undabang.feed.dto.response.GetAllMemberFeedsResponse;
+import com.project200.undabang.feed.dto.response.GetMyPageFeedsResponse;
 import com.project200.undabang.feed.dto.response.GetSpecificFeedResponse;
 import com.project200.undabang.feed.repository.FeedRepository;
 import com.project200.undabang.member.entity.Member;
+import com.project200.undabang.member.entity.MemberPicture;
 import com.project200.undabang.member.repository.MemberRepository;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -238,6 +241,105 @@ class FeedQueryServiceImplTest {
         }
     }
 
+    @Nested
+    @DisplayName("getMyPageFeeds 메소드는")
+    class Describe_getMyPageFeeds {
+
+        @Nested
+        @DisplayName("유효한 회원 ID와 피드 목록이 존재하면")
+        class Context_with_valid_member_and_feeds {
+
+            @Test
+            @DisplayName("Fetch Join으로 회원 정보를 가져오고, 피드 목록과 결합된 응답을 반환한다")
+            void it_returns_combined_mypage_response() {
+                // given
+                UUID userId = UUID.randomUUID();
+                Pageable pageable = PageRequest.of(0, 10);
+
+                // 프로필 사진이 포함된 Mock Member
+                Member mockMember = createMockMemberWithProfile(userId);
+
+                // 피드 목록 Mock 데이터
+                FeedDetailResponse feedResponse = createMockFeedResponse(100L, "My Page Feed");
+                Slice<FeedDetailResponse> mockSlice = new SliceImpl<>(List.of(feedResponse), pageable, true);
+
+                try (MockedStatic<UserContextHolder> ignored = mockStatic(UserContextHolder.class)) {
+                    given(UserContextHolder.getUserId()).willReturn(userId);
+                    // findById가 아닌 findMemberWithProfileImage를 호출해야 함
+                    given(memberRepository.findMemberWithProfileImage(userId)).willReturn(Optional.of(mockMember));
+                    given(feedRepository.getMyPageFeedList(eq(mockMember), any(), eq(pageable))).willReturn(mockSlice);
+
+                    // when
+                    GetMyPageFeedsResponse result = feedQueryService.getMyPageFeeds(null, pageable);
+
+                    // then
+                    assertThat(result.getMemberId()).isEqualTo(userId);
+                    assertThat(result.getNickname()).isEqualTo("운동하는개발자");
+                    assertThat(result.getProfileUrl()).isEqualTo("https://example.com/profile.jpg"); // Optional 체이닝 결과
+                    assertThat(result.getFeeds()).hasSize(1);
+                    assertThat(result.isHasNext()).isTrue();
+
+                    verify(memberRepository).findMemberWithProfileImage(userId);
+                    verify(feedRepository).getMyPageFeedList(mockMember, null, pageable);
+                }
+            }
+        }
+
+        @Nested
+        @DisplayName("회원의 프로필 사진 정보가 없는 경우")
+        class Context_with_member_no_profile_picture {
+
+            @Test
+            @DisplayName("프로필 관련 URL들을 null로 설정하여 안전하게 응답을 반환한다")
+            void it_returns_response_with_null_urls() {
+                // given
+                UUID userId = UUID.randomUUID();
+                Member memberNoPic = Member.builder()
+                        .memberId(userId)
+                        .memberNickname("사진없는유저")
+                        .build(); // memberPicture가 null인 상태
+
+                Slice<FeedDetailResponse> emptySlice = new SliceImpl<>(List.of(), PageRequest.of(0, 10), false);
+
+                try (MockedStatic<UserContextHolder> ignored = mockStatic(UserContextHolder.class)) {
+                    given(UserContextHolder.getUserId()).willReturn(userId);
+                    given(memberRepository.findMemberWithProfileImage(userId)).willReturn(Optional.of(memberNoPic));
+                    given(feedRepository.getMyPageFeedList(any(), any(), any())).willReturn(emptySlice);
+
+                    // when
+                    GetMyPageFeedsResponse result = feedQueryService.getMyPageFeeds(null, PageRequest.of(0, 10));
+
+                    // then
+                    assertThat(result.getThumbnailUrl()).isNull();
+                    assertThat(result.getProfileUrl()).isNull();
+                    assertThat(result.getNickname()).isEqualTo("사진없는유저");
+                }
+            }
+        }
+
+        @Nested
+        @DisplayName("존재하지 않는 회원 ID가 주어지면")
+        class Context_with_non_existing_member {
+
+            @Test
+            @DisplayName("MEMBER_NOT_FOUND 예외를 던진다")
+            void it_throws_member_not_found_exception() {
+                // given
+                UUID userId = UUID.randomUUID();
+
+                try (MockedStatic<UserContextHolder> ignored = mockStatic(UserContextHolder.class)) {
+                    given(UserContextHolder.getUserId()).willReturn(userId);
+                    given(memberRepository.findMemberWithProfileImage(userId)).willReturn(Optional.empty());
+
+                    // when & then
+                    assertThatThrownBy(() -> feedQueryService.getMyPageFeeds(null, PageRequest.of(0, 10)))
+                            .isInstanceOf(CustomException.class)
+                            .hasFieldOrPropertyWithValue("errorCode", ErrorCode.MEMBER_NOT_FOUND);
+                }
+            }
+        }
+    }
+
     private Member createMockMember(UUID memberId) {
         return Member.builder()
                 .memberId(memberId)
@@ -248,6 +350,23 @@ class FeedQueryServiceImplTest {
         return FeedDetailResponse.builder()
                 .feedId(feedId)
                 .feedContent(content)
+                .build();
+    }
+
+    private Member createMockMemberWithProfile(UUID userId) {
+        Picture picture = Picture.builder()
+                .pictureUrl("https://example.com/profile.jpg")
+                .build();
+
+        MemberPicture memberPicture = MemberPicture.builder()
+                .memberPicturesUrl("https://example.com/thumb.jpg")
+                .picture(picture)
+                .build();
+
+        return Member.builder()
+                .memberId(userId)
+                .memberNickname("운동하는개발자")
+                .memberPicture(memberPicture)
                 .build();
     }
 }


### PR DESCRIPTION
## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

마이페이지에서 회원이 작성한 피드의 목록을 보는 기능을 개발하였습니다.

커밋 a7aec3ed5a3443249acde8d593289d0c5249b69e 에서 FeedRepository를 리팩토링하였습니다.
getFeedDetailSlice 라는 메소드를 개발하여, 파라미터로 전달되는 BooleanExpression 조건에 따라 회원 정보와 피드 정보를 Slice<>로 가져올 때, 조건이 없으면 전체 피드 조회, "회원이 작성한 피드" 라는 조건이 있으면 자신이 작성한 피드 조회 기능을 반환하도록 개발하였습니다.

테스트 커버리지는 100%을 유지하였습니다.

### 스크린샷 (선택)
**API 응답 사진:** (API 응답 스크린샷을 첨부해주세요.)
<img width="897" height="398" alt="image" src="https://github.com/user-attachments/assets/21197d34-4d35-43cd-9719-1e9b66e837ca" />

**API 명세서 사진:** (API 명세서 스크린샷을 첨부해주세요.)
<img width="1011" height="654" alt="image" src="https://github.com/user-attachments/assets/14e3c330-f352-47e0-adaa-c5bf4805e91a" />
<img width="1005" height="212" alt="image" src="https://github.com/user-attachments/assets/c414a082-c397-4fcd-84c5-3b7b23ca2027" />
<img width="1002" height="710" alt="image" src="https://github.com/user-attachments/assets/ab7bf69a-6c2d-4eb3-9cfe-8f23afe890a5" />
<img width="1026" height="798" alt="image" src="https://github.com/user-attachments/assets/c2f48bdf-6b29-4953-834c-2fcc5432bc3f" />
<img width="1004" height="790" alt="image" src="https://github.com/user-attachments/assets/17354151-3fb8-4d7a-b593-9589b9098f3f" />
<img width="1018" height="794" alt="image" src="https://github.com/user-attachments/assets/a570483c-9985-44b6-83af-ee4d89893bfe" />
<img width="1004" height="685" alt="image" src="https://github.com/user-attachments/assets/9e3cf739-5ad6-4b03-af43-3ca8dd37f445" />
<img width="1019" height="267" alt="image" src="https://github.com/user-attachments/assets/74fafcb4-dfc0-402a-9879-3087a672c690" />

**테스트 커버리지 사진:** (테스트 커버리지 스크린샷을 첨부해주세요.)
<img width="806" height="108" alt="image" src="https://github.com/user-attachments/assets/ac767afb-6ae0-4ba1-a48e-87879b0605a3" />


Closes #506 
