### PR TITLE
[FIX]댓글 좋아요 여부 표시 오류 수정

### DIFF
--- a/src/main/java/com/project200/undabang/comment/dto/response/CommentResponse.java
+++ b/src/main/java/com/project200/undabang/comment/dto/response/CommentResponse.java
@@ -1,9 +1,6 @@
 package com.project200.undabang.comment.dto.response;
 
-import com.project200.undabang.comment.entity.Comment;
-
 import java.time.LocalDateTime;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 
@@ -15,33 +12,7 @@ public record CommentResponse(
         String memberThumbnailUrl,
         String content,
         Integer likesCount,
+        Boolean commentIsLiked,
         LocalDateTime createdAt,
         List<CommentResponse> children) {
-
-    public static CommentResponse from(Comment comment) {
-        return of(comment, new ArrayList<>());
-    }
-
-    public static CommentResponse of(Comment comment, List<CommentResponse> children) {
-        String profileImageUrl = null;
-        String thumbnailUrl = null;
-
-        if (comment.getMember().getMemberPicture() != null) {
-            profileImageUrl = comment.getMember().getMemberPicture().getMemberPicturesUrl();
-            if (comment.getMember().getMemberPicture().getPicture() != null) {
-                thumbnailUrl = null; // 썸네일은 추후 개발 예정
-            }
-        }
-
-        return new CommentResponse(
-                comment.getId(),
-                comment.getMember().getMemberId(),
-                comment.getMember().getMemberNickname(),
-                profileImageUrl,
-                thumbnailUrl,
-                comment.getContent(),
-                comment.getLikesCount(),
-                comment.getCreatedAt(),
-                children);
-    }
 }

--- a/src/main/java/com/project200/undabang/comment/repository/CommentRepositoryCustom.java
+++ b/src/main/java/com/project200/undabang/comment/repository/CommentRepositoryCustom.java
@@ -1,10 +1,11 @@
 package com.project200.undabang.comment.repository;
 
 import com.project200.undabang.comment.dto.response.CommentResponse;
+import com.project200.undabang.member.entity.Member;
 
 import java.util.List;
 
 public interface CommentRepositoryCustom {
 
-    List<CommentResponse> findCommentsWithChildrenByFeedId(Long feedId);
+    List<CommentResponse> findCommentsWithChildrenByFeedId(Long feedId, Member currentMember);
 }

--- a/src/main/java/com/project200/undabang/comment/repository/impl/CommentRepositoryImpl.java
+++ b/src/main/java/com/project200/undabang/comment/repository/impl/CommentRepositoryImpl.java
@@ -1,17 +1,23 @@
 package com.project200.undabang.comment.repository.impl;
 
 import com.project200.undabang.comment.dto.response.CommentResponse;
-import com.project200.undabang.comment.entity.Comment;
 import com.project200.undabang.comment.entity.QComment;
 import com.project200.undabang.comment.repository.CommentRepositoryCustom;
 import com.project200.undabang.common.entity.QPicture;
+import com.project200.undabang.like.entity.QCommentLike;
+import com.project200.undabang.member.entity.Member;
 import com.project200.undabang.member.entity.QMember;
 import com.project200.undabang.member.entity.QMemberPicture;
+import com.querydsl.core.types.Projections;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.core.types.dsl.Expressions;
+import com.querydsl.jpa.JPAExpressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -22,19 +28,31 @@ public class CommentRepositoryImpl implements CommentRepositoryCustom {
 
     private final JPAQueryFactory queryFactory;
 
-    @Override
-    public List<CommentResponse> findCommentsWithChildrenByFeedId(Long feedId) {
-        QComment comment = QComment.comment;
-        QMember member = QMember.member;
-        QMemberPicture memberPicture = QMemberPicture.memberPicture;
-        QPicture picture = QPicture.picture;
+    private final QComment comment = QComment.comment;
+    private final QMember member = QMember.member;
+    private final QMemberPicture memberPicture = QMemberPicture.memberPicture;
+    private final QPicture picture = QPicture.picture;
+    private final QCommentLike commentLike = QCommentLike.commentLike;
 
+    @Override
+    public List<CommentResponse> findCommentsWithChildrenByFeedId(Long feedId, Member currentMember) {
         // 1. 부모 댓글 조회 (parent가 null인 것만)
-        List<Comment> parentComments = queryFactory
-                .selectFrom(comment)
-                .leftJoin(comment.member, member).fetchJoin()
-                .leftJoin(member.memberPicture, memberPicture).fetchJoin()
-                .leftJoin(memberPicture.picture, picture).fetchJoin()
+        List<CommentResponse> parentComments = queryFactory
+                .select(Projections.constructor(CommentResponse.class,
+                        comment.id,
+                        member.memberId,
+                        member.memberNickname,
+                        memberPicture.memberPicturesUrl,
+                        Expressions.nullExpression(String.class), // 썸네일은 추후 개발 예정
+                        comment.content,
+                        comment.likesCount,
+                        isCommentLikedExpression(currentMember),
+                        comment.createdAt,
+                        Expressions.constant(Collections.<CommentResponse>emptyList())))
+                .from(comment)
+                .leftJoin(comment.member, member)
+                .leftJoin(member.memberPicture, memberPicture)
+                .leftJoin(memberPicture.picture, picture)
                 .where(
                         comment.feed.id.eq(feedId),
                         comment.parent.isNull(),
@@ -48,32 +66,90 @@ public class CommentRepositoryImpl implements CommentRepositoryCustom {
 
         // 2. 부모 댓글 ID 목록 추출
         List<Long> parentIds = parentComments.stream()
-                .map(Comment::getId)
+                .map(CommentResponse::commentId)
                 .collect(Collectors.toList());
 
         // 3. 대댓글 조회
-        List<Comment> childComments = queryFactory
-                .selectFrom(comment)
-                .leftJoin(comment.member, member).fetchJoin()
-                .leftJoin(member.memberPicture, memberPicture).fetchJoin()
-                .leftJoin(memberPicture.picture, picture).fetchJoin()
+        List<CommentResponse> childComments = queryFactory
+                .select(Projections.constructor(CommentResponse.class,
+                        comment.id,
+                        member.memberId,
+                        member.memberNickname,
+                        memberPicture.memberPicturesUrl,
+                        Expressions.nullExpression(String.class),
+                        comment.content,
+                        comment.likesCount,
+                        isCommentLikedExpression(currentMember),
+                        comment.createdAt,
+                        Expressions.constant(Collections.<CommentResponse>emptyList())))
+                .from(comment)
+                .leftJoin(comment.member, member)
+                .leftJoin(member.memberPicture, memberPicture)
+                .leftJoin(memberPicture.picture, picture)
                 .where(
                         comment.parent.id.in(parentIds),
                         comment.deletedAt.isNull())
                 .orderBy(comment.createdAt.asc())
                 .fetch();
 
-        // 4. 부모 ID별 대댓글 그룹핑
-        Map<Long, List<CommentResponse>> childrenMap = childComments.stream()
-                .collect(Collectors.groupingBy(
-                        c -> c.getParent().getId(),
-                        Collectors.mapping(CommentResponse::from, Collectors.toList())));
+        // 4. 대댓글의 부모 ID를 가져오기 위한 매핑 쿼리
+        Map<Long, List<CommentResponse>> childrenMap = buildChildrenMap(childComments, parentIds);
 
         // 5. 부모 댓글에 대댓글 조립
         return parentComments.stream()
-                .map(parent -> CommentResponse.of(parent,
-                        childrenMap.getOrDefault(parent.getId(), new ArrayList<>())))
+                .map(parent -> new CommentResponse(
+                        parent.commentId(),
+                        parent.memberId(),
+                        parent.memberNickname(),
+                        parent.memberProfileImageUrl(),
+                        parent.memberThumbnailUrl(),
+                        parent.content(),
+                        parent.likesCount(),
+                        parent.commentIsLiked(),
+                        parent.createdAt(),
+                        childrenMap.getOrDefault(parent.commentId(), new ArrayList<>())))
                 .collect(Collectors.toList());
     }
 
+    /**
+     * 대댓글을 부모 댓글 ID별로 그룹핑합니다.
+     */
+    private Map<Long, List<CommentResponse>> buildChildrenMap(List<CommentResponse> childComments,
+                                                              List<Long> parentIds) {
+        if (childComments.isEmpty()) {
+            return Collections.emptyMap();
+        }
+
+        // 대댓글의 부모 ID 매핑을 위해 별도 조회
+        QComment c = QComment.comment;
+        Map<Long, Long> childToParentMap = queryFactory
+                .select(c.id, c.parent.id)
+                .from(c)
+                .where(c.parent.id.in(parentIds), c.deletedAt.isNull())
+                .fetch()
+                .stream()
+                .collect(Collectors.toMap(
+                        tuple -> tuple.get(c.id),
+                        tuple -> tuple.get(c.parent.id)));
+
+        return childComments.stream()
+                .collect(Collectors.groupingBy(
+                        child -> childToParentMap.getOrDefault(child.commentId(), -1L)));
+    }
+
+    /**
+     * 현재 사용자가 특정 댓글을 좋아요 했는지 확인하는 조건식을 생성합니다.
+     */
+    private BooleanExpression isCommentLikedExpression(Member currentMember) {
+        if (currentMember == null) {
+            return Expressions.FALSE;
+        }
+
+        return JPAExpressions
+                .selectOne()
+                .from(commentLike)
+                .where(commentLike.comment.id.eq(comment.id)
+                        .and(commentLike.member.memberId.eq(currentMember.getMemberId())))
+                .exists();
+    }
 }

--- a/src/main/java/com/project200/undabang/comment/service/impl/CommentQueryServiceImpl.java
+++ b/src/main/java/com/project200/undabang/comment/service/impl/CommentQueryServiceImpl.java
@@ -3,14 +3,18 @@ package com.project200.undabang.comment.service.impl;
 import com.project200.undabang.comment.dto.response.CommentResponse;
 import com.project200.undabang.comment.repository.CommentRepository;
 import com.project200.undabang.comment.service.CommentQueryService;
+import com.project200.undabang.common.context.UserContextHolder;
 import com.project200.undabang.common.web.exception.CustomException;
 import com.project200.undabang.common.web.exception.ErrorCode;
 import com.project200.undabang.feed.repository.FeedRepository;
+import com.project200.undabang.member.entity.Member;
+import com.project200.undabang.member.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.UUID;
 
 @Service
 @RequiredArgsConstructor
@@ -19,6 +23,7 @@ public class CommentQueryServiceImpl implements CommentQueryService {
 
     private final CommentRepository commentRepository;
     private final FeedRepository feedRepository;
+    private final MemberRepository memberRepository;
 
     @Override
     public List<CommentResponse> getComments(Long feedId) {
@@ -27,6 +32,12 @@ public class CommentQueryServiceImpl implements CommentQueryService {
             throw new CustomException(ErrorCode.FEED_NOT_FOUND);
         }
 
-        return commentRepository.findCommentsWithChildrenByFeedId(feedId);
+        // 현재 사용자 조회 (비로그인 시 null)
+        UUID currentUserId = UserContextHolder.getUserId();
+        Member currentMember = memberRepository
+                .findByMemberIdAndMemberDeletedAtNull(currentUserId)
+                .orElse(null);
+
+        return commentRepository.findCommentsWithChildrenByFeedId(feedId, currentMember);
     }
 }

--- a/src/test/java/com/project200/undabang/comment/controller/CommentQueryControllerTest.java
+++ b/src/test/java/com/project200/undabang/comment/controller/CommentQueryControllerTest.java
@@ -49,6 +49,7 @@ class CommentQueryControllerTest extends AbstractRestDocSupport {
                 null,
                 "대댓글 내용입니다.",
                 3,
+                false,
                 LocalDateTime.now().minusMinutes(30),
                 new ArrayList<>());
 
@@ -60,6 +61,7 @@ class CommentQueryControllerTest extends AbstractRestDocSupport {
                 null,
                 "부모 댓글 내용입니다.",
                 5,
+                true,
                 LocalDateTime.now().minusHours(1),
                 List.of(reply));
 
@@ -81,10 +83,11 @@ class CommentQueryControllerTest extends AbstractRestDocSupport {
             BDDMockito.given(commentQueryService.getComments(feedId)).willReturn(comments);
 
             // when
-            String response = mockMvc.perform(MockMvcRequestBuilders.get("/api/v1/feeds/{feedId}/comments", feedId)
-                    .contentType(MediaType.APPLICATION_JSON)
-                    .accept(MediaType.APPLICATION_JSON)
-                    .headers(getCommonApiHeaders(testMemberId)))
+            String response = mockMvc
+                    .perform(MockMvcRequestBuilders.get("/api/v1/feeds/{feedId}/comments", feedId)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .accept(MediaType.APPLICATION_JSON)
+                            .headers(getCommonApiHeaders(testMemberId)))
                     .andExpect(status().isOk())
                     .andDo(document.document(
                             requestHeaders(HEADER_ACCESS_TOKEN),
@@ -98,6 +101,7 @@ class CommentQueryControllerTest extends AbstractRestDocSupport {
                                     fieldWithPath("data[].memberThumbnailUrl").type(JsonFieldType.STRING).description("댓글 작성자 프로필 썸네일 URL입니다.").optional(),
                                     fieldWithPath("data[].content").type(JsonFieldType.STRING).description("댓글 내용입니다."),
                                     fieldWithPath("data[].likesCount").type(JsonFieldType.NUMBER).description("댓글 좋아요 수 입니다."),
+                                    fieldWithPath("data[].commentIsLiked").type(JsonFieldType.BOOLEAN).description("현재 사용자의 댓글 좋아요 여부입니다."),
                                     fieldWithPath("data[].createdAt").type(JsonFieldType.STRING).description("댓글이 작성된 시간입니다."),
                                     fieldWithPath("data[].children").type(JsonFieldType.ARRAY).description("대댓글 목록입니다."),
                                     fieldWithPath("data[].children[].commentId").type(JsonFieldType.NUMBER).description("대댓글 고유 식별자(ID) 입니다."),
@@ -107,6 +111,7 @@ class CommentQueryControllerTest extends AbstractRestDocSupport {
                                     fieldWithPath("data[].children[].memberThumbnailUrl").type(JsonFieldType.STRING).description("대댓글 작성자 프로필 썸네일 URL").optional(),
                                     fieldWithPath("data[].children[].content").type(JsonFieldType.STRING).description("대댓글 내용"),
                                     fieldWithPath("data[].children[].likesCount").type(JsonFieldType.NUMBER).description("대댓글 좋아요 수"),
+                                    fieldWithPath("data[].children[].commentIsLiked").type(JsonFieldType.BOOLEAN).description("현재 사용자의 대댓글 좋아요 여부"),
                                     fieldWithPath("data[].children[].createdAt").type(JsonFieldType.STRING).description("대댓글 작성 시간"),
                                     fieldWithPath("data[].children[].children").type(JsonFieldType.ARRAY).description("대댓글의 대댓글 (현재 미지원)")))))
                     .andReturn().getResponse().getContentAsString();

--- a/src/test/java/com/project200/undabang/comment/service/impl/CommentQueryServiceImplTest.java
+++ b/src/test/java/com/project200/undabang/comment/service/impl/CommentQueryServiceImplTest.java
@@ -2,25 +2,33 @@ package com.project200.undabang.comment.service.impl;
 
 import com.project200.undabang.comment.dto.response.CommentResponse;
 import com.project200.undabang.comment.repository.CommentRepository;
+import com.project200.undabang.common.context.UserContextHolder;
 import com.project200.undabang.common.web.exception.CustomException;
 import com.project200.undabang.common.web.exception.ErrorCode;
 import com.project200.undabang.feed.repository.FeedRepository;
+import com.project200.undabang.member.entity.Member;
+import com.project200.undabang.member.repository.MemberRepository;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.mockito.MockedStatic;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mockStatic;
 
 @ExtendWith(MockitoExtension.class)
 class CommentQueryServiceImplTest {
@@ -34,6 +42,27 @@ class CommentQueryServiceImplTest {
     @Mock
     private FeedRepository feedRepository;
 
+    @Mock
+    private MemberRepository memberRepository;
+
+    @Mock
+    private Member currentMember;
+
+    private MockedStatic<UserContextHolder> userContextHolderMock;
+    private UUID testUserId;
+
+    @BeforeEach
+    void setUp() {
+        testUserId = UUID.randomUUID();
+        userContextHolderMock = mockStatic(UserContextHolder.class);
+        userContextHolderMock.when(UserContextHolder::getUserId).thenReturn(testUserId);
+    }
+
+    @AfterEach
+    void tearDown() {
+        userContextHolderMock.close();
+    }
+
     private List<CommentResponse> createSampleComments() {
         CommentResponse reply = new CommentResponse(
                 2L,
@@ -43,6 +72,7 @@ class CommentQueryServiceImplTest {
                 null,
                 "대댓글 내용입니다.",
                 3,
+                false,
                 LocalDateTime.now().minusMinutes(30),
                 new ArrayList<>());
 
@@ -54,6 +84,7 @@ class CommentQueryServiceImplTest {
                 null,
                 "부모 댓글 내용입니다.",
                 5,
+                true,
                 LocalDateTime.now().minusHours(1),
                 List.of(reply));
 
@@ -72,7 +103,10 @@ class CommentQueryServiceImplTest {
             List<CommentResponse> mockComments = createSampleComments();
 
             given(feedRepository.existsById(feedId)).willReturn(true);
-            given(commentRepository.findCommentsWithChildrenByFeedId(feedId)).willReturn(mockComments);
+            given(memberRepository.findByMemberIdAndMemberDeletedAtNull(testUserId))
+                    .willReturn(Optional.of(currentMember));
+            given(commentRepository.findCommentsWithChildrenByFeedId(feedId, currentMember))
+                    .willReturn(mockComments);
 
             // when
             List<CommentResponse> result = commentQueryService.getComments(feedId);
@@ -103,7 +137,10 @@ class CommentQueryServiceImplTest {
             Long feedId = 1L;
 
             given(feedRepository.existsById(feedId)).willReturn(true);
-            given(commentRepository.findCommentsWithChildrenByFeedId(feedId)).willReturn(new ArrayList<>());
+            given(memberRepository.findByMemberIdAndMemberDeletedAtNull(testUserId))
+                    .willReturn(Optional.of(currentMember));
+            given(commentRepository.findCommentsWithChildrenByFeedId(feedId, currentMember))
+                    .willReturn(new ArrayList<>());
 
             // when
             List<CommentResponse> result = commentQueryService.getComments(feedId);


### PR DESCRIPTION
## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

CommentResponse에 Boolean commentIsLiked 필드 추가 — 댓글 조회 시 현재 사용자의 좋아요 여부를 응답에 포함하도록 변경

CommentRepositoryImpl을 Projection 방식으로 전환 — FeedRepositoryImpl의 isLikedExpression
 패턴과 동일하게 JPAExpressions.exists() 서브쿼리를 사용하여 DB 레벨에서 좋아요 여부를 판단

CommentQueryServiceImpl에서 현재 사용자 조회 후 Repository에 전달 — UserContextHolder로 로그인 사용자를 가져오고, 비로그인 시 false를 반환하도록 처리 + 관련 테스트 & RestDocs 업데이트

### 스크린샷 (선택)
**API 응답 사진:** (API 응답 스크린샷을 첨부해주세요.)
<img width="1082" height="1568" alt="image" src="https://github.com/user-attachments/assets/b7e9d3e9-aa7a-456b-9418-e073ae1e73ec" />

**API 명세서 사진:** (API 명세서 스크린샷을 첨부해주세요.)
<img width="1496" height="1340" alt="image" src="https://github.com/user-attachments/assets/59227b86-46fe-42cc-8272-881a4789c7c7" />
<img width="1514" height="1880" alt="image" src="https://github.com/user-attachments/assets/5afb4395-5d8b-4d7a-b61d-02b2a19e0ae8" />
<img width="1484" height="1966" alt="image" src="https://github.com/user-attachments/assets/2aabd18c-07a3-4934-96c3-51c8f71e59ec" />
<img width="1472" height="1966" alt="image" src="https://github.com/user-attachments/assets/e5e0e278-3af9-4a3d-a06c-14c8585a32f1" />
<img width="1564" height="746" alt="image" src="https://github.com/user-attachments/assets/723c30ab-801f-4527-9752-947181fa8353" />


**테스트 커버리지 사진:** (테스트 커버리지 스크린샷을 첨부해주세요.)
<img width="1228" height="198" alt="image" src="https://github.com/user-attachments/assets/009c3afd-bab6-406d-ab3b-0a5495b2759d" />

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

## #️⃣연관된 이슈

> ex) #이슈번호, Closes #이슈번호
