### PR TITLE
[Feat] 피드 내용 수정 기능 개발 [0.11.8]

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ plugins {
 }
 
 group = 'com.project200'
-version = '0.11.4-SNAPSHOT'
+version = '0.11.8-SNAPSHOT'
 
 java {
     toolchain {

--- a/src/docs/asciidoc/feed/피드-수정-API.adoc
+++ b/src/docs/asciidoc/feed/피드-수정-API.adoc
@@ -1,0 +1,36 @@
+== 피드 수정 API
+
+=== 설명
+
+- #PATCH# `/api/v1/feeds/{feedId}`
+- 회원이 작성한 피드를 수정하는 API 입니다.
+- 요청시 피드 내용은 필수로 입력받으며, 피드 게시판 내용을 제거하고 싶은경우 요청 본문에 피드 게시판 식별자를 입력하지 않으면 자동으로 게시판 내용이 삭제되도록 하였습니다.
+
+=== 개발 이력
+
+- Sprint 23 (2026-01-30): 기능 개발이 완료되었습니다.
+
+=== 개발 참고 사항
+
+- <<공통-개발-참고-사항,공통 개발 참고 사항>>을 참고하세요.
+
+=== 코드 샘플
+
+operation::update-member-feed/update-member-feed_-success[snippets="curl-request,http-request,http-response"]
+
+=== 매개 변수
+
+operation::update-member-feed/update-member-feed_-success[snippets="request-headers,path-parameters,response-fields"]
+
+==== 응답 상태 코드
+
+|===
+|상태 코드|설명
+|200|요청이 성공적으로 처리되었습니다.
+|400|요청 본문을 읽을 수 없거나 형식이 올바르지 않습니다.
+|401|인증되지 않은 요청입니다. Access Token이 없거나 유효하지 않습니다
+|404|존재하지 않는 회원입니다. +
+존재하지 않는 피드 타입 입니다. +
+존재하지 않는 피드 입니다.
+|===
+

--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -254,3 +254,5 @@ include::overview/공통-개발-참고-사항.adoc[]
 - 마이페이지에서 내가 작성한 피드 목록 조회 API #GET# `/api/v1/mypage/feeds`
 
 - 피드 생성 API #POST# `/api/v1/feeds`
+
+- 피드 수정 API #PATCH# `/api/v1/feeds/{feedId}`

--- a/src/docs/asciidoc/피드-API.adoc
+++ b/src/docs/asciidoc/피드-API.adoc
@@ -26,3 +26,5 @@ include::feed/특정-피드-상세-조회-API.adoc[]
 include::feed/마이페이지-내가-작성한-피드-목록-조회-API.adoc[]
 
 include::feed/피드-생성-API.adoc[]
+
+include::feed/피드-수정-API.adoc[]

--- a/src/main/java/com/project200/undabang/feed/controller/FeedCommandController.java
+++ b/src/main/java/com/project200/undabang/feed/controller/FeedCommandController.java
@@ -2,16 +2,15 @@ package com.project200.undabang.feed.controller;
 
 import com.project200.undabang.common.web.response.CommonResponse;
 import com.project200.undabang.feed.dto.request.CreateFeedRequest;
+import com.project200.undabang.feed.dto.request.UpdateFeedRequest;
 import com.project200.undabang.feed.dto.response.CreateFeedResponse;
+import com.project200.undabang.feed.dto.response.UpdateFeedResponse;
 import com.project200.undabang.feed.service.FeedCommandService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
@@ -27,5 +26,16 @@ public class FeedCommandController {
     public ResponseEntity<CommonResponse<CreateFeedResponse>> createMemberFeed(@Valid @RequestBody CreateFeedRequest request) {
 
         return ResponseEntity.status(HttpStatus.CREATED).body(CommonResponse.create(feedCommandService.createMemberFeed(request)));
+    }
+
+    /**
+     * 특정 피드의 정보를 업데이트합니다.
+     * 피드 ID에 해당하는 리소스를 찾아 사용자가 제공한 요청 데이터를 기반으로 수정합니다.
+     */
+    @PatchMapping("/v1/feeds/{feedId}")
+    public ResponseEntity<CommonResponse<UpdateFeedResponse>> updateMemberFeed(@PathVariable Long feedId,
+                                                                               @Valid @RequestBody UpdateFeedRequest request) {
+
+        return ResponseEntity.ok(CommonResponse.update(feedCommandService.updateMemberFeed(feedId, request)));
     }
 }

--- a/src/main/java/com/project200/undabang/feed/dto/request/UpdateFeedRequest.java
+++ b/src/main/java/com/project200/undabang/feed/dto/request/UpdateFeedRequest.java
@@ -8,7 +8,7 @@ import lombok.NoArgsConstructor;
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor
-public class CreateFeedRequest {
+public class UpdateFeedRequest {
     @NotBlank(message = "피드 내용을 입력해주세요.")
     private String feedContent;
     private Long feedTypeId;

--- a/src/main/java/com/project200/undabang/feed/dto/response/UpdateFeedResponse.java
+++ b/src/main/java/com/project200/undabang/feed/dto/response/UpdateFeedResponse.java
@@ -1,0 +1,42 @@
+package com.project200.undabang.feed.dto.response;
+
+import com.project200.undabang.feed.entity.Feed;
+import com.project200.undabang.feed.entity.FeedType;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.Optional;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class UpdateFeedResponse {
+    private long feedId;
+    private String feedContent;
+    private Integer feedLikesCount;
+    private Integer feedCommentsCount;
+    private Long feedTypeId;
+    private String feedTypeName;
+    private String feedTypeDesc;
+
+    public static UpdateFeedResponse of(Feed feed) {
+        Optional<FeedType> optionalFeedType = Optional.ofNullable(feed.getFeedType());
+
+        Long feedTypeId = optionalFeedType.map(FeedType::getFeedTypeId).orElse(null);
+        String feedTypeName = optionalFeedType.map(FeedType::getFeedTypeName).orElse(null);
+        String feedTypeDesc = optionalFeedType.map(FeedType::getFeedTypeDesc).orElse(null);
+
+        return UpdateFeedResponse.builder()
+                .feedId(feed.getId())
+                .feedContent(feed.getFeedContent())
+                .feedLikesCount(feed.getLikesCount())
+                .feedCommentsCount(feed.getCommentsCount())
+                .feedTypeId(feedTypeId)
+                .feedTypeName(feedTypeName)
+                .feedTypeDesc(feedTypeDesc)
+                .build();
+    }
+}

--- a/src/main/java/com/project200/undabang/feed/entity/Feed.java
+++ b/src/main/java/com/project200/undabang/feed/entity/Feed.java
@@ -67,4 +67,10 @@ public class Feed {
                 .createdAt(LocalDateTime.now())
                 .build();
     }
+
+    public void update(String feedContent, FeedType feedType) {
+        this.feedContent = feedContent;
+        this.feedType = feedType;
+        this.updatedAt = LocalDateTime.now();
+    }
 }

--- a/src/main/java/com/project200/undabang/feed/repository/FeedRepository.java
+++ b/src/main/java/com/project200/undabang/feed/repository/FeedRepository.java
@@ -1,7 +1,11 @@
 package com.project200.undabang.feed.repository;
 
 import com.project200.undabang.feed.entity.Feed;
+import com.project200.undabang.member.entity.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface FeedRepository extends JpaRepository<Feed, Long>, FeedRepositoryCustom {
+    Optional<Feed> findByIdAndMemberAndDeletedAtNull(Long id, Member member);
 }

--- a/src/main/java/com/project200/undabang/feed/repository/FeedRepositoryCustom.java
+++ b/src/main/java/com/project200/undabang/feed/repository/FeedRepositoryCustom.java
@@ -11,6 +11,5 @@ import java.util.Optional;
 public interface FeedRepositoryCustom {
     Slice<FeedDetailResponse> getAllFeedList(Member currentMember, Long prevFeedId, Pageable pageable);
     Optional<GetSpecificFeedResponse> getSpecificFeed(Member currentMember, Long feedId);
-
     Slice<FeedDetailResponse> getMyPageFeedList(Member currentMember, Long prevFeedId, Pageable pageable);
 }

--- a/src/main/java/com/project200/undabang/feed/repository/impl/FeedRepositoryImpl.java
+++ b/src/main/java/com/project200/undabang/feed/repository/impl/FeedRepositoryImpl.java
@@ -118,9 +118,9 @@ public class FeedRepositoryImpl implements FeedRepositoryCustom {
      * 주어진 조건을 기반으로 피드 상세 정보를 페이징 처리하여 반환합니다.
      *
      * @param currentMember 현재 요청을 보낸 회원의 정보
-     * @param prevFeedId 이전에 조회한 마지막 피드의 ID
-     * @param pageable 페이징 정보를 담고 있는 객체
-     * @param condition 추가로 적용할 조건식
+     * @param prevFeedId    이전에 조회한 마지막 피드의 ID
+     * @param pageable      페이징 정보를 담고 있는 객체
+     * @param condition     추가로 적용할 조건식
      * @return 특정 조건과 페이징 정보를 기반으로 필터링된 피드 상세 응답의 슬라이스
      */
     private Slice<FeedDetailResponse> getFeedDetailSlice(Member currentMember, Long prevFeedId, Pageable pageable, BooleanExpression condition) {

--- a/src/main/java/com/project200/undabang/feed/service/FeedCommandService.java
+++ b/src/main/java/com/project200/undabang/feed/service/FeedCommandService.java
@@ -1,8 +1,12 @@
 package com.project200.undabang.feed.service;
 
 import com.project200.undabang.feed.dto.request.CreateFeedRequest;
+import com.project200.undabang.feed.dto.request.UpdateFeedRequest;
 import com.project200.undabang.feed.dto.response.CreateFeedResponse;
+import com.project200.undabang.feed.dto.response.UpdateFeedResponse;
 
 public interface FeedCommandService {
     CreateFeedResponse createMemberFeed(CreateFeedRequest request);
+
+    UpdateFeedResponse updateMemberFeed(Long feedId, UpdateFeedRequest request);
 }

--- a/src/main/java/com/project200/undabang/feed/service/impl/FeedCommandServiceImpl.java
+++ b/src/main/java/com/project200/undabang/feed/service/impl/FeedCommandServiceImpl.java
@@ -4,7 +4,9 @@ import com.project200.undabang.common.context.UserContextHolder;
 import com.project200.undabang.common.web.exception.CustomException;
 import com.project200.undabang.common.web.exception.ErrorCode;
 import com.project200.undabang.feed.dto.request.CreateFeedRequest;
+import com.project200.undabang.feed.dto.request.UpdateFeedRequest;
 import com.project200.undabang.feed.dto.response.CreateFeedResponse;
+import com.project200.undabang.feed.dto.response.UpdateFeedResponse;
 import com.project200.undabang.feed.entity.Feed;
 import com.project200.undabang.feed.entity.FeedType;
 import com.project200.undabang.feed.repository.FeedRepository;
@@ -27,30 +29,57 @@ public class FeedCommandServiceImpl implements FeedCommandService {
     private final MemberRepository memberRepository;
 
     /**
+     * 주어진 피드 ID와 업데이트 요청 정보를 바탕으로 피드 정보를 수정합니다.
+     */
+    @Override
+    public UpdateFeedResponse updateMemberFeed(Long feedId, UpdateFeedRequest request) {
+        Member member = getMember(UserContextHolder.getUserId());
+
+        Feed feed = getFeed(feedId, member);
+        FeedType feedType = getFeedType(request.getFeedTypeId());
+
+        feed.update(request.getFeedContent(), feedType);
+
+        return UpdateFeedResponse.of(feed);
+    }
+
+    /**
      * 주어진 요청 정보를 바탕으로 새 피드를 생성합니다.
      */
     @Override
     public CreateFeedResponse createMemberFeed(CreateFeedRequest request) {
         Member member = getMember(UserContextHolder.getUserId());
 
-        FeedType feedType = null;
-
-        if (request.getFeedTypeId() != null) {
-            feedType = feedTypeRepository.findById(request.getFeedTypeId()).orElseThrow(() -> new CustomException(ErrorCode.FEED_TYPE_NOT_FOUND));
-        }
-
+        FeedType feedType = getFeedType(request.getFeedTypeId());
         Feed savedFeed = feedRepository.save(Feed.create(member, request.getFeedContent(), feedType));
 
         return CreateFeedResponse.of(savedFeed);
     }
 
     /**
+     * 주어진 피드 ID를 기준으로 피드 정보를 조회합니다.
+     * 피드가 존재하지 않을 경우 예외를 발생시킵니다.
+     */
+    private Feed getFeed(Long feedId, Member member) {
+        return feedRepository.findByIdAndMemberAndDeletedAtNull(feedId, member).orElseThrow(() -> new CustomException(ErrorCode.FEED_NOT_FOUND));
+    }
+
+    /**
+     * 주어진 feedTypeId를 이용하여 FeedType 엔티티를 조회합니다.
+     * feedTypeId가 null인 경우 null을 반환하며, 조회 실패 시 예외를 발생시킵니다.
+     */
+    private FeedType getFeedType(Long feedTypeId) {
+        if (feedTypeId == null) {
+            return null;
+        }
+
+        return feedTypeRepository.findById(feedTypeId)
+                .orElseThrow(() -> new CustomException(ErrorCode.FEED_TYPE_NOT_FOUND));
+    }
+
+    /**
      * 주어진 회원 ID를 기반으로 회원 정보를 조회합니다.
      * 회원이 존재하지 않을 경우 예외를 발생시킵니다.
-     *
-     * @param memberId 조회할 회원의 UUID
-     * @return 조회된 회원 엔티티
-     * @throws CustomException 회원 정보를 찾을 수 없을 때 발생
      */
     private Member getMember(UUID memberId) {
         return memberRepository.findById(memberId).orElseThrow(() -> new CustomException(ErrorCode.MEMBER_NOT_FOUND));

--- a/src/test/java/com/project200/undabang/feed/controller/FeedCommandControllerTest.java
+++ b/src/test/java/com/project200/undabang/feed/controller/FeedCommandControllerTest.java
@@ -2,27 +2,35 @@ package com.project200.undabang.feed.controller;
 
 import com.project200.undabang.configuration.AbstractRestDocSupport;
 import com.project200.undabang.feed.dto.request.CreateFeedRequest;
+import com.project200.undabang.feed.dto.request.UpdateFeedRequest;
 import com.project200.undabang.feed.dto.response.CreateFeedResponse;
+import com.project200.undabang.feed.dto.response.UpdateFeedResponse;
 import com.project200.undabang.feed.service.FeedCommandService;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.http.MediaType;
+import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders;
+import org.springframework.restdocs.payload.JsonFieldType;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 import java.util.UUID;
 
 import static com.networknt.schema.JsonType.NUMBER;
 import static com.networknt.schema.JsonType.STRING;
+import static com.project200.undabang.configuration.DocumentFormatGenerator.getTypeFormat;
 import static com.project200.undabang.configuration.HeadersGenerator.getCommonApiHeaders;
 import static com.project200.undabang.configuration.RestDocsUtils.HEADER_ACCESS_TOKEN;
 import static com.project200.undabang.configuration.RestDocsUtils.commonResponseFields;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.verify;
 import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
 import static org.springframework.restdocs.payload.PayloadDocumentation.*;
+import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
+import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -32,6 +40,68 @@ class FeedCommandControllerTest extends AbstractRestDocSupport {
 
     @MockitoBean
     private FeedCommandService feedCommandService;
+
+    @Nested
+    @DisplayName("updateMemberFeed 메소드는")
+    class UpdateMemberFeed {
+
+        @Test
+        @DisplayName("피드 수정 요청이 유효하면 200 상태코드와 수정된 정보를 반환한다")
+        void updateMemberFeed_Success() throws Exception {
+            // given
+            UUID memberId = UUID.randomUUID();
+            Long feedId = 100L;
+            UpdateFeedRequest request = new UpdateFeedRequest("오늘도 러닝 완료! 수정합니다.", 2L);
+
+            UpdateFeedResponse response = UpdateFeedResponse.builder()
+                    .feedId(feedId)
+                    .feedContent("오늘도 러닝 완료! 수정합니다.")
+                    .feedLikesCount(10)
+                    .feedCommentsCount(2)
+                    .feedTypeId(2L)
+                    .feedTypeName("러닝다방")
+                    .feedTypeDesc("러닝을 즐기는 사람들의 공간")
+                    .build();
+
+            given(feedCommandService.updateMemberFeed(eq(feedId), any(UpdateFeedRequest.class)))
+                    .willReturn(response);
+
+            // when & then
+            mockMvc.perform(RestDocumentationRequestBuilders.patch("/api/v1/feeds/{feedId}", feedId)
+                            .content(objectMapper.writeValueAsString(request))
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .accept(MediaType.APPLICATION_JSON)
+                            .headers(getCommonApiHeaders(memberId)))
+                    .andExpectAll(
+                            status().isOk(),
+                            jsonPath("$.succeed").value(true),
+                            jsonPath("$.data.feedId").value(feedId),
+                            jsonPath("$.data.feedContent").value("오늘도 러닝 완료! 수정합니다."),
+                            jsonPath("$.data.feedTypeName").value("러닝다방")
+                    )
+                    .andDo(document.document(
+                            requestHeaders(HEADER_ACCESS_TOKEN),
+                            pathParameters(
+                                    parameterWithName("feedId").attributes(getTypeFormat(JsonFieldType.NUMBER)).description("수정할 피드의 고유 식별자입니다.")
+                            ),
+                            requestFields(
+                                    fieldWithPath("feedContent").type(STRING).description("수정할 피드의 본문 내용입니다."),
+                                    fieldWithPath("feedTypeId").type(NUMBER).description("변경할 피드 타입 식별자입니다. 카테고리를 유지하거나 변경할 때 사용하며, null을 보내면 카테고리가 해제됩니다.").optional()
+                            ),
+                            responseFields(commonResponseFields(
+                                    fieldWithPath("data.feedId").type(NUMBER).description("수정된 피드의 식별자입니다."),
+                                    fieldWithPath("data.feedContent").type(STRING).description("수정된 피드의 본문 내용입니다."),
+                                    fieldWithPath("data.feedLikesCount").type(NUMBER).description("수정된 피드의 현재 좋아요 수입니다."),
+                                    fieldWithPath("data.feedCommentsCount").type(NUMBER).description("수정된 피드의 현재 댓글 수입니다."),
+                                    fieldWithPath("data.feedTypeId").type(NUMBER).description("수정된 피드 타입 식별자입니다.").optional(),
+                                    fieldWithPath("data.feedTypeName").type(STRING).description("수정된 피드 타입 이름입니다.").optional(),
+                                    fieldWithPath("data.feedTypeDesc").type(STRING).description("수정된 피드 타입 설명입니다.").optional()
+                            ))
+                    ));
+
+            verify(feedCommandService).updateMemberFeed(eq(feedId), any(UpdateFeedRequest.class));
+        }
+    }
 
     @Nested
     @DisplayName("POST /api/v1/feeds API는")

--- a/src/test/java/com/project200/undabang/feed/repository/FeedRepositoryTest.java
+++ b/src/test/java/com/project200/undabang/feed/repository/FeedRepositoryTest.java
@@ -1,0 +1,108 @@
+package com.project200.undabang.feed.repository;
+
+import com.project200.undabang.configuration.TestQuerydslConfig;
+import com.project200.undabang.feed.entity.Feed;
+import com.project200.undabang.member.entity.Member;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+import org.springframework.context.annotation.Import;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DataJpaTest
+@Import(TestQuerydslConfig.class)
+class FeedRepositoryTest {
+
+    @Autowired
+    private FeedRepository feedRepository;
+
+    @Autowired
+    private TestEntityManager em;
+
+    @Nested
+    @DisplayName("findByIdAndMemberAndDeletedAtNull 메소드는")
+    class Describe_findByIdAndMemberAndDeletedAtNull {
+
+        @Nested
+        @DisplayName("본인이 작성하고 삭제되지 않은 피드 ID가 주어지면")
+        class Context_with_valid_my_feed {
+
+            @Test
+            @DisplayName("해당 피드 엔티티를 Optional로 반환한다")
+            void it_returns_optional_feed() {
+                // given
+                Member member = persistMember();
+                Feed myFeed = persistFeed(member, "내 피드 내용");
+
+                // when
+                Optional<Feed> result = feedRepository.findByIdAndMemberAndDeletedAtNull(myFeed.getId(), member);
+
+                // then
+                assertThat(result).isPresent();
+                assertThat(result.get().getFeedContent()).isEqualTo("내 피드 내용");
+            }
+        }
+
+        @Nested
+        @DisplayName("삭제된 피드(deletedAt이 null이 아님) ID가 주어지면")
+        class Context_with_deleted_feed {
+
+            @Test
+            @DisplayName("빈 Optional을 반환한다")
+            void it_returns_empty_optional() {
+                // given
+                Member member = persistMember();
+                // 헬퍼 메서드를 통해 삭제된 피드 생성
+                Feed deletedFeed = persistDeletedFeed(member, "삭제된 글");
+
+                // when
+                Optional<Feed> result = feedRepository.findByIdAndMemberAndDeletedAtNull(deletedFeed.getId(), member);
+
+                // then
+                assertThat(result).isEmpty();
+            }
+        }
+    }
+
+    private Member persistMember() {
+        Member member = Member.builder()
+                .memberId(UUID.randomUUID())
+                .memberEmail(UUID.randomUUID() + "@test.com")
+                .memberNickname("유저_" + UUID.randomUUID().toString().substring(0, 5))
+                .memberBday(LocalDate.of(1995, 1, 1))
+                .build();
+        return em.persist(member);
+    }
+
+    private Feed persistFeed(Member member, String content) {
+        Feed feed = Feed.builder()
+                .member(member)
+                .feedContent(content)
+                .createdAt(LocalDateTime.now())
+                .likesCount(0)
+                .commentsCount(0)
+                .build();
+        return em.persist(feed);
+    }
+
+    private Feed persistDeletedFeed(Member member, String content) {
+        Feed feed = Feed.builder()
+                .member(member)
+                .feedContent(content)
+                .createdAt(LocalDateTime.now())
+                .deletedAt(LocalDateTime.now())
+                .likesCount(0)
+                .commentsCount(0)
+                .build();
+        return em.persist(feed);
+    }
+}

--- a/src/test/java/com/project200/undabang/feed/service/impl/FeedCommandServiceImplTest.java
+++ b/src/test/java/com/project200/undabang/feed/service/impl/FeedCommandServiceImplTest.java
@@ -4,7 +4,9 @@ import com.project200.undabang.common.context.UserContextHolder;
 import com.project200.undabang.common.web.exception.CustomException;
 import com.project200.undabang.common.web.exception.ErrorCode;
 import com.project200.undabang.feed.dto.request.CreateFeedRequest;
+import com.project200.undabang.feed.dto.request.UpdateFeedRequest;
 import com.project200.undabang.feed.dto.response.CreateFeedResponse;
+import com.project200.undabang.feed.dto.response.UpdateFeedResponse;
 import com.project200.undabang.feed.entity.Feed;
 import com.project200.undabang.feed.entity.FeedType;
 import com.project200.undabang.feed.repository.FeedRepository;
@@ -31,7 +33,6 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.*;
-
 @ExtendWith(MockitoExtension.class)
 class FeedCommandServiceImplTest {
 
@@ -46,115 +47,203 @@ class FeedCommandServiceImplTest {
     private MemberRepository memberRepository;
 
     @Nested
-    @DisplayName("createMemberFeed 메소드는")
-    class Describe_createMemberFeed {
+    @DisplayName("updateMemberFeed 메소드는")
+    class Describe_updateMemberFeed {
 
-        @Nested
-        @DisplayName("유효한 요청 정보가 주어지면")
-        class Context_with_valid_request {
+        @Test
+        @DisplayName("유효한 수정 요청이 주어지면 피드 내용과 타입을 변경하고 응답을 반환한다")
+        void it_updates_feed_content_and_type() {
+            // given
+            UUID userId = UUID.randomUUID();
+            Long feedId = 100L;
+            Long newTypeId = 2L;
+            UpdateFeedRequest request = new UpdateFeedRequest("수정된 내용", newTypeId);
 
-            @Test
-            @DisplayName("피드를 생성하고 저장된 피드의 ID를 반환한다")
-            void it_saves_feed_and_returns_id() {
-                // given
-                UUID userId = UUID.randomUUID();
-                Long feedTypeId = 1L;
-                CreateFeedRequest request = new CreateFeedRequest("운동 완료!", feedTypeId);
+            Member member = createMember(userId);
+            FeedType newType = createFeedType(newTypeId, "러닝다방");
+            Feed existingFeed = createFeed(feedId, member, createFeedType(1L, "수영다방"));
 
-                Member mockMember = createMember(userId);
-                FeedType mockType = createFeedType(feedTypeId);
-                Feed savedFeed = createFeedWithId(100L);
+            try (MockedStatic<UserContextHolder> ignored = mockStatic(UserContextHolder.class)) {
+                given(UserContextHolder.getUserId()).willReturn(userId);
+                given(memberRepository.findById(userId)).willReturn(Optional.of(member));
+                given(feedRepository.findByIdAndMemberAndDeletedAtNull(feedId, member)).willReturn(Optional.of(existingFeed));
+                given(feedTypeRepository.findById(newTypeId)).willReturn(Optional.of(newType));
 
-                try (MockedStatic<UserContextHolder> ignored = mockStatic(UserContextHolder.class)) {
-                    given(UserContextHolder.getUserId()).willReturn(userId);
-                    given(memberRepository.findById(userId)).willReturn(Optional.of(mockMember));
-                    given(feedTypeRepository.findById(feedTypeId)).willReturn(Optional.of(mockType));
-                    given(feedRepository.save(any(Feed.class))).willReturn(savedFeed);
+                // when
+                UpdateFeedResponse response = feedCommandService.updateMemberFeed(feedId, request);
 
-                    // when
-                    CreateFeedResponse result = feedCommandService.createMemberFeed(request);
-
-                    // then
-                    assertThat(result.getFeedId()).isEqualTo(100L);
-                    verify(feedRepository).save(any(Feed.class));
-                }
-            }
-
-            @Test
-            @DisplayName("피드 타입 ID가 없어도(null) 정상적으로 피드를 생성한다")
-            void it_saves_feed_without_type_when_id_is_null() {
-                // given
-                UUID userId = UUID.randomUUID();
-                CreateFeedRequest request = new CreateFeedRequest("카테고리 없는 글", null);
-
-                try (MockedStatic<UserContextHolder> ignored = mockStatic(UserContextHolder.class)) {
-                    given(UserContextHolder.getUserId()).willReturn(userId);
-                    given(memberRepository.findById(userId)).willReturn(Optional.of(createMember(userId)));
-                    given(feedRepository.save(any(Feed.class))).willReturn(createFeedWithId(101L));
-
-                    // when
-                    feedCommandService.createMemberFeed(request);
-
-                    // then
-                    verify(feedTypeRepository, never()).findById(any());
-                    verify(feedRepository).save(argThat(feed -> feed.getFeedType() == null));
-                }
+                // then
+                assertThat(response.getFeedContent()).isEqualTo("수정된 내용");
+                assertThat(response.getFeedTypeId()).isEqualTo(newTypeId);
+                assertThat(response.getFeedTypeName()).isEqualTo("러닝다방");
             }
         }
 
-        @Nested
-        @DisplayName("존재하지 않는 회원 ID가 주어지면")
-        class Context_when_member_not_found {
+        @Test
+        @DisplayName("피드 타입 ID가 null이면 카테고리를 null로 업데이트한다")
+        void it_updates_feed_and_removes_type() {
+            // given
+            UUID userId = UUID.randomUUID();
+            Long feedId = 100L;
+            UpdateFeedRequest request = new UpdateFeedRequest("내용만 수정", null);
 
-            @Test
-            @DisplayName("MEMBER_NOT_FOUND 예외를 던진다")
-            void it_throws_member_not_found_exception() {
-                // given
-                UUID userId = UUID.randomUUID();
-                CreateFeedRequest request = new CreateFeedRequest("내용", null);
+            Member member = createMember(userId);
+            Feed existingFeed = createFeed(feedId, member, createFeedType(1L, "기존타입"));
 
-                try (MockedStatic<UserContextHolder> ignored = mockStatic(UserContextHolder.class)) {
-                    given(UserContextHolder.getUserId()).willReturn(userId);
-                    given(memberRepository.findById(userId)).willReturn(Optional.empty());
+            try (MockedStatic<UserContextHolder> ignored = mockStatic(UserContextHolder.class)) {
+                given(UserContextHolder.getUserId()).willReturn(userId);
+                given(memberRepository.findById(userId)).willReturn(Optional.of(member));
+                given(feedRepository.findByIdAndMemberAndDeletedAtNull(feedId, member)).willReturn(Optional.of(existingFeed));
 
-                    // when & then
-                    assertThatThrownBy(() -> feedCommandService.createMemberFeed(request))
-                            .isInstanceOf(CustomException.class)
-                            .hasFieldOrPropertyWithValue("errorCode", ErrorCode.MEMBER_NOT_FOUND);
-                }
+                // when
+                UpdateFeedResponse response = feedCommandService.updateMemberFeed(feedId, request);
+
+                // then
+                assertThat(response.getFeedTypeId()).isNull();
+                verify(feedTypeRepository, never()).findById(any());
             }
         }
 
-        @Nested
-        @DisplayName("피드 타입 ID가 존재하지만 실제 데이터가 없는 경우")
-        class Context_when_feed_type_not_found {
+        @Test
+        @DisplayName("존재하지 않는 회원 ID인 경우 MEMBER_NOT_FOUND 예외를 던든다")
+        void it_throws_member_not_found_when_updating() {
+            UUID userId = UUID.randomUUID();
+            try (MockedStatic<UserContextHolder> ignored = mockStatic(UserContextHolder.class)) {
+                given(UserContextHolder.getUserId()).willReturn(userId);
+                given(memberRepository.findById(userId)).willReturn(Optional.empty());
 
-            @Test
-            @DisplayName("FEED_TYPE_NOT_FOUND 예외를 던진다")
-            void it_throws_feed_type_not_found_exception() {
-                // given
-                UUID userId = UUID.randomUUID();
-                Long invalidTypeId = 999L;
-                CreateFeedRequest request = new CreateFeedRequest("내용", invalidTypeId);
+                assertThatThrownBy(() -> feedCommandService.updateMemberFeed(1L, new UpdateFeedRequest("내용", null)))
+                        .isInstanceOf(CustomException.class)
+                        .hasFieldOrPropertyWithValue("errorCode", ErrorCode.MEMBER_NOT_FOUND);
+            }
+        }
 
-                try (MockedStatic<UserContextHolder> ignored = mockStatic(UserContextHolder.class)) {
-                    given(UserContextHolder.getUserId()).willReturn(userId);
-                    given(memberRepository.findById(userId)).willReturn(Optional.of(createMember(userId)));
-                    given(feedTypeRepository.findById(invalidTypeId)).willReturn(Optional.empty());
+        @Test
+        @DisplayName("자신의 피드가 아니거나 삭제된 경우 FEED_NOT_FOUND 예외를 던진다")
+        void it_throws_feed_not_found_when_updating() {
+            UUID userId = UUID.randomUUID();
+            Member member = createMember(userId);
+            try (MockedStatic<UserContextHolder> ignored = mockStatic(UserContextHolder.class)) {
+                given(UserContextHolder.getUserId()).willReturn(userId);
+                given(memberRepository.findById(userId)).willReturn(Optional.of(member));
+                given(feedRepository.findByIdAndMemberAndDeletedAtNull(anyLong(), eq(member))).willReturn(Optional.empty());
 
-                    // when & then
-                    assertThatThrownBy(() -> feedCommandService.createMemberFeed(request))
-                            .isInstanceOf(CustomException.class)
-                            .hasFieldOrPropertyWithValue("errorCode", ErrorCode.FEED_TYPE_NOT_FOUND);
-                }
+                assertThatThrownBy(() -> feedCommandService.updateMemberFeed(999L, new UpdateFeedRequest("내용", null)))
+                        .isInstanceOf(CustomException.class)
+                        .hasFieldOrPropertyWithValue("errorCode", ErrorCode.FEED_NOT_FOUND);
+            }
+        }
+
+        @Test
+        @DisplayName("수정하려는 피드 타입이 존재하지 않으면 FEED_TYPE_NOT_FOUND 예외를 던진다")
+        void it_throws_feed_type_not_found_when_updating() {
+            UUID userId = UUID.randomUUID();
+            Long invalidTypeId = 999L;
+            Member member = createMember(userId);
+            Feed existingFeed = createFeed(1L, member, null);
+
+            try (MockedStatic<UserContextHolder> ignored = mockStatic(UserContextHolder.class)) {
+                given(UserContextHolder.getUserId()).willReturn(userId);
+                given(memberRepository.findById(userId)).willReturn(Optional.of(member));
+                given(feedRepository.findByIdAndMemberAndDeletedAtNull(anyLong(), eq(member))).willReturn(Optional.of(existingFeed));
+                given(feedTypeRepository.findById(invalidTypeId)).willReturn(Optional.empty());
+
+                assertThatThrownBy(() -> feedCommandService.updateMemberFeed(1L, new UpdateFeedRequest("내용", invalidTypeId)))
+                        .isInstanceOf(CustomException.class)
+                        .hasFieldOrPropertyWithValue("errorCode", ErrorCode.FEED_TYPE_NOT_FOUND);
             }
         }
     }
 
+    @Nested
+    @DisplayName("createMemberFeed 메소드는")
+    class Describe_createMemberFeed {
+
+        @Test
+        @DisplayName("유효한 요청 정보가 주어지면 피드를 생성하고 ID를 반환한다")
+        void it_saves_feed_and_returns_id() {
+            // given
+            UUID userId = UUID.randomUUID();
+            Long feedTypeId = 1L;
+            CreateFeedRequest request = new CreateFeedRequest("운동 완료!", feedTypeId);
+
+            Member mockMember = createMember(userId);
+            FeedType mockType = createFeedType(feedTypeId, "카테고리");
+            Feed savedFeed = createFeed(100L, mockMember, mockType);
+
+            try (MockedStatic<UserContextHolder> ignored = mockStatic(UserContextHolder.class)) {
+                given(UserContextHolder.getUserId()).willReturn(userId);
+                given(memberRepository.findById(userId)).willReturn(Optional.of(mockMember));
+                given(feedTypeRepository.findById(feedTypeId)).willReturn(Optional.of(mockType));
+                given(feedRepository.save(any(Feed.class))).willReturn(savedFeed);
+
+                // when
+                CreateFeedResponse result = feedCommandService.createMemberFeed(request);
+
+                // then
+                assertThat(result.getFeedId()).isEqualTo(100L);
+                verify(feedRepository).save(any(Feed.class));
+            }
+        }
+
+        @Test
+        @DisplayName("피드 타입 ID가 null이어도 정상적으로 피드를 생성한다")
+        void it_saves_feed_without_type_when_id_is_null() {
+            // given
+            UUID userId = UUID.randomUUID();
+            CreateFeedRequest request = new CreateFeedRequest("카테고리 없는 글", null);
+
+            try (MockedStatic<UserContextHolder> ignored = mockStatic(UserContextHolder.class)) {
+                given(UserContextHolder.getUserId()).willReturn(userId);
+                given(memberRepository.findById(userId)).willReturn(Optional.of(createMember(userId)));
+                given(feedRepository.save(any(Feed.class))).willReturn(createFeed(101L, createMember(userId), null));
+
+                // when
+                feedCommandService.createMemberFeed(request);
+
+                // then
+                verify(feedTypeRepository, never()).findById(any());
+                verify(feedRepository).save(argThat(feed -> feed.getFeedType() == null));
+            }
+        }
+
+        @Test
+        @DisplayName("회원 ID가 존재하지 않으면 MEMBER_NOT_FOUND 예외를 던진다")
+        void it_throws_member_not_found_when_creating() {
+            UUID userId = UUID.randomUUID();
+            try (MockedStatic<UserContextHolder> ignored = mockStatic(UserContextHolder.class)) {
+                given(UserContextHolder.getUserId()).willReturn(userId);
+                given(memberRepository.findById(userId)).willReturn(Optional.empty());
+
+                assertThatThrownBy(() -> feedCommandService.createMemberFeed(new CreateFeedRequest("내용", null)))
+                        .isInstanceOf(CustomException.class)
+                        .hasFieldOrPropertyWithValue("errorCode", ErrorCode.MEMBER_NOT_FOUND);
+            }
+        }
+
+        @Test
+        @DisplayName("입력된 피드 타입이 존재하지 않으면 FEED_TYPE_NOT_FOUND 예외를 던진다")
+        void it_throws_feed_type_not_found_when_creating() {
+            UUID userId = UUID.randomUUID();
+            Long invalidTypeId = 999L;
+            try (MockedStatic<UserContextHolder> ignored = mockStatic(UserContextHolder.class)) {
+                given(UserContextHolder.getUserId()).willReturn(userId);
+                given(memberRepository.findById(userId)).willReturn(Optional.of(createMember(userId)));
+                given(feedTypeRepository.findById(invalidTypeId)).willReturn(Optional.empty());
+
+                assertThatThrownBy(() -> feedCommandService.createMemberFeed(new CreateFeedRequest("내용", invalidTypeId)))
+                        .isInstanceOf(CustomException.class)
+                        .hasFieldOrPropertyWithValue("errorCode", ErrorCode.FEED_TYPE_NOT_FOUND);
+            }
+        }
+    }
+
+    // --- Helper Methods ---
+
     private Member createMember(UUID userId) {
         return Member.builder()
                 .memberId(userId)
-                .memberEmail(userId.toString() + "@test.com")
+                .memberEmail(userId + "@test.com")
                 .memberNickname("테스터_" + userId.toString().substring(0, 8))
                 .memberGender(MemberGender.MALE)
                 .memberBday(LocalDate.of(1995, 1, 1))
@@ -164,27 +253,22 @@ class FeedCommandServiceImplTest {
                 .build();
     }
 
-    private FeedType createFeedType(Long typeId) {
+    private FeedType createFeedType(Long id, String name) {
         return FeedType.builder()
-                .feedTypeId(typeId)
-                .feedTypeName("테스트 카테고리")
-                .feedTypeDesc("테스트용 카테고리 설명입니다.")
+                .feedTypeId(id)
+                .feedTypeName(name)
+                .feedTypeDesc(name + " 설명")
                 .feedTypeIsActive(true)
                 .createdAt(LocalDateTime.now())
                 .build();
     }
 
-    private Feed createFeedWithId(Long feedId) {
-        Member dummyMember = Member.builder()
-                .memberId(UUID.randomUUID())
-                .memberEmail("author@test.com")
-                .memberNickname("작성자")
-                .build();
-
+    private Feed createFeed(Long id, Member member, FeedType type) {
         return Feed.builder()
-                .id(feedId)
-                .member(dummyMember)
-                .feedContent("테스트 피드 내용입니다.")
+                .id(id)
+                .member(member)
+                .feedType(type)
+                .feedContent("피드 내용")
                 .likesCount(0)
                 .commentsCount(0)
                 .createdAt(LocalDateTime.now())

--- a/src/test/java/com/project200/undabang/feed/service/impl/FeedCommandServiceImplTest.java
+++ b/src/test/java/com/project200/undabang/feed/service/impl/FeedCommandServiceImplTest.java
@@ -105,7 +105,7 @@ class FeedCommandServiceImplTest {
         }
 
         @Test
-        @DisplayName("존재하지 않는 회원 ID인 경우 MEMBER_NOT_FOUND 예외를 던든다")
+        @DisplayName("존재하지 않는 회원 ID인 경우 MEMBER_NOT_FOUND 예외를 던진다")
         void it_throws_member_not_found_when_updating() {
             UUID userId = UUID.randomUUID();
             try (MockedStatic<UserContextHolder> ignored = mockStatic(UserContextHolder.class)) {


### PR DESCRIPTION
## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

피드 내용 본문은 필수로 입력받고, 피드 타입 식별자를 입력받아서 피드 내용 및 게시판 내용을 수정하는 기능을 개발하였습니다.
피드 타입 식별자를 입력받지 않은 경우는 게시판을 제거하도록 설정하였습니다.

변경감지를 통해 엔티티 수정을 진행하였습니다.

또한 테스트코드는 100%를 유지하였습니다.

### 스크린샷 (선택)
**API 응답 사진:** (API 응답 스크린샷을 첨부해주세요.)
<img width="709" height="378" alt="image" src="https://github.com/user-attachments/assets/4a36a2ab-f32b-4c60-b983-26eb604f3cec" />

**API 명세서 사진:** (API 명세서 스크린샷을 첨부해주세요.)
<img width="1000" height="799" alt="image" src="https://github.com/user-attachments/assets/fb88a843-24fe-4f03-ba47-d658ed058997" />
<img width="991" height="341" alt="image" src="https://github.com/user-attachments/assets/2b174aa6-e568-4398-85f4-7a23a63ef222" />
<img width="1011" height="797" alt="image" src="https://github.com/user-attachments/assets/7e48ba74-0f3a-4bf4-bca8-21c0af802a09" />
<img width="1003" height="771" alt="image" src="https://github.com/user-attachments/assets/56073e9c-77f6-41d4-81ee-f65e623b3199" />
<img width="1004" height="685" alt="image" src="https://github.com/user-attachments/assets/4088aa62-6554-4ef2-9ccd-4aba3818800e" />
<img width="1078" height="359" alt="image" src="https://github.com/user-attachments/assets/39fc9cb9-99d5-4075-8f99-e09799840542" />

**테스트 커버리지 사진:** (테스트 커버리지 스크린샷을 첨부해주세요.)
<img width="800" height="129" alt="image" src="https://github.com/user-attachments/assets/310dc147-7fd8-4bf5-bb28-fa94053e0d68" />

Closes #502
