### PR TITLE
chore(AWS): 새 AWS 계정으로 서비스 이관 및 Cognito 이전 대응

### DIFF
--- a/.github/workflows/dev-server-cicd.yml
+++ b/.github/workflows/dev-server-cicd.yml
@@ -79,7 +79,7 @@ jobs:
       - name: Build and push image to Amazon ECR
         if: ${{ github.ref == 'refs/heads/develop' }}
         env:
-          REGISTRY: 825773631552.dkr.ecr.ap-northeast-2.amazonaws.com
+          REGISTRY: 867637277997.dkr.ecr.ap-northeast-2.amazonaws.com
           REPOSITORY: undabang/dev-server-repository
           IMAGE_TAG: latest
         run: |

--- a/.github/workflows/prod-server-cicd.yml
+++ b/.github/workflows/prod-server-cicd.yml
@@ -60,7 +60,7 @@ jobs:
       - name: Build and push image to Amazon ECR
         if: ${{ github.ref == 'refs/heads/main' }}
         env:
-          REGISTRY: 825773631552.dkr.ecr.ap-northeast-2.amazonaws.com
+          REGISTRY: 867637277997.dkr.ecr.ap-northeast-2.amazonaws.com
           REPOSITORY: undabang/prod-server-repository
           IMAGE_TAG: latest
         run: |

--- a/deploy-dev/deploy.sh
+++ b/deploy-dev/deploy.sh
@@ -9,7 +9,7 @@
 set -ex
 
 # 2. 필요한 변수 설정 (가독성 및 재사용성 증가)
-ECR_REGISTRY="825773631552.dkr.ecr.ap-northeast-2.amazonaws.com"
+ECR_REGISTRY="867637277997.dkr.ecr.ap-northeast-2.amazonaws.com"
 REPOSITORY_NAME="undabang/dev-server-repository"
 IMAGE_NAME="${ECR_REGISTRY}/${REPOSITORY_NAME}:latest"
 CONTAINER_NAME="server-dev"

--- a/deploy-dev/docker-compose.yml
+++ b/deploy-dev/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3"
 
 services:
   server-dev:
-    image: "825773631552.dkr.ecr.ap-northeast-2.amazonaws.com/undabang/dev-server-repository:latest"
+    image: "867637277997.dkr.ecr.ap-northeast-2.amazonaws.com/undabang/dev-server-repository:latest"
     restart: always
     container_name: "server-dev"
     ports:

--- a/deploy-prod/docker-compose-sub.yml
+++ b/deploy-prod/docker-compose-sub.yml
@@ -2,7 +2,7 @@ version: "3.3"
 
 services:
   server-prod-sub:
-    image: "825773631552.dkr.ecr.ap-northeast-2.amazonaws.com/undabang/prod-server-repository:latest"
+    image: "867637277997.dkr.ecr.ap-northeast-2.amazonaws.com/undabang/prod-server-repository:latest"
     container_name: "server-prod-sub"
     ports:
       - "8081:8080"

--- a/deploy-prod/docker-compose.yml
+++ b/deploy-prod/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3.3"
 
 services:
   server-prod:
-    image: "825773631552.dkr.ecr.ap-northeast-2.amazonaws.com/undabang/prod-server-repository:latest"
+    image: "867637277997.dkr.ecr.ap-northeast-2.amazonaws.com/undabang/prod-server-repository:latest"
     container_name: "server-prod"
     ports:
       - "8080:8080"

--- a/deploy-prod/scripts/config.sh
+++ b/deploy-prod/scripts/config.sh
@@ -6,7 +6,7 @@ export DEPLOY_DIR="/home/ec2-user/deploy/prod/zip"
 export SCRIPTS_DIR="${DEPLOY_DIR}/scripts"
 
 # ECR 설정
-export ECR_REGISTRY="825773631552.dkr.ecr.ap-northeast-2.amazonaws.com"
+export ECR_REGISTRY="867637277997.dkr.ecr.ap-northeast-2.amazonaws.com"
 export ECR_REPOSITORY="undabang/prod-server-repository"
 export IMAGE_TAG="latest"
 

--- a/src/main/java/com/project200/undabang/common/config/WebConfig.java
+++ b/src/main/java/com/project200/undabang/common/config/WebConfig.java
@@ -3,7 +3,7 @@ package com.project200.undabang.common.config;
 import com.project200.undabang.common.web.interceptor.XUserEmailCheckInterceptor;
 import com.project200.undabang.common.web.interceptor.XUserIdCheckInterceptor;
 import com.project200.undabang.member.repository.MemberRepository;
-import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
@@ -15,20 +15,26 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
  * 이 클래스는 인터셉터 등록 및 기타 웹 관련 설정을 담당합니다.
  */
 @Configuration
-@RequiredArgsConstructor
 public class WebConfig implements WebMvcConfigurer {
 
-    private final MemberRepository memberRepository;
+    private final ObjectProvider<MemberRepository> memberRepositoryProvider;
+
+    public WebConfig(ObjectProvider<MemberRepository> memberRepositoryProvider) {
+        this.memberRepositoryProvider = memberRepositoryProvider;
+    }
 
     /**
      * XUserIdCheckInterceptor 빈을 생성합니다.
      * 이 인터셉터는 요청에 X-User-Id 헤더가 있는지 확인합니다.
+     * <p>
+     * MemberRepository 는 {@link ObjectProvider} 로 주입받아 JPA 컨텍스트가 없는
+     * 테스트 슬라이스(@WebMvcTest 등)에서도 컨텍스트 로딩이 실패하지 않도록 합니다.
      *
      * @return XUserIdCheckInterceptor 인스턴스
      */
     @Bean
     public XUserIdCheckInterceptor xUserIdCheckInterceptor() {
-        return new XUserIdCheckInterceptor(memberRepository);
+        return new XUserIdCheckInterceptor(memberRepositoryProvider.getIfAvailable());
     }
 
     @Bean
@@ -56,7 +62,7 @@ public class WebConfig implements WebMvcConfigurer {
         // build reports를 위한 리소스 핸들러
         registry.addResourceHandler("/build/reports/**")
                 .addResourceLocations("classpath:/static/", "file:./build/reports/")
-                .setCachePeriod(3600) 
+                .setCachePeriod(3600)
                 .resourceChain(true);
 
         // REST Docs 문서를 위한 리소스 핸들러

--- a/src/main/java/com/project200/undabang/common/config/WebConfig.java
+++ b/src/main/java/com/project200/undabang/common/config/WebConfig.java
@@ -2,6 +2,8 @@ package com.project200.undabang.common.config;
 
 import com.project200.undabang.common.web.interceptor.XUserEmailCheckInterceptor;
 import com.project200.undabang.common.web.interceptor.XUserIdCheckInterceptor;
+import com.project200.undabang.member.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
@@ -13,7 +15,10 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
  * 이 클래스는 인터셉터 등록 및 기타 웹 관련 설정을 담당합니다.
  */
 @Configuration
+@RequiredArgsConstructor
 public class WebConfig implements WebMvcConfigurer {
+
+    private final MemberRepository memberRepository;
 
     /**
      * XUserIdCheckInterceptor 빈을 생성합니다.
@@ -23,7 +28,7 @@ public class WebConfig implements WebMvcConfigurer {
      */
     @Bean
     public XUserIdCheckInterceptor xUserIdCheckInterceptor() {
-        return new XUserIdCheckInterceptor();
+        return new XUserIdCheckInterceptor(memberRepository);
     }
 
     @Bean

--- a/src/main/java/com/project200/undabang/common/web/interceptor/XUserIdCheckInterceptor.java
+++ b/src/main/java/com/project200/undabang/common/web/interceptor/XUserIdCheckInterceptor.java
@@ -9,6 +9,7 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.lang.Nullable;
 import org.springframework.web.servlet.HandlerInterceptor;
 
 import java.util.Optional;
@@ -37,6 +38,11 @@ public class XUserIdCheckInterceptor implements HandlerInterceptor {
     /** X-USER-EMAIL 헤더 상수 */
     private static final String USER_EMAIL_HEADER = "X-USER-EMAIL";
 
+    /**
+     * MemberRepository 는 @WebMvcTest 등 JPA가 없는 슬라이스 테스트 컨텍스트에서는 null 일 수 있으며,
+     * 이 경우 email 기반 조회는 생략되고 기존 X-USER-ID(sub) fallback 만 수행됩니다.
+     */
+    @Nullable
     private final MemberRepository memberRepository;
 
     /**
@@ -61,7 +67,8 @@ public class XUserIdCheckInterceptor implements HandlerInterceptor {
         String userIdString = request.getHeader(USER_ID_HEADER);
 
         // 우선순위 1: email로 DB 조회 (Cognito 이전 후 sub 값이 바뀌어도 동작)
-        if (userEmail != null && !userEmail.isEmpty()) {
+        // memberRepository 가 주입되지 않은 테스트 컨텍스트에서는 건너뛰고 X-USER-ID fallback 사용
+        if (memberRepository != null && userEmail != null && !userEmail.isEmpty()) {
             Optional<Member> memberOpt = memberRepository.findByMemberEmailAndMemberDeletedAtNull(userEmail);
             if (memberOpt.isPresent()) {
                 UserContextHolder.setUserId(memberOpt.get().getMemberId());

--- a/src/main/java/com/project200/undabang/common/web/interceptor/XUserIdCheckInterceptor.java
+++ b/src/main/java/com/project200/undabang/common/web/interceptor/XUserIdCheckInterceptor.java
@@ -94,14 +94,14 @@ public class XUserIdCheckInterceptor implements HandlerInterceptor {
             }
         }
 
-        // X-USER-EMAIL 이 있었지만 DB 에서 회원을 찾지 못했고 X-USER-ID 도 없는 경우 → 인증 실패
+        // X-USER-ID 가 없어 컨텍스트를 설정할 수 없음
+        // (X-USER-EMAIL 이 있었지만 회원을 찾지 못한 케이스도 여기 포함 — 가입 전 유저일 수 있음)
         if (userEmail != null && !userEmail.isEmpty()) {
-            log.error("X-USER-EMAIL로 회원을 찾을 수 없고 X-USER-ID도 없습니다: uri={}, email={}",
+            log.error("X-USER-EMAIL은 있으나 회원 조회 실패 + X-USER-ID 누락: uri={}, email={}",
                     request.getRequestURI(), userEmail);
-            throw new CustomException(ErrorCode.AUTHENTICATION_FAILED);
+        } else {
+            log.error("X-USER-ID / X-USER-EMAIL 헤더가 모두 누락되었습니다: {}", request.getRequestURI());
         }
-
-        log.error("X-USER-ID / X-USER-EMAIL 헤더가 모두 누락되었습니다: {}", request.getRequestURI());
         throw new CustomException(ErrorCode.USER_ID_HEADER_MISSING);
     }
 

--- a/src/main/java/com/project200/undabang/common/web/interceptor/XUserIdCheckInterceptor.java
+++ b/src/main/java/com/project200/undabang/common/web/interceptor/XUserIdCheckInterceptor.java
@@ -3,34 +3,50 @@ package com.project200.undabang.common.web.interceptor;
 import com.project200.undabang.common.context.UserContextHolder;
 import com.project200.undabang.common.web.exception.CustomException;
 import com.project200.undabang.common.web.exception.ErrorCode;
+import com.project200.undabang.member.entity.Member;
+import com.project200.undabang.member.repository.MemberRepository;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.stereotype.Component;
 import org.springframework.web.servlet.HandlerInterceptor;
 
+import java.util.Optional;
 import java.util.UUID;
 
 /**
- * HTTP 요청의 X-USER-ID 헤더를 검증하고 사용자 컨텍스트를 설정하는 인터셉터
+ * HTTP 요청의 X-USER-ID / X-USER-EMAIL 헤더를 검증하고 사용자 컨텍스트를 설정하는 인터셉터
  * <p>
- * 이 인터셉터는 모든 요청에서 X-USER-ID 헤더를 확인하여:
+ * 이 인터셉터는 모든 요청에서 헤더를 확인하여:
  * <ul>
- *   <li>헤더가 존재하는지 검사합니다</li>
- *   <li>헤더 값이 유효한 UUID 형식인지 검증합니다</li>
+ *   <li>X-USER-EMAIL 헤더가 존재하면 이메일로 DB 조회하여 member_id를 컨텍스트에 설정합니다 (우선)</li>
+ *   <li>없거나 조회 실패 시 X-USER-ID(sub) 헤더가 유효한 UUID 형식인지 검증합니다</li>
  *   <li>유효한 경우 {@link UserContextHolder}에 사용자 ID를 설정합니다</li>
  * </ul>
+ * Cognito 사용자 풀 이전 시 sub 값이 바뀌어도 이메일로 회원을 찾을 수 있게 하기 위함입니다.
  * 요청 처리가 완료된 후에는 사용자 컨텍스트를 자동으로 초기화합니다.
  */
 
 @Slf4j
+@RequiredArgsConstructor
 public class XUserIdCheckInterceptor implements HandlerInterceptor {
 
     /** X-USER-ID 헤더 상수 */
     private static final String USER_ID_HEADER = "X-USER-ID";
 
+    /** X-USER-EMAIL 헤더 상수 */
+    private static final String USER_EMAIL_HEADER = "X-USER-EMAIL";
+
+    private final MemberRepository memberRepository;
+
     /**
-     * HTTP 요청이 처리되기 전에 X-USER-ID 헤더를 검증하고 사용자 컨텍스트를 설정합니다.
+     * HTTP 요청이 처리되기 전에 X-USER-EMAIL / X-USER-ID 헤더를 검증하고 사용자 컨텍스트를 설정합니다.
+     * <p>
+     * 우선순위:
+     * <ol>
+     *   <li>X-USER-EMAIL 로 DB 조회 성공 → member_id를 컨텍스트에 설정 (Cognito 이전 대응)</li>
+     *   <li>그 외 X-USER-ID(sub)를 UUID로 파싱해서 컨텍스트에 설정 (기존 방식)</li>
+     * </ol>
      *
      * @param request 현재 HTTP 요청
      * @param response 현재 HTTP 응답
@@ -41,21 +57,38 @@ public class XUserIdCheckInterceptor implements HandlerInterceptor {
      */
     @Override
     public boolean preHandle(final HttpServletRequest request, final HttpServletResponse response, final Object handler) throws Exception {
+        String userEmail = request.getHeader(USER_EMAIL_HEADER);
         String userIdString = request.getHeader(USER_ID_HEADER);
+
+        // 우선순위 1: email로 DB 조회 (Cognito 이전 후 sub 값이 바뀌어도 동작)
+        if (userEmail != null && !userEmail.isEmpty()) {
+            Optional<Member> memberOpt = memberRepository.findByMemberEmailAndMemberDeletedAtNull(userEmail);
+            if (memberOpt.isPresent()) {
+                UserContextHolder.setUserId(memberOpt.get().getMemberId());
+                UserContextHolder.setUserEmail(userEmail);
+                return true;
+            }
+            log.debug("X-USER-EMAIL로 회원을 찾을 수 없어 X-USER-ID로 fallback: {}", userEmail);
+        }
+
+        // 우선순위 2: sub(X-USER-ID) 기반 (기존 방식 — 신규 가입 직후 혹은 email 매핑 헤더가 없는 경우)
         if (userIdString != null && !userIdString.isEmpty()) {
             try {
                 UUID userId = UUID.fromString(userIdString);
                 UserContextHolder.setUserId(userId);
+                if (userEmail != null && !userEmail.isEmpty()) {
+                    UserContextHolder.setUserEmail(userEmail);
+                }
+                return true;
             } catch (IllegalArgumentException e) {
                 // UUID 형식이 잘못된 경우 로깅 또는 에러 처리
                 log.error("X-USER-ID header가 유효하지 않은 UUID 형식입니다: " + userIdString, e);
                 throw new CustomException(ErrorCode.INVALID_USER_ID_FORMAT);
             }
-        } else {
-            log.error("X-USER-ID 헤더가 누락되었습니다: " + request.getRequestURI());
-            throw new CustomException(ErrorCode.USER_ID_HEADER_MISSING);
         }
-        return true; // 계속해서 요청 처리 진행
+
+        log.error("X-USER-ID / X-USER-EMAIL 헤더가 모두 누락되었습니다: " + request.getRequestURI());
+        throw new CustomException(ErrorCode.USER_ID_HEADER_MISSING);
     }
 
     /**

--- a/src/main/java/com/project200/undabang/common/web/interceptor/XUserIdCheckInterceptor.java
+++ b/src/main/java/com/project200/undabang/common/web/interceptor/XUserIdCheckInterceptor.java
@@ -82,12 +82,19 @@ public class XUserIdCheckInterceptor implements HandlerInterceptor {
                 return true;
             } catch (IllegalArgumentException e) {
                 // UUID 형식이 잘못된 경우 로깅 또는 에러 처리
-                log.error("X-USER-ID header가 유효하지 않은 UUID 형식입니다: " + userIdString, e);
+                log.error("X-USER-ID header가 유효하지 않은 UUID 형식입니다: {}", userIdString, e);
                 throw new CustomException(ErrorCode.INVALID_USER_ID_FORMAT);
             }
         }
 
-        log.error("X-USER-ID / X-USER-EMAIL 헤더가 모두 누락되었습니다: " + request.getRequestURI());
+        // X-USER-EMAIL 이 있었지만 DB 에서 회원을 찾지 못했고 X-USER-ID 도 없는 경우 → 인증 실패
+        if (userEmail != null && !userEmail.isEmpty()) {
+            log.error("X-USER-EMAIL로 회원을 찾을 수 없고 X-USER-ID도 없습니다: uri={}, email={}",
+                    request.getRequestURI(), userEmail);
+            throw new CustomException(ErrorCode.AUTHENTICATION_FAILED);
+        }
+
+        log.error("X-USER-ID / X-USER-EMAIL 헤더가 모두 누락되었습니다: {}", request.getRequestURI());
         throw new CustomException(ErrorCode.USER_ID_HEADER_MISSING);
     }
 

--- a/src/main/java/com/project200/undabang/member/repository/MemberRepository.java
+++ b/src/main/java/com/project200/undabang/member/repository/MemberRepository.java
@@ -17,6 +17,8 @@ public interface MemberRepository extends JpaRepository<Member, UUID>, MemberRep
 
     Optional<Member> findByMemberIdAndMemberDeletedAtNull(UUID memberId);
 
+    Optional<Member> findByMemberEmailAndMemberDeletedAtNull(String memberEmail);
+
     @EntityGraph(attributePaths = {"memberPicture", "memberPicture.picture", "preferredExercises", "preferredExercises.exercise"})
     Optional<Member> findMemberProfileByMemberIdAndMemberDeletedAtNull(UUID memberId);
 }

--- a/src/test/resources/application-dev-docs.yml
+++ b/src/test/resources/application-dev-docs.yml
@@ -1,5 +1,5 @@
 restdocs:
   uris:
     scheme: https
-    host: api.undabang.store
+    host: api.undabang.site
     port: 443

--- a/src/test/resources/application-prod-docs.yml
+++ b/src/test/resources/application-prod-docs.yml
@@ -1,5 +1,5 @@
 restdocs:
   uris:
     scheme: https
-    host: api.undabang.store
+    host: api.undabang.site
     port: 443

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -73,7 +73,7 @@ cors:
 restdocs:
   uris:
     scheme: https
-    host: api.undabang.store
+    host: api.undabang.site
     port: 443
 
 batch:


### PR DESCRIPTION
## Summary
기존 AWS 계정(`825773631552`)에서 새 AWS 계정(`867637277997`)으로 인프라 이관 + `undabang.store` → `undabang.site` 도메인 변경에 따른 설정/코드 업데이트.

## 주요 변경사항

### 인프라 설정 (chore)
- ECR 레지스트리 주소 변경 (`825773631552` → `867637277997`)
  - `.github/workflows/dev-server-cicd.yml`
  - `.github/workflows/prod-server-cicd.yml`
  - `deploy-dev/deploy.sh`
  - `deploy-dev/docker-compose.yml`
  - `deploy-prod/docker-compose.yml`
  - `deploy-prod/docker-compose-sub.yml`
  - `deploy-prod/scripts/config.sh`
- REST Docs host 변경 (`api.undabang.store` → `api.undabang.site`)
  - `src/test/resources/application.yml`
  - `src/test/resources/application-dev-docs.yml`
  - `src/test/resources/application-prod-docs.yml`

### 코드 (feat)
- `XUserIdCheckInterceptor`에 `MemberRepository` 주입하여 email 기반 회원 조회 로직 추가
- Cognito 사용자 풀 이전 시 sub 값이 바뀌어도 email로 회원을 찾을 수 있도록 대응
- `MemberRepository.findByMemberEmailAndMemberDeletedAtNull` 추가

## 관련 GitHub Secrets
다음 Secrets도 함께 업데이트됨:
- \`APPLICATION_PROD_YML\`, \`APPLICATION_DEV_YML\` — 새 RDS 엔드포인트, 새 S3 버킷명, 새 도메인 반영
- \`AWS_ACCESS_KEY_ID\`, \`AWS_SECRET_ACCESS_KEY\` — 새 계정 IAM 사용자 (github-actions-ci)
- \`AWS_S3_DEPLOY_DEV_BUCKET_NAME\`, \`AWS_S3_DEPLOY_PROD_BUCKET_NAME\` — \`new-\` 접두사 버킷

## Test plan
- [ ] CI 빌드 성공 (ECR push)
- [ ] CodeDeploy 배포 성공 (새 계정)
- [ ] EC2에서 새 ECR 이미지로 컨테이너 재시작 확인
- [ ] 기존 Cognito JWT로 로그인 동작 확인 (email 조회 fallback)
- [ ] 새 Cognito JWT로 로그인 동작 확인 (email로 member_id 매핑)

🤖 Generated with [Claude Code](https://claude.com/claude-code)