### PR TITLE
[FIX]사용자간의 채팅 방을 찾을 시에 중독 되어 있어도 맨 처음 채팅방으로 매핑되도록 변경

### DIFF
--- a/src/main/java/com/project200/undabang/chat/repository/impl/ChatroomRepositoryImpl.java
+++ b/src/main/java/com/project200/undabang/chat/repository/impl/ChatroomRepositoryImpl.java
@@ -174,6 +174,6 @@ public class ChatroomRepositoryImpl implements ChatroomRepositoryCustom {
                 .where(chatroomMember.member.in(currentMember, targetMember))
                 .groupBy(chatroomMember.chatroom.id)
                 .having(chatroomMember.count().eq(2L))
-                .fetchOne();
+                .fetchFirst();
     }
 }


### PR DESCRIPTION
## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
네트워크 오류로인해 서버 생성 요청이 2번 중복해서 날아갔을 시에 2개의 채팅방이 만들어지는 에러 발생
채팅방 조회시에 fetchOne()로직에 걸려 500 에러 발생해서 채팅 기능 오류
fetchOne()을 fetchFirst()로 변경하여 채팅방이 두개이상 생겨도 처음 생긴 채팅방으로 조회

### 스크린샷 (선택)
**API 응답 사진:** (API 응답 스크린샷을 첨부해주세요.)

**API 명세서 사진:** (API 명세서 스크린샷을 첨부해주세요.)

**테스트 커버리지 사진:** (테스트 커버리지 스크린샷을 첨부해주세요.)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

## #️⃣연관된 이슈

> ex) #이슈번호, Closes #이슈번호
