### PR TITLE
[FEAT] 차단 관계가 있는 회원의 피드/댓글 조회 금지 설정

### DIFF
--- a/src/main/java/com/project200/undabang/comment/repository/impl/CommentRepositoryImpl.java
+++ b/src/main/java/com/project200/undabang/comment/repository/impl/CommentRepositoryImpl.java
@@ -7,6 +7,7 @@ import com.project200.undabang.common.entity.QPicture;
 import com.project200.undabang.like.entity.QCommentLike;
 import com.project200.undabang.member.entity.Member;
 import com.project200.undabang.member.entity.QMember;
+import com.project200.undabang.member.entity.QMemberBlock;
 import com.project200.undabang.member.entity.QMemberPicture;
 import com.querydsl.core.types.Projections;
 import com.querydsl.core.types.dsl.BooleanExpression;
@@ -33,6 +34,7 @@ public class CommentRepositoryImpl implements CommentRepositoryCustom {
     private final QMemberPicture memberPicture = QMemberPicture.memberPicture;
     private final QPicture picture = QPicture.picture;
     private final QCommentLike commentLike = QCommentLike.commentLike;
+    private final QMemberBlock memberBlock = QMemberBlock.memberBlock;
 
     @Override
     public List<CommentResponse> findCommentsWithChildrenByFeedId(Long feedId, Member currentMember) {
@@ -56,7 +58,8 @@ public class CommentRepositoryImpl implements CommentRepositoryCustom {
                 .where(
                         comment.feed.id.eq(feedId),
                         comment.parent.isNull(),
-                        comment.deletedAt.isNull())
+                        comment.deletedAt.isNull(),
+                        isNotBlockedCommentOwner(currentMember))
                 .orderBy(comment.createdAt.asc())
                 .fetch();
 
@@ -88,7 +91,8 @@ public class CommentRepositoryImpl implements CommentRepositoryCustom {
                 .leftJoin(memberPicture.picture, picture)
                 .where(
                         comment.parent.id.in(parentIds),
-                        comment.deletedAt.isNull())
+                        comment.deletedAt.isNull(),
+                        isNotBlockedCommentOwner(currentMember))
                 .orderBy(comment.createdAt.asc())
                 .fetch();
 
@@ -151,5 +155,30 @@ public class CommentRepositoryImpl implements CommentRepositoryCustom {
                 .where(commentLike.comment.id.eq(comment.id)
                         .and(commentLike.member.memberId.eq(currentMember.getMemberId())))
                 .exists();
+    }
+
+    /**
+     * 차단 관계(양방향)인 회원의 댓글을 제외하는 조건식을 생성합니다.
+     */
+    private BooleanExpression isNotBlockedCommentOwner(Member currentMember) {
+        if (currentMember == null) {
+            return null;
+        }
+
+        return JPAExpressions
+                .selectOne()
+                .from(memberBlock)
+                .where(
+                        memberBlock.memberBlockDeletedAt.isNull(),
+                        memberBlock.blocker.memberId.eq(currentMember.getMemberId())
+                                .and(memberBlock.blocked.memberId
+                                        .eq(comment.member.memberId))
+                                .or(
+                                        memberBlock.blocker.memberId.eq(
+                                                        comment.member.memberId)
+                                                .and(memberBlock.blocked.memberId
+                                                        .eq(currentMember
+                                                                .getMemberId()))))
+                .notExists();
     }
 }

--- a/src/main/java/com/project200/undabang/feed/repository/impl/FeedRepositoryImpl.java
+++ b/src/main/java/com/project200/undabang/feed/repository/impl/FeedRepositoryImpl.java
@@ -11,6 +11,7 @@ import com.project200.undabang.feed.entity.QFeedPicture;
 import com.project200.undabang.feed.entity.QFeedType;
 import com.project200.undabang.feed.repository.FeedRepositoryCustom;
 import com.project200.undabang.like.entity.QFeedLike;
+import com.project200.undabang.member.entity.QMemberBlock;
 import com.project200.undabang.member.entity.Member;
 import com.project200.undabang.member.entity.QMember;
 import com.project200.undabang.member.entity.QMemberPicture;
@@ -45,6 +46,7 @@ public class FeedRepositoryImpl implements FeedRepositoryCustom {
     private final QFeedPicture feedPicture = QFeedPicture.feedPicture;
     private final QFeedLike feedLike = QFeedLike.feedLike;
     private final QComment comment = QComment.comment;
+    private final QMemberBlock memberBlock = QMemberBlock.memberBlock;
 
     private static final int EXTRA_FETCH_SIZE = 1; // hasNext 확인용 상수
 
@@ -94,8 +96,7 @@ public class FeedRepositoryImpl implements FeedRepositoryCustom {
                 .leftJoin(feed.feedType, feedType)
                 .where(
                         feed.id.eq(feedId),
-                        feed.deletedAt.isNull()
-                ) // 삭제되지 않은 특정 피드만 조회
+                        feed.deletedAt.isNull()) // 삭제되지 않은 특정 피드만 조회
                 .fetchOne();
 
         // 해당 피드 데이터가 없는 경우 Optional.empty()를 반환
@@ -112,8 +113,7 @@ public class FeedRepositoryImpl implements FeedRepositoryCustom {
                 .where(
                         feedPicture.feed.id.eq(feedId),
                         feedPicture.feed.deletedAt.isNull(),
-                        picture.pictureDeletedAt.isNull()
-                )
+                        picture.pictureDeletedAt.isNull())
                 .fetch();
 
         return Optional.of(GetSpecificFeedResponse.from(contentRecord, feedPictureList));
@@ -128,7 +128,8 @@ public class FeedRepositoryImpl implements FeedRepositoryCustom {
      * @param condition     추가로 적용할 조건식
      * @return 특정 조건과 페이징 정보를 기반으로 필터링된 피드 상세 응답의 슬라이스
      */
-    private Slice<FeedDetailResponse> getFeedDetailSlice(Member currentMember, Long prevFeedId, Pageable pageable, BooleanExpression condition) {
+    private Slice<FeedDetailResponse> getFeedDetailSlice(Member currentMember, Long prevFeedId, Pageable pageable,
+            BooleanExpression condition) {
 
         List<FeedDetailRecord> contentRecords = queryFactory
                 .select(Projections.constructor(FeedDetailRecord.class,
@@ -154,8 +155,8 @@ public class FeedRepositoryImpl implements FeedRepositoryCustom {
                 .where(
                         olderThanPrevFeedId(prevFeedId),
                         feed.deletedAt.isNull(),
-                        condition
-                )
+                        isNotBlockedFeedOwner(currentMember),
+                        condition)
                 .orderBy(feed.id.desc()) // 최근 피드부터 읽기 (정확히는 최근에 작성된 피드가 생성도 늦게 되었다고 가정)
                 .limit(pageable.getPageSize() + EXTRA_FETCH_SIZE) // 다음 피드가 존재하는지 구별하도록 10 + 1 로 설정
                 .fetch();
@@ -252,5 +253,26 @@ public class FeedRepositoryImpl implements FeedRepositoryCustom {
                 .from(feedLike)
                 .where(feedLike.feed.id.eq(feed.id).and(feedLike.member.memberId.eq(currentMember.getMemberId())))
                 .exists();
+    }
+
+    /**
+     * 차단 관계(양방향)인 회원의 피드를 제외하는 조건식을 생성합니다.
+     */
+    private BooleanExpression isNotBlockedFeedOwner(Member currentMember) {
+        if (currentMember == null) {
+            return null;
+        }
+
+        return JPAExpressions
+                .selectOne()
+                .from(memberBlock)
+                .where(
+                        memberBlock.memberBlockDeletedAt.isNull(),
+                        memberBlock.blocker.memberId.eq(currentMember.getMemberId())
+                                .and(memberBlock.blocked.memberId.eq(feed.member.memberId))
+                                .or(
+                                        memberBlock.blocker.memberId.eq(feed.member.memberId)
+                                                .and(memberBlock.blocked.memberId.eq(currentMember.getMemberId()))))
+                .notExists();
     }
 }


### PR DESCRIPTION
## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

차단 관계에 있는 유저의 피드/댓글이 조회 되지 않도록 하였습니다.
### 스크린샷 (선택)
**API 응답 사진:** (API 응답 스크린샷을 첨부해주세요.)
<img width="2458" height="2002" alt="Pasted Graphic" src="https://github.com/user-attachments/assets/cfb315fd-321d-453b-b1e8-7b7c2ed76a4d" />
<img width="1648" height="1220" alt="Pasted Graphic 1" src="https://github.com/user-attachments/assets/421b53ec-bbb4-438c-b188-629a1fecbb56" />
<img width="2178" height="396" alt="Pasted Graphic 2" src="https://github.com/user-attachments/assets/23db4881-1ac4-4d05-b473-49dd8fc10ba8" />

**API 명세서 사진:** (API 명세서 스크린샷을 첨부해주세요.)

**테스트 커버리지 사진:** (테스트 커버리지 스크린샷을 첨부해주세요.)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

## #️⃣연관된 이슈

> ex) #이슈번호, Closes #537 
