### PR TITLE
[FIX]댓글 commentIsLiked boolean 변수 빌드 테스트 오류 수정

### DIFF
--- a/src/test/java/com/project200/undabang/comment/repository/impl/CommentRepositoryImplTest.java
+++ b/src/test/java/com/project200/undabang/comment/repository/impl/CommentRepositoryImplTest.java
@@ -52,7 +52,7 @@ class CommentRepositoryImplTest {
             flushAndClear();
 
             // when
-            List<CommentResponse> result = commentRepository.findCommentsWithChildrenByFeedId(feed.getId());
+            List<CommentResponse> result = commentRepository.findCommentsWithChildrenByFeedId(feed.getId(), author);
 
             // then
             assertThat(result).hasSize(1);
@@ -73,7 +73,7 @@ class CommentRepositoryImplTest {
             flushAndClear();
 
             // when
-            List<CommentResponse> result = commentRepository.findCommentsWithChildrenByFeedId(feed.getId());
+            List<CommentResponse> result = commentRepository.findCommentsWithChildrenByFeedId(feed.getId(), author);
 
             // then
             assertThat(result).hasSize(1);
@@ -96,7 +96,7 @@ class CommentRepositoryImplTest {
             flushAndClear();
 
             // when
-            List<CommentResponse> result = commentRepository.findCommentsWithChildrenByFeedId(feed.getId());
+            List<CommentResponse> result = commentRepository.findCommentsWithChildrenByFeedId(feed.getId(), author);
 
             // then
             assertThat(result).hasSize(1);
@@ -122,7 +122,7 @@ class CommentRepositoryImplTest {
             flushAndClear();
 
             // when
-            List<CommentResponse> result = commentRepository.findCommentsWithChildrenByFeedId(feed.getId());
+            List<CommentResponse> result = commentRepository.findCommentsWithChildrenByFeedId(feed.getId(), author);
 
             // then
             assertThat(result).hasSize(1);
@@ -142,7 +142,7 @@ class CommentRepositoryImplTest {
             flushAndClear();
 
             // when
-            List<CommentResponse> result = commentRepository.findCommentsWithChildrenByFeedId(feed.getId());
+            List<CommentResponse> result = commentRepository.findCommentsWithChildrenByFeedId(feed.getId(), author);
 
             // then
             assertThat(result).hasSize(1);
@@ -160,7 +160,7 @@ class CommentRepositoryImplTest {
             flushAndClear();
 
             // when
-            List<CommentResponse> result = commentRepository.findCommentsWithChildrenByFeedId(feed.getId());
+            List<CommentResponse> result = commentRepository.findCommentsWithChildrenByFeedId(feed.getId(), author);
 
             // then
             assertThat(result).isEmpty();
@@ -183,7 +183,7 @@ class CommentRepositoryImplTest {
             flushAndClear();
 
             // when
-            List<CommentResponse> result = commentRepository.findCommentsWithChildrenByFeedId(feed.getId());
+            List<CommentResponse> result = commentRepository.findCommentsWithChildrenByFeedId(feed.getId(), author);
 
             // then
             assertThat(result).hasSize(2);
@@ -209,7 +209,7 @@ class CommentRepositoryImplTest {
             flushAndClear();
 
             // when
-            List<CommentResponse> result = commentRepository.findCommentsWithChildrenByFeedId(feed.getId());
+            List<CommentResponse> result = commentRepository.findCommentsWithChildrenByFeedId(feed.getId(), author);
 
             // then
             assertThat(result).hasSize(1);
@@ -243,10 +243,12 @@ class CommentRepositoryImplTest {
         MemberPicture memberPicture = MemberPicture.builder()
                 .member(member)
                 .picture(picture)
+                .memberPicturesUrl(url)
                 .build();
         em.persist(memberPicture);
 
         member.updateProfilePicture(memberPicture);
+        em.flush();
     }
 
     private Feed createAndSaveFeed(Member member, String content) {


### PR DESCRIPTION
## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

CommentResponse에 Boolean commentIsLiked 필드 추가 — 댓글 조회 시 현재 사용자의 좋아요 여부를 응답에 포함하도록 변경

CommentRepositoryImpl을 Projection 방식으로 전환 — FeedRepositoryImpl의 isLikedExpression
 패턴과 동일하게 JPAExpressions.exists() 서브쿼리를 사용하여 DB 레벨에서 좋아요 여부를 판단

CommentQueryServiceImpl에서 현재 사용자 조회 후 Repository에 전달 — UserContextHolder로 로그인 사용자를 가져오고, 비로그인 시 false를 반환하도록 처리 + 관련 테스트 & RestDocs 업데이트

### 스크린샷 (선택)
**API 응답 사진:** (API 응답 스크린샷을 첨부해주세요.)
<img width="1082" height="1568" alt="image" src="https://github.com/user-attachments/assets/b7e9d3e9-aa7a-456b-9418-e073ae1e73ec" />

**API 명세서 사진:** (API 명세서 스크린샷을 첨부해주세요.)
<img width="1496" height="1340" alt="image" src="https://github.com/user-attachments/assets/59227b86-46fe-42cc-8272-881a4789c7c7" />
<img width="1514" height="1880" alt="image" src="https://github.com/user-attachments/assets/5afb4395-5d8b-4d7a-b61d-02b2a19e0ae8" />
<img width="1484" height="1966" alt="image" src="https://github.com/user-attachments/assets/2aabd18c-07a3-4934-96c3-51c8f71e59ec" />
<img width="1472" height="1966" alt="image" src="https://github.com/user-attachments/assets/e5e0e278-3af9-4a3d-a06c-14c8585a32f1" />
<img width="1564" height="746" alt="image" src="https://github.com/user-attachments/assets/723c30ab-801f-4527-9752-947181fa8353" />


**테스트 커버리지 사진:** (테스트 커버리지 스크린샷을 첨부해주세요.)
<img width="1228" height="198" alt="image" src="https://github.com/user-attachments/assets/009c3afd-bab6-406d-ab3b-0a5495b2759d" />

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

## #️⃣연관된 이슈

> ex) #이슈번호, Closes #이슈번호
