### PR TITLE
[CHORE] 댓글 목록 조회 시 맴버 프로필 안보이는 오류 수정

### DIFF
--- a/src/main/java/com/project200/undabang/comment/dto/response/CommentResponse.java
+++ b/src/main/java/com/project200/undabang/comment/dto/response/CommentResponse.java
@@ -27,7 +27,7 @@ public record CommentResponse(
         String thumbnailUrl = null;
 
         if (comment.getMember().getMemberPicture() != null) {
-            profileImageUrl = comment.getMember().getMemberPicture().getMemberPicturesUrl();
+            profileImageUrl = comment.getMember().getMemberPicture().getPicture().getPictureUrl();
             if (comment.getMember().getMemberPicture().getPicture() != null) {
                 thumbnailUrl = null; // 썸네일은 추후 개발 예정
             }

--- a/src/main/java/com/project200/undabang/comment/service/impl/CommentCommandServiceImpl.java
+++ b/src/main/java/com/project200/undabang/comment/service/impl/CommentCommandServiceImpl.java
@@ -40,14 +40,17 @@ public class CommentCommandServiceImpl implements CommentCommandService {
                 .orElseThrow(() -> new CustomException(ErrorCode.MEMBER_NOT_FOUND));
 
         // 부모 댓글 조회 (대댓글인 경우)
-        Comment parentComment = request.parentCommentId() == null ? null :
-                commentRepository.findByIdAndDeletedAtIsNull(request.parentCommentId())
-                        .orElseThrow(() -> new CustomException(ErrorCode.COMMENT_PARENT_NOT_FOUND));
+        Comment parentComment = request.parentCommentId() == null ? null
+                : commentRepository.findByIdAndDeletedAtIsNull(request.parentCommentId())
+                .orElseThrow(() -> new CustomException(
+                        ErrorCode.COMMENT_PARENT_NOT_FOUND));
 
         // 댓글 생성
         Comment comment = Comment.create(member, feed, parentComment, request);
-
         Comment savedComment = commentRepository.save(comment);
+
+        // 피드 댓글 수 증가
+        feed.incrementCommentsCount();
 
         return new CreateCommentResponse(savedComment.getId());
     }
@@ -66,6 +69,9 @@ public class CommentCommandServiceImpl implements CommentCommandService {
         if (!comment.getMember().getMemberId().equals(currentUserId)) {
             throw new CustomException(ErrorCode.COMMENT_DELETE_FORBIDDEN);
         }
+
+        // 피드 댓글 수 감소
+        comment.getFeed().decrementCommentsCount();
 
         // Soft delete
         comment.delete();

--- a/src/main/java/com/project200/undabang/feed/entity/Feed.java
+++ b/src/main/java/com/project200/undabang/feed/entity/Feed.java
@@ -78,4 +78,14 @@ public class Feed {
         this.updatedAt = LocalDateTime.now();
         this.deletedAt = LocalDateTime.now();
     }
+
+    public void incrementCommentsCount() {
+        this.commentsCount++;
+    }
+
+    public void decrementCommentsCount() {
+        if (this.commentsCount > 0) {
+            this.commentsCount--;
+        }
+    }
 }

--- a/src/test/java/com/project200/undabang/comment/repository/impl/CommentRepositoryImplTest.java
+++ b/src/test/java/com/project200/undabang/comment/repository/impl/CommentRepositoryImplTest.java
@@ -1,0 +1,295 @@
+package com.project200.undabang.comment.repository.impl;
+
+import com.project200.undabang.comment.dto.response.CommentResponse;
+import com.project200.undabang.comment.entity.Comment;
+import com.project200.undabang.comment.repository.CommentRepository;
+import com.project200.undabang.common.entity.Picture;
+import com.project200.undabang.configuration.TestQuerydslConfig;
+import com.project200.undabang.feed.entity.Feed;
+import com.project200.undabang.member.entity.Member;
+import com.project200.undabang.member.entity.MemberPicture;
+import com.project200.undabang.member.enums.MemberGender;
+import jakarta.persistence.EntityManager;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DataJpaTest
+@Import(TestQuerydslConfig.class)
+@DisplayName("CommentRepositoryImpl 통합 테스트")
+class CommentRepositoryImplTest {
+
+    @Autowired
+    private EntityManager em;
+
+    @Autowired
+    private CommentRepository commentRepository;
+
+    @Nested
+    @DisplayName("findCommentsWithChildrenByFeedId 메소드는")
+    class Describe_findCommentsWithChildrenByFeedId {
+
+        @Test
+        @DisplayName("피드의 댓글 목록을 조회할 때 프로필 사진이 있는 회원의 경우 Picture URL을 정상적으로 반환한다")
+        void it_returns_comments_with_profile_picture_url() {
+            // given
+            Member author = createAndSaveMember("작성자", "author@test.com");
+            createAndSaveMemberProfilePicture(author, "https://example.com/profile.jpg");
+
+            Feed feed = createAndSaveFeed(author, "피드 내용");
+            Comment parentComment = createAndSaveComment(feed, author, null, "부모 댓글 내용");
+
+            flushAndClear();
+
+            // when
+            List<CommentResponse> result = commentRepository.findCommentsWithChildrenByFeedId(feed.getId());
+
+            // then
+            assertThat(result).hasSize(1);
+            CommentResponse response = result.get(0);
+            assertThat(response.memberNickname()).isEqualTo("작성자");
+            assertThat(response.memberProfileImageUrl()).isEqualTo("https://example.com/profile.jpg");
+            assertThat(response.content()).isEqualTo("부모 댓글 내용");
+        }
+
+        @Test
+        @DisplayName("프로필 사진이 없는 회원의 댓글은 memberProfileImageUrl이 null로 반환된다")
+        void it_returns_null_profile_url_when_member_has_no_picture() {
+            // given
+            Member author = createAndSaveMember("사진없음", "nophoto@test.com");
+            Feed feed = createAndSaveFeed(author, "피드");
+            Comment comment = createAndSaveComment(feed, author, null, "댓글");
+
+            flushAndClear();
+
+            // when
+            List<CommentResponse> result = commentRepository.findCommentsWithChildrenByFeedId(feed.getId());
+
+            // then
+            assertThat(result).hasSize(1);
+            assertThat(result.get(0).memberProfileImageUrl()).isNull();
+        }
+
+        @Test
+        @DisplayName("부모 댓글과 대댓글을 계층 구조로 정상 조회한다")
+        void it_returns_parent_and_child_comments_hierarchically() {
+            // given
+            Member author = createAndSaveMember("작성자", "author@test.com");
+            Member replier = createAndSaveMember("답글러", "replier@test.com");
+            createAndSaveMemberProfilePicture(replier, "https://example.com/replier.jpg");
+
+            Feed feed = createAndSaveFeed(author, "피드 내용");
+            Comment parent = createAndSaveComment(feed, author, null, "부모 댓글");
+            Comment child1 = createAndSaveComment(feed, replier, parent, "대댓글 1");
+            Comment child2 = createAndSaveComment(feed, replier, parent, "대댓글 2");
+
+            flushAndClear();
+
+            // when
+            List<CommentResponse> result = commentRepository.findCommentsWithChildrenByFeedId(feed.getId());
+
+            // then
+            assertThat(result).hasSize(1);
+            CommentResponse parentResponse = result.get(0);
+            assertThat(parentResponse.content()).isEqualTo("부모 댓글");
+            assertThat(parentResponse.children()).hasSize(2);
+            assertThat(parentResponse.children())
+                    .extracting(CommentResponse::content)
+                    .containsExactly("대댓글 1", "대댓글 2");
+            assertThat(parentResponse.children().get(0).memberProfileImageUrl())
+                    .isEqualTo("https://example.com/replier.jpg");
+        }
+
+        @Test
+        @DisplayName("삭제된 댓글은 조회 결과에서 제외된다")
+        void it_excludes_deleted_comments() {
+            // given
+            Member author = createAndSaveMember("작성자", "author@test.com");
+            Feed feed = createAndSaveFeed(author, "피드");
+            Comment activeComment = createAndSaveComment(feed, author, null, "살아있는 댓글");
+            Comment deletedComment = createAndSaveDeletedComment(feed, author, null, "삭제된 댓글");
+
+            flushAndClear();
+
+            // when
+            List<CommentResponse> result = commentRepository.findCommentsWithChildrenByFeedId(feed.getId());
+
+            // then
+            assertThat(result).hasSize(1);
+            assertThat(result.get(0).content()).isEqualTo("살아있는 댓글");
+        }
+
+        @Test
+        @DisplayName("부모 댓글은 살아있지만 대댓글이 삭제된 경우 대댓글은 제외된다")
+        void it_excludes_deleted_child_comments() {
+            // given
+            Member author = createAndSaveMember("작성자", "author@test.com");
+            Feed feed = createAndSaveFeed(author, "피드");
+            Comment parent = createAndSaveComment(feed, author, null, "부모 댓글");
+            Comment activeChild = createAndSaveComment(feed, author, parent, "살아있는 대댓글");
+            Comment deletedChild = createAndSaveDeletedComment(feed, author, parent, "삭제된 대댓글");
+
+            flushAndClear();
+
+            // when
+            List<CommentResponse> result = commentRepository.findCommentsWithChildrenByFeedId(feed.getId());
+
+            // then
+            assertThat(result).hasSize(1);
+            assertThat(result.get(0).children()).hasSize(1);
+            assertThat(result.get(0).children().get(0).content()).isEqualTo("살아있는 대댓글");
+        }
+
+        @Test
+        @DisplayName("댓글이 없는 피드는 빈 리스트를 반환한다")
+        void it_returns_empty_list_when_no_comments() {
+            // given
+            Member author = createAndSaveMember("작성자", "author@test.com");
+            Feed feed = createAndSaveFeed(author, "댓글 없는 피드");
+
+            flushAndClear();
+
+            // when
+            List<CommentResponse> result = commentRepository.findCommentsWithChildrenByFeedId(feed.getId());
+
+            // then
+            assertThat(result).isEmpty();
+        }
+
+        @Test
+        @DisplayName("여러 부모 댓글과 각각의 대댓글을 정상적으로 조회한다")
+        void it_returns_multiple_parents_with_each_children() {
+            // given
+            Member author = createAndSaveMember("작성자", "author@test.com");
+            Feed feed = createAndSaveFeed(author, "피드");
+
+            Comment parent1 = createAndSaveComment(feed, author, null, "첫 번째 부모");
+            createAndSaveComment(feed, author, parent1, "첫 번째 부모의 대댓글");
+
+            Comment parent2 = createAndSaveComment(feed, author, null, "두 번째 부모");
+            createAndSaveComment(feed, author, parent2, "두 번째 부모의 대댓글 1");
+            createAndSaveComment(feed, author, parent2, "두 번째 부모의 대댓글 2");
+
+            flushAndClear();
+
+            // when
+            List<CommentResponse> result = commentRepository.findCommentsWithChildrenByFeedId(feed.getId());
+
+            // then
+            assertThat(result).hasSize(2);
+            assertThat(result.get(0).children()).hasSize(1);
+            assertThat(result.get(1).children()).hasSize(2);
+        }
+
+        @Test
+        @DisplayName("댓글의 likesCount를 정상적으로 조회한다")
+        void it_returns_comments_with_likes_count() {
+            // given
+            Member author = createAndSaveMember("작성자", "author@test.com");
+            Feed feed = createAndSaveFeed(author, "피드");
+            Comment comment = Comment.builder()
+                    .feed(feed)
+                    .member(author)
+                    .content("좋아요 5개 댓글")
+                    .likesCount(5)
+                    .createdAt(LocalDateTime.now())
+                    .build();
+            em.persist(comment);
+
+            flushAndClear();
+
+            // when
+            List<CommentResponse> result = commentRepository.findCommentsWithChildrenByFeedId(feed.getId());
+
+            // then
+            assertThat(result).hasSize(1);
+            assertThat(result.get(0).likesCount()).isEqualTo(5);
+        }
+    }
+
+    // ==================== Helper Methods ====================
+
+    private Member createAndSaveMember(String nickname, String email) {
+        Member member = Member.builder()
+                .memberId(UUID.randomUUID())
+                .memberEmail(email)
+                .memberNickname(nickname)
+                .memberGender(MemberGender.MALE)
+                .memberBday(LocalDate.of(1990, 1, 1))
+                .memberScore((byte) 50)
+                .build();
+        em.persist(member);
+        return member;
+    }
+
+    private void createAndSaveMemberProfilePicture(Member member, String url) {
+        Picture picture = Picture.builder()
+                .pictureUrl(url)
+                .pictureName("profile.jpg")
+                .pictureSize(1024)
+                .build();
+        em.persist(picture);
+
+        MemberPicture memberPicture = MemberPicture.builder()
+                .member(member)
+                .picture(picture)
+                .build();
+        em.persist(memberPicture);
+
+        member.updateProfilePicture(memberPicture);
+    }
+
+    private Feed createAndSaveFeed(Member member, String content) {
+        Feed feed = Feed.builder()
+                .member(member)
+                .feedContent(content)
+                .likesCount(0)
+                .commentsCount(0)
+                .createdAt(LocalDateTime.now())
+                .build();
+        em.persist(feed);
+        return feed;
+    }
+
+    private Comment createAndSaveComment(Feed feed, Member member, Comment parent, String content) {
+        Comment comment = Comment.builder()
+                .feed(feed)
+                .member(member)
+                .parent(parent)
+                .content(content)
+                .likesCount(0)
+                .createdAt(LocalDateTime.now())
+                .build();
+        em.persist(comment);
+        return comment;
+    }
+
+    private Comment createAndSaveDeletedComment(Feed feed, Member member, Comment parent, String content) {
+        Comment comment = Comment.builder()
+                .feed(feed)
+                .member(member)
+                .parent(parent)
+                .content(content)
+                .likesCount(0)
+                .createdAt(LocalDateTime.now())
+                .deletedAt(LocalDateTime.now())
+                .build();
+        em.persist(comment);
+        return comment;
+    }
+
+    private void flushAndClear() {
+        em.flush();
+        em.clear();
+    }
+}

--- a/src/test/java/com/project200/undabang/comment/service/impl/CommentCommandServiceImplTest.java
+++ b/src/test/java/com/project200/undabang/comment/service/impl/CommentCommandServiceImplTest.java
@@ -116,6 +116,7 @@ class CommentCommandServiceImplTest {
 
                 // then
                 assertThat(result.commentId()).isEqualTo(1L);
+                assertThat(feed.getCommentsCount()).isEqualTo(1);
             }
         }
 
@@ -146,6 +147,7 @@ class CommentCommandServiceImplTest {
 
                 // then
                 assertThat(result.commentId()).isEqualTo(2L);
+                assertThat(feed.getCommentsCount()).isEqualTo(1);
             }
         }
 
@@ -219,6 +221,7 @@ class CommentCommandServiceImplTest {
 
                 // then
                 assertThat(comment.isDeleted()).isTrue();
+                assertThat(feed.getCommentsCount()).isEqualTo(0);
             }
         }
 


### PR DESCRIPTION
## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)


피드의 댓글 목록 조회 시에 맴버 프로필이 null값으로만 오는 오류를 수정하였습니다.

### 스크린샷 (선택)
**API 응답 사진:** (API 응답 스크린샷을 첨부해주세요.)
<img width="2254" height="1790" alt="image" src="https://github.com/user-attachments/assets/9bc5d7b4-19b0-402e-ba6d-e7e88ecaa0bb" />

**API 명세서 사진:** (API 명세서 스크린샷을 첨부해주세요.)
<img width="1312" height="1518" alt="image" src="https://github.com/user-attachments/assets/6052cdd1-199d-4cdc-833b-b5516ed52286" />
<img width="1290" height="1402" alt="image" src="https://github.com/user-attachments/assets/d0d63b4b-14fc-4cbd-a749-6c45a2bad953" />
<img width="1292" height="1746" alt="image" src="https://github.com/user-attachments/assets/2eaaeb01-551a-4c9d-96a7-295ef2597b11" />
<img width="1322" height="1822" alt="image" src="https://github.com/user-attachments/assets/d1d94e99-89fc-4ca0-a5c8-572cea31eb08" />
<img width="1288" height="1798" alt="image" src="https://github.com/user-attachments/assets/459ff04c-b1bb-414e-b2b3-1d67c8788691" />
<img width="1300" height="1004" alt="image" src="https://github.com/user-attachments/assets/4c671059-d130-47e2-9f4d-f953d8f2369a" />

**테스트 커버리지 사진:** (테스트 커버리지 스크린샷을 첨부해주세요.)
<img width="1988" height="192" alt="image" src="https://github.com/user-attachments/assets/12b30415-74db-4a52-819e-6bd409bd2f54" />

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

## #️⃣연관된 이슈

> ex) #이슈번호, Closes #이슈번호
