### PR TITLE
[Feat] 피드 이미지 삭제 기능 개발 [0.12.2]

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ plugins {
 }
 
 group = 'com.project200'
-version = '0.11.10-SNAPSHOT'
+version = '0.12.2-SNAPSHOT'
 
 java {
     toolchain {

--- a/src/docs/asciidoc/feed/피드-이미지-삭제-API.adoc
+++ b/src/docs/asciidoc/feed/피드-이미지-삭제-API.adoc
@@ -1,0 +1,37 @@
+== 피드 이미지 삭제 API
+
+=== 설명
+
+#DELETE# `/api/v1/feeds/{feedId}/pictures/{pictureId}`
+
+- 회원이 작성한 피드의 이미지를 삭제하는 API 입니다.
+- 삭제가 필요한 경우, 해당 API 를 사용해서 삭제 후 추가 하는 방향으로 진행하시면 됩니다.
+
+=== 개발 이력
+
+- Sprint 23 (2026-02-17): 기능 개발이 완료되었습니다.
+
+=== 개발 참고 사항
+
+- <<공통-개발-참고-사항,공통 개발 참고 사항>>을 참고하세요.
+
+=== 코드 샘플
+
+operation::delete-feed-pictures/delete-feed-pictures_-success[snippets="curl-request,http-request,http-response"]
+
+=== 매개 변수
+
+operation::delete-feed-pictures/delete-feed-pictures_-success[snippets="request-headers,path-parameters,response-fields"]
+
+==== 응답 상태 코드
+
+|===
+|상태 코드|설명
+|200|요청이 성공적으로 처리되었지만, 반환할 데이터가 없습니다.
+|400|요청 본문을 읽을 수 없거나 형식이 올바르지 않습니다.
+|401|인증되지 않은 요청입니다. Access Token이 없거나 유효하지 않습니다
+|404|존재하지 않는 회원입니다. +
+존재하지 않는 피드 타입 입니다. +
+존재하지 않는 피드 입니다.
+|===
+

--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -261,6 +261,8 @@ include::overview/공통-개발-참고-사항.adoc[]
 
 - 피드 이미지 목록 추가 API #POST# `/api/v1/feeds/{feedId}/pictures`
 
+- 피드 이미지 삭제 API #DELETE# `/api/v1/feeds/{feedId}/pictures/{pictureId}`
+
 === xref:댓글-API.html[댓글 API]
 - 특정 피드의 댓글 목록 조회 API #GET# `/api/v1/feeds/{feedId}/comments`
 

--- a/src/docs/asciidoc/피드-API.adoc
+++ b/src/docs/asciidoc/피드-API.adoc
@@ -32,3 +32,5 @@ include::feed/피드-수정-API.adoc[]
 include::feed/피드-삭제-API.adoc[]
 
 include::feed/피드-이미지-목록-추가-API.adoc[]
+
+include::feed/피드-이미지-삭제-API.adoc[]

--- a/src/main/java/com/project200/undabang/common/web/exception/ErrorCode.java
+++ b/src/main/java/com/project200/undabang/common/web/exception/ErrorCode.java
@@ -110,6 +110,7 @@ public enum ErrorCode {
     FEED_TYPE_NOT_FOUND(404, "FEED_TYPE_NOT_FOUND", "존재하지 않는 피드 타입입니다."),
 
     // 피드 사진 관련 에러
+    FEED_PICTURE_NOT_FOUND(404, "FEED_PICTURE_NOT_FOUND", "존재하지 않는 피드 사진 입니다."),
     FEED_PICTURE_MAX_COUNT_EXCEED(409, "FEED_PICTURE_MAX_COUNT_EXCEED", "저장할 수 있는 최대 피드 사진 갯수를 초과했습니다.");
 
     private final HttpStatusCode status;

--- a/src/main/java/com/project200/undabang/common/web/exception/ErrorCode.java
+++ b/src/main/java/com/project200/undabang/common/web/exception/ErrorCode.java
@@ -110,7 +110,7 @@ public enum ErrorCode {
     FEED_TYPE_NOT_FOUND(404, "FEED_TYPE_NOT_FOUND", "존재하지 않는 피드 타입입니다."),
 
     // 피드 사진 관련 에러
-    FEED_PICTURE_NOT_FOUND(404, "FEED_PICTURE_NOT_FOUND", "존재하지 않는 피드 사진 입니다."),
+    FEED_PICTURE_NOT_FOUND(404, "FEED_PICTURE_NOT_FOUND", "존재하지 않는 피드 사진입니다."),
     FEED_PICTURE_MAX_COUNT_EXCEED(409, "FEED_PICTURE_MAX_COUNT_EXCEED", "저장할 수 있는 최대 피드 사진 갯수를 초과했습니다.");
 
     private final HttpStatusCode status;

--- a/src/main/java/com/project200/undabang/feed/controller/FeedCommandController.java
+++ b/src/main/java/com/project200/undabang/feed/controller/FeedCommandController.java
@@ -77,10 +77,10 @@ public class FeedCommandController {
      * 주어진 피드 ID와 사진 ID를 기반으로 특정 피드에서 사진을 삭제합니다.
      */
     @DeleteMapping("/v1/feeds/{feedId}/pictures/{pictureId}")
-    public ResponseEntity<CommonResponse<Void>> deleteFeedPictures(@PathVariable long feedId,
-                                                                   @PathVariable long pictureId) {
+    public ResponseEntity<CommonResponse<Void>> deleteFeedPicture(@PathVariable Long feedId,
+                                                                  @PathVariable Long pictureId) {
 
-        feedPictureService.deleteFeedPictures(feedId, pictureId);
+        feedPictureService.deleteFeedPicture(feedId, pictureId);
         return ResponseEntity.ok(CommonResponse.delete(null));
     }
 }

--- a/src/main/java/com/project200/undabang/feed/controller/FeedCommandController.java
+++ b/src/main/java/com/project200/undabang/feed/controller/FeedCommandController.java
@@ -60,6 +60,9 @@ public class FeedCommandController {
         return ResponseEntity.ok(CommonResponse.delete(feedCommandService.deleteMemberFeed(feedId)));
     }
 
+    /**
+     * 주어진 피드 ID를 기반으로 피드에 새로운 사진을 추가합니다.
+     */
     @PostMapping(value = "/v1/feeds/{feedId}/pictures", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public ResponseEntity<CommonResponse<List<CreateFeedPictureResponse>>> createFeedPictures(
             @PathVariable @Positive(message = "올바른 피드 식별자를 입력해주세요") Long feedId,
@@ -68,5 +71,16 @@ public class FeedCommandController {
             @RequestPart("pictures") List<MultipartFile> feedPictureList) {
 
         return ResponseEntity.status(HttpStatus.CREATED).body(CommonResponse.create(feedPictureService.createFeedPictures(feedId, feedPictureList)));
+    }
+
+    /**
+     * 주어진 피드 ID와 사진 ID를 기반으로 특정 피드에서 사진을 삭제합니다.
+     */
+    @DeleteMapping("/v1/feeds/{feedId}/pictures/{pictureId}")
+    public ResponseEntity<CommonResponse<Void>> deleteFeedPictures(@PathVariable long feedId,
+                                                                   @PathVariable long pictureId) {
+
+        feedPictureService.deleteFeedPictures(feedId, pictureId);
+        return ResponseEntity.ok(CommonResponse.delete(null));
     }
 }

--- a/src/main/java/com/project200/undabang/feed/repository/FeedPictureRepository.java
+++ b/src/main/java/com/project200/undabang/feed/repository/FeedPictureRepository.java
@@ -4,6 +4,10 @@ import com.project200.undabang.feed.entity.Feed;
 import com.project200.undabang.feed.entity.FeedPicture;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface FeedPictureRepository extends JpaRepository<FeedPicture, Long> {
     long countByFeedAndPicture_PictureDeletedAtNull(Feed feed);
+
+    Optional<FeedPicture> findByFeedAndIdAndPicture_PictureDeletedAtNull(Feed feed, Long id);
 }

--- a/src/main/java/com/project200/undabang/feed/repository/FeedRepositoryCustom.java
+++ b/src/main/java/com/project200/undabang/feed/repository/FeedRepositoryCustom.java
@@ -11,6 +11,5 @@ import java.util.Optional;
 public interface FeedRepositoryCustom {
     Slice<FeedDetailResponse> getAllFeedList(Member currentMember, Long prevFeedId, Pageable pageable);
     Optional<GetSpecificFeedResponse> getSpecificFeed(Member currentMember, Long feedId);
-
     Slice<FeedDetailResponse> getMyPageFeedList(Member currentMember, Long prevFeedId, Pageable pageable);
 }

--- a/src/main/java/com/project200/undabang/feed/repository/impl/FeedRepositoryImpl.java
+++ b/src/main/java/com/project200/undabang/feed/repository/impl/FeedRepositoryImpl.java
@@ -111,7 +111,8 @@ public class FeedRepositoryImpl implements FeedRepositoryCustom {
                 .join(feedPicture.picture, picture)
                 .where(
                         feedPicture.feed.id.eq(feedId),
-                        feedPicture.feed.deletedAt.isNull()
+                        feedPicture.feed.deletedAt.isNull(),
+                        picture.pictureDeletedAt.isNull()
                 )
                 .fetch();
 
@@ -190,7 +191,8 @@ public class FeedRepositoryImpl implements FeedRepositoryCustom {
                 .join(feedPicture.picture, picture)
                 .where(
                         feedPicture.feed.id.in(feedIdList),
-                        feedPicture.feed.deletedAt.isNull()
+                        feedPicture.feed.deletedAt.isNull(),
+                        picture.pictureDeletedAt.isNull()
                 )
                 .transform(GroupBy.groupBy(feedPicture.feed.id)
                         .as(GroupBy.list(Projections.constructor(FeedPictureRecord.class,

--- a/src/main/java/com/project200/undabang/feed/service/FeedPictureService.java
+++ b/src/main/java/com/project200/undabang/feed/service/FeedPictureService.java
@@ -7,4 +7,6 @@ import java.util.List;
 
 public interface FeedPictureService {
     List<CreateFeedPictureResponse> createFeedPictures(Long feedId, List<MultipartFile> imageFileList);
+
+    void deleteFeedPictures(long feedId, long pictureId);
 }

--- a/src/main/java/com/project200/undabang/feed/service/FeedPictureService.java
+++ b/src/main/java/com/project200/undabang/feed/service/FeedPictureService.java
@@ -8,5 +8,5 @@ import java.util.List;
 public interface FeedPictureService {
     List<CreateFeedPictureResponse> createFeedPictures(Long feedId, List<MultipartFile> imageFileList);
 
-    void deleteFeedPictures(long feedId, long pictureId);
+    void deleteFeedPicture(long feedId, long pictureId);
 }

--- a/src/main/java/com/project200/undabang/feed/service/FeedQueryService.java
+++ b/src/main/java/com/project200/undabang/feed/service/FeedQueryService.java
@@ -8,6 +8,5 @@ import org.springframework.data.domain.Pageable;
 public interface FeedQueryService {
     GetAllMemberFeedsResponse getAllMemberFeeds(Long prevFeedId, Pageable pageable);
     GetSpecificFeedResponse getSpecificFeed(Long feedId);
-
     GetMyPageFeedsResponse getMyPageFeeds(Long prevFeedId, Pageable pageable);
 }

--- a/src/main/java/com/project200/undabang/feed/service/impl/FeedPictureServiceImpl.java
+++ b/src/main/java/com/project200/undabang/feed/service/impl/FeedPictureServiceImpl.java
@@ -40,7 +40,7 @@ public class FeedPictureServiceImpl implements FeedPictureService {
      * 이미지가 존재하지 않거나 이미 삭제된 경우 예외를 발생시킵니다.
      */
     @Override
-    public void deleteFeedPictures(long feedId, long pictureId) {
+    public void deleteFeedPicture(long feedId, long pictureId) {
         Member member = getMember(UserContextHolder.getUserId());
         Feed feed = getFeed(feedId, member);
 

--- a/src/main/java/com/project200/undabang/feed/service/impl/FeedPictureServiceImpl.java
+++ b/src/main/java/com/project200/undabang/feed/service/impl/FeedPictureServiceImpl.java
@@ -36,6 +36,21 @@ public class FeedPictureServiceImpl implements FeedPictureService {
     private final PolicyService policyService;
 
     /**
+     * 주어진 피드 ID와 사진 ID에 해당하는 피드 이미지를 삭제합니다.
+     * 이미지가 존재하지 않거나 이미 삭제된 경우 예외를 발생시킵니다.
+     */
+    @Override
+    public void deleteFeedPictures(long feedId, long pictureId) {
+        Member member = getMember(UserContextHolder.getUserId());
+        Feed feed = getFeed(feedId, member);
+
+        FeedPicture feedPicture = feedPictureRepository.findByFeedAndIdAndPicture_PictureDeletedAtNull(feed, pictureId)
+                .orElseThrow(() -> new CustomException(ErrorCode.FEED_PICTURE_NOT_FOUND));
+
+        pictureService.deletePictureFromS3AndDB(feedPicture.getPicture());
+    }
+
+    /**
      * 주어진 피드 ID에 해당하는 피드에 이미지 파일 리스트를 업로드한 후, 이를 데이터베이스에 저장하고 결과를 반환합니다.
      */
     @Override

--- a/src/test/java/com/project200/undabang/feed/controller/FeedCommandControllerTest.java
+++ b/src/test/java/com/project200/undabang/feed/controller/FeedCommandControllerTest.java
@@ -231,4 +231,41 @@ class FeedCommandControllerTest extends AbstractRestDocSupport {
             verify(feedCommandService).createMemberFeed(any(CreateFeedRequest.class));
         }
     }
+
+    @Nested
+    @DisplayName("deleteFeedPictures 메소드는")
+    class DeleteFeedPictures {
+
+        @Test
+        @DisplayName("피드 사진 삭제 요청이 유효하면 200 상태코드를 반환한다")
+        void deleteFeedPictures_Success() throws Exception {
+            // given
+            UUID memberId = UUID.randomUUID();
+            Long feedId = 1L;
+            Long pictureId = 100L;
+
+            // Service는 void 반환이므로 doNothing() 설정
+            doNothing().when(feedPictureService).deleteFeedPictures(feedId, pictureId);
+
+            // when & then
+            mockMvc.perform(RestDocumentationRequestBuilders.delete("/api/v1/feeds/{feedId}/pictures/{pictureId}", feedId, pictureId)
+                            .headers(getCommonApiHeaders(memberId))
+                            .contentType(MediaType.APPLICATION_JSON))
+                    .andExpectAll(
+                            status().isOk(),
+                            jsonPath("$.succeed").value(true),
+                            jsonPath("$.data").isEmpty() // null 확인
+                    )
+                    .andDo(document.document(
+                            requestHeaders(HEADER_ACCESS_TOKEN),
+                            pathParameters(
+                                    parameterWithName("feedId").attributes(getTypeFormat(JsonFieldType.NUMBER)).description("삭제할 사진이 속한 피드의 식별자입니다."),
+                                    parameterWithName("pictureId").attributes(getTypeFormat(JsonFieldType.NUMBER)).description("삭제할 사진의 고유 식별자입니다.")
+                            ),
+                            responseFields(commonResponseFields(
+                                    fieldWithPath("data").attributes(getTypeFormat(JsonFieldType.NULL)).description("삭제 성공 시 데이터는 반환되지 않습니다.")
+                            ))
+                    ));
+        }
+    }
 }

--- a/src/test/java/com/project200/undabang/feed/controller/FeedCommandControllerTest.java
+++ b/src/test/java/com/project200/undabang/feed/controller/FeedCommandControllerTest.java
@@ -245,7 +245,7 @@ class FeedCommandControllerTest extends AbstractRestDocSupport {
             Long pictureId = 100L;
 
             // Service는 void 반환이므로 doNothing() 설정
-            doNothing().when(feedPictureService).deleteFeedPictures(feedId, pictureId);
+            doNothing().when(feedPictureService).deleteFeedPicture(feedId, pictureId);
 
             // when & then
             mockMvc.perform(RestDocumentationRequestBuilders.delete("/api/v1/feeds/{feedId}/pictures/{pictureId}", feedId, pictureId)

--- a/src/test/java/com/project200/undabang/feed/repository/FeedPictureRepositoryTest.java
+++ b/src/test/java/com/project200/undabang/feed/repository/FeedPictureRepositoryTest.java
@@ -14,6 +14,7 @@ import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.context.annotation.Import;
 
 import java.time.LocalDateTime;
+import java.util.Optional;
 import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -77,6 +78,71 @@ class FeedPictureRepositoryTest {
         }
     }
 
+    @Nested
+    @DisplayName("Describe: findByFeedAndIdAndPicture_PictureDeletedAtNull 메소드는")
+    class Describe_FindByFeedAndId {
+
+        @Test
+        @DisplayName("피드에 속하고 삭제되지 않은 사진이면 조회에 성공한다")
+        void it_returns_picture_when_exists_and_active() {
+            // given
+            Member author = createAndSaveMember("tester");
+            Feed feed = createAndSaveFeed(author, "내 피드");
+
+            // 활성 사진 생성
+            FeedPicture savedPic = createAndSaveFeedPicture(feed, "active.jpg", false);
+            Long pictureId = savedPic.getId();
+
+            flushAndClear();
+
+            // when
+            Optional<FeedPicture> result = feedPictureRepository.findByFeedAndIdAndPicture_PictureDeletedAtNull(feed, pictureId);
+
+            // then
+            assertThat(result).isPresent();
+            assertThat(result.get().getId()).isEqualTo(pictureId);
+            assertThat(result.get().getPicture().getPictureUrl()).isEqualTo("active.jpg");
+        }
+
+        @Test
+        @DisplayName("사진이 존재하지만 삭제된 상태라면 조회되지 않는다")
+        void it_returns_empty_when_picture_is_deleted() {
+            // given
+            Member author = createAndSaveMember("tester");
+            Feed feed = createAndSaveFeed(author, "내 피드");
+
+            FeedPicture deletedPic = createAndSaveFeedPicture(feed, "deleted.jpg", true);
+            Long pictureId = deletedPic.getId();
+
+            flushAndClear();
+
+            // when
+            Optional<FeedPicture> result = feedPictureRepository.findByFeedAndIdAndPicture_PictureDeletedAtNull(feed, pictureId);
+
+            // then
+            assertThat(result).isEmpty();
+        }
+
+        @Test
+        @DisplayName("사진이 존재하고 활성 상태지만, 다른 피드의 사진이라면 조회되지 않는다")
+        void it_returns_empty_when_picture_belongs_to_other_feed() {
+            // given
+            Member author = createAndSaveMember("tester");
+            Feed myFeed = createAndSaveFeed(author, "내 피드");
+            Feed otherFeed = createAndSaveFeed(author, "남의 피드");
+
+            FeedPicture otherPic = createAndSaveFeedPicture(otherFeed, "other.jpg", false);
+            Long otherPictureId = otherPic.getId();
+
+            flushAndClear();
+
+            Optional<FeedPicture> result = feedPictureRepository.findByFeedAndIdAndPicture_PictureDeletedAtNull(myFeed, otherPictureId);
+
+            // then
+            assertThat(result).isEmpty();
+        }
+    }
+
     private Member createAndSaveMember(String nickname) {
         Member member = Member.builder()
                 .memberId(UUID.randomUUID())
@@ -97,7 +163,7 @@ class FeedPictureRepositoryTest {
         return feed;
     }
 
-    private void createAndSaveFeedPicture(Feed feed, String url, boolean isDeleted) {
+    private FeedPicture createAndSaveFeedPicture(Feed feed, String url, boolean isDeleted) {
         Picture picture = Picture.builder()
                 .pictureUrl(url)
                 .pictureName("file.jpg")
@@ -111,6 +177,8 @@ class FeedPictureRepositoryTest {
                 .feed(feed)
                 .build();
         em.persist(feedPicture);
+
+        return feedPicture;
     }
 
     private void flushAndClear() {

--- a/src/test/java/com/project200/undabang/feed/service/impl/FeedPictureServiceImplTest.java
+++ b/src/test/java/com/project200/undabang/feed/service/impl/FeedPictureServiceImplTest.java
@@ -165,4 +165,102 @@ class FeedPictureServiceImplTest {
             }
         }
     }
+
+    @Nested
+    @DisplayName("Describe: deleteFeedPictures 메소드는")
+    class Describe_DeleteFeedPictures {
+
+        @Test
+        @DisplayName("본인의 피드에 존재하고 삭제되지 않은 사진 ID가 주어지면 사진을 삭제한다")
+        void it_deletes_picture_successfully() {
+            // given
+            UUID memberId = UUID.randomUUID();
+            Long feedId = 1L;
+            Long pictureId = 100L;
+
+            // Mock 객체 생성
+            Member member = mock(Member.class);
+            Feed feed = mock(Feed.class);
+            Picture picture = mock(Picture.class);
+            FeedPicture feedPicture = mock(FeedPicture.class);
+
+            try (MockedStatic<UserContextHolder> userContext = mockStatic(UserContextHolder.class)) {
+                // 1. 로그인 유저 ID 설정
+                userContext.when(UserContextHolder::getUserId).thenReturn(memberId);
+
+                // 2. Member & Feed 조회 성공 설정
+                given(memberRepository.findByMemberIdAndMemberDeletedAtNull(memberId)).willReturn(Optional.of(member));
+                given(feedRepository.findByIdAndMemberAndDeletedAtNull(feedId, member)).willReturn(Optional.of(feed));
+
+                // 3. FeedPicture 조회 성공 설정 (Stubbing)
+                given(feedPictureRepository.findByFeedAndIdAndPicture_PictureDeletedAtNull(feed, pictureId))
+                        .willReturn(Optional.of(feedPicture));
+
+                // 4. feedPicture.getPicture() 호출 시 반환할 Picture 설정
+                given(feedPicture.getPicture()).willReturn(picture);
+
+                // when
+                feedPictureService.deleteFeedPictures(feedId, pictureId);
+
+                // then
+                // PictureService의 삭제 메서드가 올바른 인자(picture)로 호출되었는지 검증
+                verify(pictureService, times(1)).deletePictureFromS3AndDB(picture);
+            }
+        }
+
+        @Test
+        @DisplayName("사진이 해당 피드에 없거나 이미 삭제된 경우 FEED_PICTURE_NOT_FOUND 예외를 던진다")
+        void it_throws_exception_when_picture_not_found() {
+            // given
+            UUID memberId = UUID.randomUUID();
+            Long feedId = 1L;
+            Long pictureId = 999L; // 존재하지 않거나 삭제된 ID
+
+            Member member = mock(Member.class);
+            Feed feed = mock(Feed.class);
+
+            try (MockedStatic<UserContextHolder> userContext = mockStatic(UserContextHolder.class)) {
+                // 1. 로그인 유저 및 피드 정상 조회
+                userContext.when(UserContextHolder::getUserId).thenReturn(memberId);
+                given(memberRepository.findByMemberIdAndMemberDeletedAtNull(memberId)).willReturn(Optional.of(member));
+                given(feedRepository.findByIdAndMemberAndDeletedAtNull(feedId, member)).willReturn(Optional.of(feed));
+
+                // 2. FeedPicture 조회 실패 (Optional.empty 반환)
+                given(feedPictureRepository.findByFeedAndIdAndPicture_PictureDeletedAtNull(feed, pictureId))
+                        .willReturn(Optional.empty());
+
+                // when & then
+                assertThatThrownBy(() -> feedPictureService.deleteFeedPictures(feedId, pictureId))
+                        .isInstanceOf(CustomException.class)
+                        .hasFieldOrPropertyWithValue("errorCode", ErrorCode.FEED_PICTURE_NOT_FOUND);
+
+                verify(pictureService, never()).deletePictureFromS3AndDB(any(Picture.class));
+            }
+        }
+
+        @Test
+        @DisplayName("요청한 피드가 존재하지 않거나 본인의 것이 아니면 FEED_NOT_FOUND 예외를 던진다")
+        void it_throws_exception_when_feed_not_found() {
+            // given
+            UUID memberId = UUID.randomUUID();
+            Long feedId = 999L;
+            Long pictureId = 100L;
+            Member member = mock(Member.class);
+
+            try (MockedStatic<UserContextHolder> userContext = mockStatic(UserContextHolder.class)) {
+                userContext.when(UserContextHolder::getUserId).thenReturn(memberId);
+                given(memberRepository.findByMemberIdAndMemberDeletedAtNull(memberId)).willReturn(Optional.of(member));
+
+                // 피드 조회 실패 설정
+                given(feedRepository.findByIdAndMemberAndDeletedAtNull(feedId, member)).willReturn(Optional.empty());
+
+                // when & then
+                assertThatThrownBy(() -> feedPictureService.deleteFeedPictures(feedId, pictureId))
+                        .isInstanceOf(CustomException.class)
+                        .hasFieldOrPropertyWithValue("errorCode", ErrorCode.FEED_NOT_FOUND);
+
+                verify(pictureService, never()).deletePictureFromS3AndDB(any(Picture.class));
+            }
+        }
+    }
 }

--- a/src/test/java/com/project200/undabang/feed/service/impl/FeedPictureServiceImplTest.java
+++ b/src/test/java/com/project200/undabang/feed/service/impl/FeedPictureServiceImplTest.java
@@ -200,7 +200,7 @@ class FeedPictureServiceImplTest {
                 given(feedPicture.getPicture()).willReturn(picture);
 
                 // when
-                feedPictureService.deleteFeedPictures(feedId, pictureId);
+                feedPictureService.deleteFeedPicture(feedId, pictureId);
 
                 // then
                 // PictureService의 삭제 메서드가 올바른 인자(picture)로 호출되었는지 검증
@@ -230,7 +230,7 @@ class FeedPictureServiceImplTest {
                         .willReturn(Optional.empty());
 
                 // when & then
-                assertThatThrownBy(() -> feedPictureService.deleteFeedPictures(feedId, pictureId))
+                assertThatThrownBy(() -> feedPictureService.deleteFeedPicture(feedId, pictureId))
                         .isInstanceOf(CustomException.class)
                         .hasFieldOrPropertyWithValue("errorCode", ErrorCode.FEED_PICTURE_NOT_FOUND);
 
@@ -255,7 +255,7 @@ class FeedPictureServiceImplTest {
                 given(feedRepository.findByIdAndMemberAndDeletedAtNull(feedId, member)).willReturn(Optional.empty());
 
                 // when & then
-                assertThatThrownBy(() -> feedPictureService.deleteFeedPictures(feedId, pictureId))
+                assertThatThrownBy(() -> feedPictureService.deleteFeedPicture(feedId, pictureId))
                         .isInstanceOf(CustomException.class)
                         .hasFieldOrPropertyWithValue("errorCode", ErrorCode.FEED_NOT_FOUND);
 


### PR DESCRIPTION
## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

피드 이미지 삭제 기능을 추가하였습니다. 해당 기능을 사용하여 S3 및 DB에 등록된 사진을 삭제할 수 있습니다.
또한, 마이페이지 조회, 모든 피드 조회, 특정 피드 조회시 삭제한 사진이 조회되는 오류를 수정하였습니다.

테스트코드는 100%로 작성하였습니다.

### 스크린샷 (선택)
**API 응답 사진:** (API 응답 스크린샷을 첨부해주세요.)
<img width="973" height="284" alt="image" src="https://github.com/user-attachments/assets/d15ccca7-0bc4-4b6c-b77b-5fac969b1fbb" />
<img width="403" height="197" alt="image" src="https://github.com/user-attachments/assets/da1c0502-0f74-4a32-9b85-27aa86c49387" />

**API 명세서 사진:** (API 명세서 스크린샷을 첨부해주세요.)
<img width="1003" height="853" alt="image" src="https://github.com/user-attachments/assets/f451185b-0f84-4ee2-a16c-ec7720810ac1" />
<img width="1008" height="764" alt="image" src="https://github.com/user-attachments/assets/2911fa71-bff3-4705-97a6-acfa6927801f" />
<img width="1019" height="731" alt="image" src="https://github.com/user-attachments/assets/8c1fc385-c909-4772-a06b-7e99d87884fb" />
<img width="1013" height="372" alt="image" src="https://github.com/user-attachments/assets/185d2ae4-8640-4ed3-bfb8-925464aca225" />

**테스트 커버리지 사진:** (테스트 커버리지 스크린샷을 첨부해주세요.)
<img width="810" height="129" alt="image" src="https://github.com/user-attachments/assets/ef31013b-d361-4dd4-b5fb-12d637850818" />

Closes #505
