### PR TITLE
[Feat] 피드 내용 논리적 삭제 기능 추가 [0.11.9]

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ plugins {
 }
 
 group = 'com.project200'
-version = '0.11.8-SNAPSHOT'
+version = '0.11.9-SNAPSHOT'
 
 java {
     toolchain {

--- a/src/docs/asciidoc/feed/피드-삭제-API.adoc
+++ b/src/docs/asciidoc/feed/피드-삭제-API.adoc
@@ -1,0 +1,34 @@
+== 피드 삭제 API
+
+=== 설명
+
+- #DELETE# `/api/v1/feeds/{feedId}`
+- 회원이 작성한 피드를 삭제하는 API 입니다.
+
+=== 개발 이력
+
+- Sprint 23 (2026-01-30): 기능 개발이 완료되었습니다.
+
+=== 개발 참고 사항
+
+- <<공통-개발-참고-사항,공통 개발 참고 사항>>을 참고하세요.
+
+=== 코드 샘플
+
+operation::delete-member-feed/delete-member-feed_-success[snippets="curl-request,http-request,http-response"]
+
+=== 매개 변수
+
+operation::delete-member-feed/delete-member-feed_-success[snippets="request-headers,path-parameters,response-fields"]
+
+==== 응답 상태 코드
+
+|===
+|상태 코드|설명
+|200|요청이 성공적으로 처리되었습니다.
+|400|요청 본문을 읽을 수 없거나 형식이 올바르지 않습니다.
+|401|인증되지 않은 요청입니다. Access Token이 없거나 유효하지 않습니다
+|404|존재하지 않는 회원입니다. +
+존재하지 않는 피드 입니다.
+|===
+

--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -256,3 +256,5 @@ include::overview/공통-개발-참고-사항.adoc[]
 - 피드 생성 API #POST# `/api/v1/feeds`
 
 - 피드 수정 API #PATCH# `/api/v1/feeds/{feedId}`
+
+- 피드 삭제 API #DELETE# `/api/v1/feeds/{feedId}`

--- a/src/docs/asciidoc/피드-API.adoc
+++ b/src/docs/asciidoc/피드-API.adoc
@@ -28,3 +28,5 @@ include::feed/마이페이지-내가-작성한-피드-목록-조회-API.adoc[]
 include::feed/피드-생성-API.adoc[]
 
 include::feed/피드-수정-API.adoc[]
+
+include::feed/피드-삭제-API.adoc[]

--- a/src/main/java/com/project200/undabang/feed/controller/FeedCommandController.java
+++ b/src/main/java/com/project200/undabang/feed/controller/FeedCommandController.java
@@ -38,4 +38,13 @@ public class FeedCommandController {
 
         return ResponseEntity.ok(CommonResponse.update(feedCommandService.updateMemberFeed(feedId, request)));
     }
+
+    /**
+     * 주어진 피드 ID를 기반으로 특정 피드를 논리적으로 삭제합니다.
+     */
+    @DeleteMapping("/v1/feeds/{feedId}")
+    public ResponseEntity<CommonResponse<Void>> deleteMemberFeed(@PathVariable Long feedId) {
+
+        return ResponseEntity.ok(CommonResponse.delete(feedCommandService.deleteMemberFeed(feedId)));
+    }
 }

--- a/src/main/java/com/project200/undabang/feed/entity/Feed.java
+++ b/src/main/java/com/project200/undabang/feed/entity/Feed.java
@@ -73,4 +73,9 @@ public class Feed {
         this.feedType = feedType;
         this.updatedAt = LocalDateTime.now();
     }
+
+    public void delete() {
+        this.updatedAt = LocalDateTime.now();
+        this.deletedAt = LocalDateTime.now();
+    }
 }

--- a/src/main/java/com/project200/undabang/feed/repository/impl/FeedRepositoryImpl.java
+++ b/src/main/java/com/project200/undabang/feed/repository/impl/FeedRepositoryImpl.java
@@ -92,7 +92,10 @@ public class FeedRepositoryImpl implements FeedRepositoryCustom {
                 .leftJoin(member.memberPicture, memberPicture)
                 .leftJoin(memberPicture.picture, picture)
                 .leftJoin(feed.feedType, feedType)
-                .where(feed.id.eq(feedId)) // 특정 피드만 조회
+                .where(
+                        feed.id.eq(feedId),
+                        feed.deletedAt.isNull()
+                ) // 삭제되지 않은 특정 피드만 조회
                 .fetchOne();
 
         // 해당 피드 데이터가 없는 경우 Optional.empty()를 반환
@@ -107,7 +110,8 @@ public class FeedRepositoryImpl implements FeedRepositoryCustom {
                 .from(feedPicture)
                 .join(feedPicture.picture, picture)
                 .where(
-                        feedPicture.feed.id.eq(feedId)
+                        feedPicture.feed.id.eq(feedId),
+                        feedPicture.feed.deletedAt.isNull()
                 )
                 .fetch();
 
@@ -148,6 +152,7 @@ public class FeedRepositoryImpl implements FeedRepositoryCustom {
                 .leftJoin(feed.feedType, feedType)
                 .where(
                         olderThanPrevFeedId(prevFeedId),
+                        feed.deletedAt.isNull(),
                         condition
                 )
                 .orderBy(feed.id.desc()) // 최근 피드부터 읽기 (정확히는 최근에 작성된 피드가 생성도 늦게 되었다고 가정)
@@ -183,7 +188,10 @@ public class FeedRepositoryImpl implements FeedRepositoryCustom {
         return queryFactory
                 .from(feedPicture)
                 .join(feedPicture.picture, picture)
-                .where(feedPicture.feed.id.in(feedIdList))
+                .where(
+                        feedPicture.feed.id.in(feedIdList),
+                        feedPicture.feed.deletedAt.isNull()
+                )
                 .transform(GroupBy.groupBy(feedPicture.feed.id)
                         .as(GroupBy.list(Projections.constructor(FeedPictureRecord.class,
                                 feedPicture.id,

--- a/src/main/java/com/project200/undabang/feed/service/FeedCommandService.java
+++ b/src/main/java/com/project200/undabang/feed/service/FeedCommandService.java
@@ -7,6 +7,7 @@ import com.project200.undabang.feed.dto.response.UpdateFeedResponse;
 
 public interface FeedCommandService {
     CreateFeedResponse createMemberFeed(CreateFeedRequest request);
-
     UpdateFeedResponse updateMemberFeed(Long feedId, UpdateFeedRequest request);
+
+    Void deleteMemberFeed(Long feedId);
 }

--- a/src/main/java/com/project200/undabang/feed/service/impl/FeedCommandServiceImpl.java
+++ b/src/main/java/com/project200/undabang/feed/service/impl/FeedCommandServiceImpl.java
@@ -29,6 +29,19 @@ public class FeedCommandServiceImpl implements FeedCommandService {
     private final MemberRepository memberRepository;
 
     /**
+     * 주어진 피드 ID를 바탕으로 회원의 피드를 삭제합니다.
+     */
+    @Override
+    public Void deleteMemberFeed(Long feedId) {
+        Member member = getMember(UserContextHolder.getUserId());
+
+        Feed feed = getFeed(feedId, member);
+        feed.delete();
+
+        return null;
+    }
+
+    /**
      * 주어진 피드 ID와 업데이트 요청 정보를 바탕으로 피드 정보를 수정합니다.
      */
     @Override

--- a/src/test/java/com/project200/undabang/feed/controller/FeedCommandControllerTest.java
+++ b/src/test/java/com/project200/undabang/feed/controller/FeedCommandControllerTest.java
@@ -17,8 +17,7 @@ import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 import java.util.UUID;
 
-import static com.networknt.schema.JsonType.NUMBER;
-import static com.networknt.schema.JsonType.STRING;
+import static com.networknt.schema.JsonType.*;
 import static com.project200.undabang.configuration.DocumentFormatGenerator.getTypeFormat;
 import static com.project200.undabang.configuration.HeadersGenerator.getCommonApiHeaders;
 import static com.project200.undabang.configuration.RestDocsUtils.HEADER_ACCESS_TOKEN;
@@ -26,6 +25,7 @@ import static com.project200.undabang.configuration.RestDocsUtils.commonResponse
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.verify;
 import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
 import static org.springframework.restdocs.payload.PayloadDocumentation.*;
@@ -40,6 +40,47 @@ class FeedCommandControllerTest extends AbstractRestDocSupport {
 
     @MockitoBean
     private FeedCommandService feedCommandService;
+
+    @Nested
+    @DisplayName("deleteMemberFeed 메소드는")
+    class DeleteMemberFeed {
+
+        @Test
+        @DisplayName("피드 삭제 요청이 유효하면 200 상태코드와 성공 메시지를 반환한다")
+        void deleteMemberFeed_Success() throws Exception {
+            // given
+            UUID memberId = UUID.randomUUID();
+            Long feedId = 100L;
+
+            // 에러 해결: void 메서드는 doNothing()을 사용하거나 스터빙을 생략합니다.
+            doNothing().when(feedCommandService).deleteMemberFeed(feedId);
+
+            // when & then
+            mockMvc.perform(RestDocumentationRequestBuilders.delete("/api/v1/feeds/{feedId}", feedId)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .accept(MediaType.APPLICATION_JSON)
+                            .headers(getCommonApiHeaders(memberId)))
+                    .andExpectAll(
+                            status().isOk(),
+                            jsonPath("$.succeed").value(true)
+                    )
+                    .andDo(document.document(
+                            requestHeaders(HEADER_ACCESS_TOKEN),
+                            pathParameters(
+                                    parameterWithName("feedId").attributes(getTypeFormat(JsonFieldType.NUMBER)).description("삭제할 피드의 고유 식별자입니다.")
+                            ),
+                            responseFields(
+                                    fieldWithPath("succeed").type(BOOLEAN).description("요청 성공 여부입니다."),
+                                    fieldWithPath("code").type(STRING).description("응답 코드 정보 입니다."),
+                                    fieldWithPath("message").type(STRING).description("응답 메시지입니다."),
+                                    fieldWithPath("data").type(NULL).description("삭제 API는 반환 데이터가 없습니다.")
+                            )
+                    ));
+
+            // 호출 여부 검증
+            verify(feedCommandService).deleteMemberFeed(feedId);
+        }
+    }
 
     @Nested
     @DisplayName("updateMemberFeed 메소드는")

--- a/src/test/java/com/project200/undabang/feed/repository/impl/FeedRepositoryImplTest.java
+++ b/src/test/java/com/project200/undabang/feed/repository/impl/FeedRepositoryImplTest.java
@@ -50,6 +50,21 @@ class FeedRepositoryImplTest {
         @Nested
         @DisplayName("존재하는 피드 ID와 로그인한 사용자가 주어지면")
         class Context_with_existing_feed_and_login_user {
+            @Test
+            @DisplayName("피드가 존재하더라도 삭제된(deletedAt이 있는) 피드라면 Optional.empty()를 반환한다")
+            void it_returns_empty_optional_for_deleted_feed() {
+                // given
+                Member author = createAndSaveMember("author");
+                Feed feed = createAndSaveDeletedFeed(author, "삭제된 좀비 피드");
+
+                flushAndClear();
+
+                // when
+                Optional<GetSpecificFeedResponse> result = feedRepository.getSpecificFeed(null, feed.getId());
+
+                // then
+                assertThat(result).isEmpty();
+            }
 
             @Test
             @DisplayName("피드 상세 정보, 사진 목록, 좋아요/댓글 여부를 포함한 Optional 객체를 반환한다")
@@ -151,6 +166,26 @@ class FeedRepositoryImplTest {
     @Nested
     @DisplayName("getAllFeedList 메소드는")
     class Describe_getAllFeedList {
+        @Test
+        @DisplayName("전체 피드를 조회할 때 삭제된 피드는 목록에서 제외한다")
+        void it_excludes_deleted_feeds_from_list() {
+            // given
+            Member member = createAndSaveMember("runner");
+            createAndSaveFeed(member, null, "살아있는 피드 1");
+            createAndSaveDeletedFeed(member, "죽은 피드 (조회금지)");
+            createAndSaveFeed(member, null, "살아있는 피드 2");
+
+            flushAndClear();
+
+            // when
+            Slice<FeedDetailResponse> result = feedRepository.getAllFeedList(null, null, PageRequest.of(0, 10));
+
+            // then
+            assertThat(result.getContent()).hasSize(2);
+            assertThat(result.getContent())
+                    .extracting("feedContent")
+                    .doesNotContain("죽은 피드 (조회금지)");
+        }
 
         @Test
         @DisplayName("피드 목록을 최신순(ID 역순)으로 조회하고, 다음 페이지가 있다면 hasNext는 true이다")
@@ -311,6 +346,23 @@ class FeedRepositoryImplTest {
     @Nested
     @DisplayName("getMyPageFeedList 메소드는")
     class Describe_getMyPageFeedList {
+        @Test
+        @DisplayName("마이페이지 조회 시 본인의 피드라도 삭제된 것이라면 제외한다")
+        void it_excludes_my_deleted_feeds() {
+            // given
+            Member me = createAndSaveMember("me");
+            createAndSaveFeed(me, null, "내 살아있는 글");
+            createAndSaveDeletedFeed(me, "내 삭제된 글");
+
+            flushAndClear();
+
+            // when
+            Slice<FeedDetailResponse> result = feedRepository.getMyPageFeedList(me, null, PageRequest.of(0, 10));
+
+            // then
+            assertThat(result.getContent()).hasSize(1);
+            assertThat(result.getContent().get(0).getFeedContent()).isEqualTo("내 살아있는 글");
+        }
 
         @Nested
         @DisplayName("특정 회원이 작성한 피드 목록을 요청하면")
@@ -429,6 +481,19 @@ class FeedRepositoryImplTest {
         member.updateProfilePicture(mp);
 
         em.persist(member);
+    }
+
+    private Feed createAndSaveDeletedFeed(Member member, String content) {
+        Feed feed = Feed.builder()
+                .member(member)
+                .feedContent(content)
+                .likesCount(0)
+                .commentsCount(0)
+                .createdAt(LocalDateTime.now())
+                .deletedAt(LocalDateTime.now()) // 삭제 시간 주입
+                .build();
+        em.persist(feed);
+        return feed;
     }
 
     private FeedType createAndSaveFeedType(String name) {

--- a/src/test/java/com/project200/undabang/feed/service/impl/FeedCommandServiceImplTest.java
+++ b/src/test/java/com/project200/undabang/feed/service/impl/FeedCommandServiceImplTest.java
@@ -47,6 +47,49 @@ class FeedCommandServiceImplTest {
     private MemberRepository memberRepository;
 
     @Nested
+    @DisplayName("deleteMemberFeed 메소드는")
+    class Describe_deleteMemberFeed {
+
+        @Test
+        @DisplayName("본인이 작성한 피드 ID가 주어지면 피드를 논리 삭제한다")
+        void it_soft_deletes_feed() {
+            // given
+            UUID userId = UUID.randomUUID();
+            Long feedId = 100L;
+            Member member = createMember(userId);
+            Feed existingFeed = createFeed(feedId, member, null);
+
+            try (MockedStatic<UserContextHolder> ignored = mockStatic(UserContextHolder.class)) {
+                given(UserContextHolder.getUserId()).willReturn(userId);
+                given(memberRepository.findById(userId)).willReturn(Optional.of(member));
+                given(feedRepository.findByIdAndMemberAndDeletedAtNull(feedId, member)).willReturn(Optional.of(existingFeed));
+
+                // when
+                feedCommandService.deleteMemberFeed(feedId);
+
+                // then
+                assertThat(existingFeed.getDeletedAt()).isNotNull(); // 삭제 시간 기록 확인
+            }
+        }
+
+        @Test
+        @DisplayName("피드가 없거나 내 것이 아니면 FEED_NOT_FOUND 예외를 던진다")
+        void it_throws_feed_not_found_when_deleting() {
+            UUID userId = UUID.randomUUID();
+            Member member = createMember(userId);
+            try (MockedStatic<UserContextHolder> ignored = mockStatic(UserContextHolder.class)) {
+                given(UserContextHolder.getUserId()).willReturn(userId);
+                given(memberRepository.findById(userId)).willReturn(Optional.of(member));
+                given(feedRepository.findByIdAndMemberAndDeletedAtNull(anyLong(), any())).willReturn(Optional.empty());
+
+                assertThatThrownBy(() -> feedCommandService.deleteMemberFeed(999L))
+                        .isInstanceOf(CustomException.class)
+                        .hasFieldOrPropertyWithValue("errorCode", ErrorCode.FEED_NOT_FOUND);
+            }
+        }
+    }
+
+    @Nested
     @DisplayName("updateMemberFeed 메소드는")
     class Describe_updateMemberFeed {
 


### PR DESCRIPTION
## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

피드를 논리적 삭제하는 기능을 추가하였습니다. 삭제는 논리적 삭제로 엔티티에서 변경감지를 통해 진행되도록 개발하였습니다.

조회시 삭제된 피드를 조회하는 현상이 발생되어서 where절을 수정하고 테스트코드 업데이트 하였습니다.

### 스크린샷 (선택)
**API 응답 사진:** (API 응답 스크린샷을 첨부해주세요.)
<img width="388" height="191" alt="image" src="https://github.com/user-attachments/assets/39544919-42c0-46cb-a2c2-33ea862b0836" />

**API 명세서 사진:** (API 명세서 스크린샷을 첨부해주세요.)
<img width="989" height="844" alt="image" src="https://github.com/user-attachments/assets/b52dbfa3-3bf3-4a08-973c-6abe08734394" />
<img width="1009" height="765" alt="image" src="https://github.com/user-attachments/assets/34241719-6fbf-4aa3-993b-09e3acebdcc2" />
<img width="998" height="831" alt="image" src="https://github.com/user-attachments/assets/69634bbc-00aa-4198-82a4-cff3355ebf4b" />

**테스트 커버리지 사진:** (테스트 커버리지 스크린샷을 첨부해주세요.)
<img width="795" height="131" alt="image" src="https://github.com/user-attachments/assets/07e823ae-8a28-4dec-b9f9-b54acae6239d" />

Closes #503
