### PR TITLE
[FIX]댓글에서 멤버 프로필 사진이 null로 반환되는 오류 수정

### DIFF
--- a/src/main/java/com/project200/undabang/comment/repository/impl/CommentRepositoryImpl.java
+++ b/src/main/java/com/project200/undabang/comment/repository/impl/CommentRepositoryImpl.java
@@ -48,7 +48,7 @@ public class CommentRepositoryImpl implements CommentRepositoryCustom {
                         comment.id,
                         member.memberId,
                         member.memberNickname,
-                        memberPicture.memberPicturesUrl,
+                        picture.pictureUrl,
                         Expressions.nullExpression(String.class), // 썸네일은 추후 개발 예정
                         comment.content,
                         comment.likesCount,
@@ -87,7 +87,7 @@ public class CommentRepositoryImpl implements CommentRepositoryCustom {
                         comment.id,
                         member.memberId,
                         member.memberNickname,
-                        memberPicture.memberPicturesUrl,
+                        picture.pictureUrl,
                         Expressions.nullExpression(String.class),
                         comment.content,
                         comment.likesCount,


### PR DESCRIPTION
## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
기존 개발 예정인 MemberPictureUrl에 쿼리문을 매핑해서 null로 반환이 되고 있었다. MemberPictureUrl은 썸네일 프로필 사진용 엔티티이다. 따라서 picture.pictureUrl로 매핑을 변경하였다.

### 스크린샷 (선택)
**API 응답 사진:** (API 응답 스크린샷을 첨부해주세요.)
<img width="1762" height="1914" alt="Pasted Graphic 1" src="https://github.com/user-attachments/assets/899860ce-49a4-4ce0-820c-ec11aa8e10b4" />

**API 명세서 사진:** (API 명세서 스크린샷을 첨부해주세요.)
<img width="1108" height="1982" alt="Pasted Graphic 2" src="https://github.com/user-attachments/assets/72f4b851-b6dd-490c-a30b-bfbca0ef8e80" />
<img width="1146" height="1934" alt="Pasted Graphic 3" src="https://github.com/user-attachments/assets/c1db5aa2-a837-463a-8192-236c9634e3db" />
<img width="1126" height="1988" alt="Pasted Graphic 4" src="https://github.com/user-attachments/assets/8dd07720-b62a-4fa1-b2ef-18abfe610f14" />
<img width="1156" height="566" alt="datal children taogesHember meaberNicknameStrite" src="https://github.com/user-attachments/assets/7dc3ee78-a3d3-497f-8c5a-077e1e6cc74f" />

**테스트 커버리지 사진:** (테스트 커버리지 스크린샷을 첨부해주세요.)
<img width="2014" height="240" alt="Pasted Graphic" src="https://github.com/user-attachments/assets/83a1960e-e59a-4edc-998d-0ef71ce92643" />

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

## #️⃣연관된 이슈

> ex) #이슈번호, Closes #이슈번호
