### PR TITLE
Releases: AWS 계정 이전

### DIFF
--- a/.github/workflows/dev-server-cicd.yml
+++ b/.github/workflows/dev-server-cicd.yml
@@ -79,7 +79,7 @@ jobs:
       - name: Build and push image to Amazon ECR
         if: ${{ github.ref == 'refs/heads/develop' }}
         env:
-          REGISTRY: 825773631552.dkr.ecr.ap-northeast-2.amazonaws.com
+          REGISTRY: 867637277997.dkr.ecr.ap-northeast-2.amazonaws.com
           REPOSITORY: undabang/dev-server-repository
           IMAGE_TAG: latest
         run: |

--- a/.github/workflows/prod-server-cicd.yml
+++ b/.github/workflows/prod-server-cicd.yml
@@ -60,7 +60,7 @@ jobs:
       - name: Build and push image to Amazon ECR
         if: ${{ github.ref == 'refs/heads/main' }}
         env:
-          REGISTRY: 825773631552.dkr.ecr.ap-northeast-2.amazonaws.com
+          REGISTRY: 867637277997.dkr.ecr.ap-northeast-2.amazonaws.com
           REPOSITORY: undabang/prod-server-repository
           IMAGE_TAG: latest
         run: |

--- a/deploy-dev/deploy.sh
+++ b/deploy-dev/deploy.sh
@@ -9,7 +9,7 @@
 set -ex
 
 # 2. 필요한 변수 설정 (가독성 및 재사용성 증가)
-ECR_REGISTRY="825773631552.dkr.ecr.ap-northeast-2.amazonaws.com"
+ECR_REGISTRY="867637277997.dkr.ecr.ap-northeast-2.amazonaws.com"
 REPOSITORY_NAME="undabang/dev-server-repository"
 IMAGE_NAME="${ECR_REGISTRY}/${REPOSITORY_NAME}:latest"
 CONTAINER_NAME="server-dev"

--- a/deploy-dev/docker-compose.yml
+++ b/deploy-dev/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3"
 
 services:
   server-dev:
-    image: "825773631552.dkr.ecr.ap-northeast-2.amazonaws.com/undabang/dev-server-repository:latest"
+    image: "867637277997.dkr.ecr.ap-northeast-2.amazonaws.com/undabang/dev-server-repository:latest"
     restart: always
     container_name: "server-dev"
     ports:

--- a/deploy-prod/docker-compose-sub.yml
+++ b/deploy-prod/docker-compose-sub.yml
@@ -2,7 +2,7 @@ version: "3.3"
 
 services:
   server-prod-sub:
-    image: "825773631552.dkr.ecr.ap-northeast-2.amazonaws.com/undabang/prod-server-repository:latest"
+    image: "867637277997.dkr.ecr.ap-northeast-2.amazonaws.com/undabang/prod-server-repository:latest"
     container_name: "server-prod-sub"
     ports:
       - "8081:8080"

--- a/deploy-prod/docker-compose.yml
+++ b/deploy-prod/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3.3"
 
 services:
   server-prod:
-    image: "825773631552.dkr.ecr.ap-northeast-2.amazonaws.com/undabang/prod-server-repository:latest"
+    image: "867637277997.dkr.ecr.ap-northeast-2.amazonaws.com/undabang/prod-server-repository:latest"
     container_name: "server-prod"
     ports:
       - "8080:8080"

--- a/deploy-prod/scripts/config.sh
+++ b/deploy-prod/scripts/config.sh
@@ -6,7 +6,7 @@ export DEPLOY_DIR="/home/ec2-user/deploy/prod/zip"
 export SCRIPTS_DIR="${DEPLOY_DIR}/scripts"
 
 # ECR 설정
-export ECR_REGISTRY="825773631552.dkr.ecr.ap-northeast-2.amazonaws.com"
+export ECR_REGISTRY="867637277997.dkr.ecr.ap-northeast-2.amazonaws.com"
 export ECR_REPOSITORY="undabang/prod-server-repository"
 export IMAGE_TAG="latest"
 

--- a/src/main/java/com/project200/undabang/chat/repository/impl/ChatroomRepositoryImpl.java
+++ b/src/main/java/com/project200/undabang/chat/repository/impl/ChatroomRepositoryImpl.java
@@ -174,6 +174,6 @@ public class ChatroomRepositoryImpl implements ChatroomRepositoryCustom {
                 .where(chatroomMember.member.in(currentMember, targetMember))
                 .groupBy(chatroomMember.chatroom.id)
                 .having(chatroomMember.count().eq(2L))
-                .fetchFirst();
+                .fetchOne();
     }
 }

--- a/src/main/java/com/project200/undabang/chat/repository/impl/ChatroomRepositoryImpl.java
+++ b/src/main/java/com/project200/undabang/chat/repository/impl/ChatroomRepositoryImpl.java
@@ -174,6 +174,6 @@ public class ChatroomRepositoryImpl implements ChatroomRepositoryCustom {
                 .where(chatroomMember.member.in(currentMember, targetMember))
                 .groupBy(chatroomMember.chatroom.id)
                 .having(chatroomMember.count().eq(2L))
-                .fetchOne();
+                .fetchFirst();
     }
 }

--- a/src/main/java/com/project200/undabang/common/config/WebConfig.java
+++ b/src/main/java/com/project200/undabang/common/config/WebConfig.java
@@ -3,7 +3,7 @@ package com.project200.undabang.common.config;
 import com.project200.undabang.common.web.interceptor.XUserEmailCheckInterceptor;
 import com.project200.undabang.common.web.interceptor.XUserIdCheckInterceptor;
 import com.project200.undabang.member.repository.MemberRepository;
-import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
@@ -15,20 +15,26 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
  * 이 클래스는 인터셉터 등록 및 기타 웹 관련 설정을 담당합니다.
  */
 @Configuration
-@RequiredArgsConstructor
 public class WebConfig implements WebMvcConfigurer {
 
-    private final MemberRepository memberRepository;
+    private final ObjectProvider<MemberRepository> memberRepositoryProvider;
+
+    public WebConfig(ObjectProvider<MemberRepository> memberRepositoryProvider) {
+        this.memberRepositoryProvider = memberRepositoryProvider;
+    }
 
     /**
      * XUserIdCheckInterceptor 빈을 생성합니다.
      * 이 인터셉터는 요청에 X-User-Id 헤더가 있는지 확인합니다.
+     * <p>
+     * MemberRepository 는 {@link ObjectProvider} 로 주입받아 JPA 컨텍스트가 없는
+     * 테스트 슬라이스(@WebMvcTest 등)에서도 컨텍스트 로딩이 실패하지 않도록 합니다.
      *
      * @return XUserIdCheckInterceptor 인스턴스
      */
     @Bean
     public XUserIdCheckInterceptor xUserIdCheckInterceptor() {
-        return new XUserIdCheckInterceptor(memberRepository);
+        return new XUserIdCheckInterceptor(memberRepositoryProvider.getIfAvailable());
     }
 
     @Bean
@@ -56,7 +62,7 @@ public class WebConfig implements WebMvcConfigurer {
         // build reports를 위한 리소스 핸들러
         registry.addResourceHandler("/build/reports/**")
                 .addResourceLocations("classpath:/static/", "file:./build/reports/")
-                .setCachePeriod(3600) 
+                .setCachePeriod(3600)
                 .resourceChain(true);
 
         // REST Docs 문서를 위한 리소스 핸들러

--- a/src/main/java/com/project200/undabang/common/config/WebConfig.java
+++ b/src/main/java/com/project200/undabang/common/config/WebConfig.java
@@ -2,6 +2,8 @@ package com.project200.undabang.common.config;
 
 import com.project200.undabang.common.web.interceptor.XUserEmailCheckInterceptor;
 import com.project200.undabang.common.web.interceptor.XUserIdCheckInterceptor;
+import com.project200.undabang.member.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
@@ -13,7 +15,10 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
  * 이 클래스는 인터셉터 등록 및 기타 웹 관련 설정을 담당합니다.
  */
 @Configuration
+@RequiredArgsConstructor
 public class WebConfig implements WebMvcConfigurer {
+
+    private final MemberRepository memberRepository;
 
     /**
      * XUserIdCheckInterceptor 빈을 생성합니다.
@@ -23,7 +28,7 @@ public class WebConfig implements WebMvcConfigurer {
      */
     @Bean
     public XUserIdCheckInterceptor xUserIdCheckInterceptor() {
-        return new XUserIdCheckInterceptor();
+        return new XUserIdCheckInterceptor(memberRepository);
     }
 
     @Bean

--- a/src/main/java/com/project200/undabang/common/web/interceptor/XUserIdCheckInterceptor.java
+++ b/src/main/java/com/project200/undabang/common/web/interceptor/XUserIdCheckInterceptor.java
@@ -18,13 +18,15 @@ import java.util.UUID;
 /**
  * HTTP 요청의 X-USER-ID / X-USER-EMAIL 헤더를 검증하고 사용자 컨텍스트를 설정하는 인터셉터
  * <p>
- * 이 인터셉터는 모든 요청에서 헤더를 확인하여:
- * <ul>
- *   <li>X-USER-ID(sub)가 유효한 UUID 이고 해당 회원이 DB에 존재하면 그대로 사용합니다 (우선)</li>
- *   <li>X-USER-ID 로 회원을 찾지 못한 경우에만 X-USER-EMAIL 로 DB 조회하여 member_id 를 설정합니다 (Cognito 이전 fallback)</li>
- * </ul>
- * Cognito 사용자 풀 이전 시 sub 값이 바뀌어도 이메일로 회원을 찾을 수 있게 하기 위함이며,
- * email 을 fallback 으로만 사용하여 외부에서 email 헤더 위조만으로 타 계정 가장이 불가능하도록 제한합니다.
+ * 우선순위:
+ * <ol>
+ *   <li>X-USER-ID(sub) 가 유효한 UUID 이고 해당 회원이 DB 에 존재 → 그대로 컨텍스트에 설정 (대부분의 요청 경로)</li>
+ *   <li>X-USER-ID 로 회원을 찾지 못했고 X-USER-EMAIL 로 회원을 찾으면 그 회원의 member_id 로 설정 (Cognito 이전 fallback)</li>
+ *   <li>둘 다 실패했지만 X-USER-ID 가 유효한 UUID 인 경우 → '아직 가입되지 않은 사용자' (e.g. /auth/v1/sign-up) 로 간주하고
+ *       X-USER-ID 를 그대로 컨텍스트에 설정하여 하위 핸들러가 처리하도록 pass-through 한다</li>
+ * </ol>
+ * X-USER-ID / X-USER-EMAIL 은 API Gateway Cognito Authorizer 가 검증된 JWT 클레임에서 주입/덮어쓰는 것으로
+ * 신뢰되며, 외부에서 email 헤더만 위조해 타 계정을 가장하는 것은 Authorizer 계층에서 차단된다.
  * 요청 처리가 완료된 후에는 사용자 컨텍스트를 자동으로 초기화합니다.
  */
 
@@ -47,65 +49,64 @@ public class XUserIdCheckInterceptor implements HandlerInterceptor {
 
     /**
      * HTTP 요청이 처리되기 전에 X-USER-ID / X-USER-EMAIL 헤더를 검증하고 사용자 컨텍스트를 설정합니다.
-     * <p>
-     * 우선순위:
-     * <ol>
-     *   <li>X-USER-ID(sub) 를 UUID 로 파싱 → 회원 존재 시 컨텍스트에 설정 (기존 방식, 대부분의 요청 경로)</li>
-     *   <li>X-USER-ID 로 회원을 찾지 못했고 X-USER-EMAIL 이 존재 → email 로 DB 조회하여 설정 (Cognito 이전 fallback)</li>
-     * </ol>
-     * email fallback 은 X-USER-ID 로 회원을 찾지 못한 경우에만 동작하므로, 요청당 DB 조회는 일반적으로
-     * 존재 검증 1회로 끝나며, 외부에서 email 만 위조해 가장하는 것을 차단한다.
      *
      * @param request 현재 HTTP 요청
      * @param response 현재 HTTP 응답
      * @param handler 요청을 처리할 핸들러
      * @return 요청 처리를 계속 진행할지 여부 (true: 계속 진행, false: 중단)
-     * @throws Exception 예외 발생 시
-     * @throws CustomException 유효하지 않은 사용자 ID 형식 또는 헤더 누락 시
+     * @throws CustomException X-USER-ID 가 유효하지 않은 UUID 형식이거나 헤더가 전부 누락된 경우
      */
     @Override
-    public boolean preHandle(final HttpServletRequest request, final HttpServletResponse response, final Object handler) throws Exception {
+    public boolean preHandle(final HttpServletRequest request, final HttpServletResponse response, final Object handler) {
         String userEmail = request.getHeader(USER_EMAIL_HEADER);
         String userIdString = request.getHeader(USER_ID_HEADER);
 
-        // 우선순위 1: X-USER-ID(sub) — 회원 ID 와 일치하면 그대로 사용
+        UUID parsedUserId = null;
         if (userIdString != null && !userIdString.isEmpty()) {
             try {
-                UUID userId = UUID.fromString(userIdString);
-                // memberRepository 가 없는 슬라이스 테스트 컨텍스트에서는 존재 검증을 생략한다.
-                if (memberRepository == null || memberRepository.existsById(userId)) {
-                    UserContextHolder.setUserId(userId);
-                    if (userEmail != null && !userEmail.isEmpty()) {
-                        UserContextHolder.setUserEmail(userEmail);
-                    }
-                    return true;
-                }
-                log.debug("X-USER-ID 로 회원을 찾지 못해 X-USER-EMAIL fallback 시도: userId={}, email={}",
-                        userId, maskEmail(userEmail));
+                parsedUserId = UUID.fromString(userIdString);
             } catch (IllegalArgumentException e) {
                 log.error("X-USER-ID header가 유효하지 않은 UUID 형식입니다: {}", userIdString, e);
                 throw new CustomException(ErrorCode.INVALID_USER_ID_FORMAT);
             }
         }
 
-        // 우선순위 2: X-USER-EMAIL fallback (Cognito 이전으로 sub 가 바뀐 회원 대응)
+        // 우선순위 1: X-USER-ID(sub) 가 회원 ID 와 일치하면 그대로 사용 (대부분의 요청)
+        // memberRepository 가 없는 슬라이스 테스트 컨텍스트에서는 존재 검증을 생략한다.
+        if (parsedUserId != null && (memberRepository == null || memberRepository.existsById(parsedUserId))) {
+            setContext(parsedUserId, userEmail);
+            return true;
+        }
+
+        // 우선순위 2: X-USER-EMAIL fallback (Cognito 이전으로 sub 가 바뀐 기존 회원 대응)
         if (memberRepository != null && userEmail != null && !userEmail.isEmpty()) {
             Optional<Member> memberOpt = memberRepository.findByMemberEmailAndMemberDeletedAtNull(userEmail);
             if (memberOpt.isPresent()) {
-                UserContextHolder.setUserId(memberOpt.get().getMemberId());
-                UserContextHolder.setUserEmail(userEmail);
+                setContext(memberOpt.get().getMemberId(), userEmail);
                 return true;
             }
         }
 
-        // 둘 다 실패
-        if (userEmail != null && !userEmail.isEmpty()) {
-            log.error("X-USER-EMAIL 은 있으나 회원 조회 실패 + X-USER-ID 매핑 실패: uri={}, email={}",
-                    request.getRequestURI(), maskEmail(userEmail));
-        } else {
-            log.error("X-USER-ID / X-USER-EMAIL 헤더가 모두 누락되었습니다: {}", request.getRequestURI());
+        // 우선순위 3: X-USER-ID 는 유효하지만 DB 에 없고 email 로도 찾지 못한 경우
+        //            → '아직 가입되지 않은 사용자' (e.g. /auth/v1/sign-up) 플로우로 간주하고
+        //              X-USER-ID 로 컨텍스트만 세팅한 뒤 pass-through 한다.
+        if (parsedUserId != null) {
+            log.debug("신규 사용자 추정 pass-through: userId={}, email={}, uri={}",
+                    parsedUserId, maskEmail(userEmail), request.getRequestURI());
+            setContext(parsedUserId, userEmail);
+            return true;
         }
+
+        // X-USER-ID 자체가 없는 경우
+        log.error("X-USER-ID 헤더가 누락되었습니다: {}", request.getRequestURI());
         throw new CustomException(ErrorCode.USER_ID_HEADER_MISSING);
+    }
+
+    private static void setContext(UUID userId, String userEmail) {
+        UserContextHolder.setUserId(userId);
+        if (userEmail != null && !userEmail.isEmpty()) {
+            UserContextHolder.setUserEmail(userEmail);
+        }
     }
 
     /**
@@ -123,7 +124,7 @@ public class XUserIdCheckInterceptor implements HandlerInterceptor {
     }
 
     /**
-     * 이메일의 로컬 파트를 마스킹한다 (예: dongwon@example.com → d*****n@example.com).
+     * 이메일의 로컬 파트를 마스킹한다 (예: dongwon@example.com → d***n@example.com).
      * 로그에 PII 가 원본 그대로 남지 않도록 하기 위함.
      */
     private static String maskEmail(String email) {

--- a/src/main/java/com/project200/undabang/common/web/interceptor/XUserIdCheckInterceptor.java
+++ b/src/main/java/com/project200/undabang/common/web/interceptor/XUserIdCheckInterceptor.java
@@ -9,6 +9,7 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.lang.Nullable;
 import org.springframework.web.servlet.HandlerInterceptor;
 
 import java.util.Optional;
@@ -37,6 +38,11 @@ public class XUserIdCheckInterceptor implements HandlerInterceptor {
     /** X-USER-EMAIL 헤더 상수 */
     private static final String USER_EMAIL_HEADER = "X-USER-EMAIL";
 
+    /**
+     * MemberRepository 는 @WebMvcTest 등 JPA가 없는 슬라이스 테스트 컨텍스트에서는 null 일 수 있으며,
+     * 이 경우 email 기반 조회는 생략되고 기존 X-USER-ID(sub) fallback 만 수행됩니다.
+     */
+    @Nullable
     private final MemberRepository memberRepository;
 
     /**
@@ -61,7 +67,8 @@ public class XUserIdCheckInterceptor implements HandlerInterceptor {
         String userIdString = request.getHeader(USER_ID_HEADER);
 
         // 우선순위 1: email로 DB 조회 (Cognito 이전 후 sub 값이 바뀌어도 동작)
-        if (userEmail != null && !userEmail.isEmpty()) {
+        // memberRepository 가 주입되지 않은 테스트 컨텍스트에서는 건너뛰고 X-USER-ID fallback 사용
+        if (memberRepository != null && userEmail != null && !userEmail.isEmpty()) {
             Optional<Member> memberOpt = memberRepository.findByMemberEmailAndMemberDeletedAtNull(userEmail);
             if (memberOpt.isPresent()) {
                 UserContextHolder.setUserId(memberOpt.get().getMemberId());

--- a/src/main/java/com/project200/undabang/common/web/interceptor/XUserIdCheckInterceptor.java
+++ b/src/main/java/com/project200/undabang/common/web/interceptor/XUserIdCheckInterceptor.java
@@ -94,14 +94,14 @@ public class XUserIdCheckInterceptor implements HandlerInterceptor {
             }
         }
 
-        // X-USER-EMAIL 이 있었지만 DB 에서 회원을 찾지 못했고 X-USER-ID 도 없는 경우 → 인증 실패
+        // X-USER-ID 가 없어 컨텍스트를 설정할 수 없음
+        // (X-USER-EMAIL 이 있었지만 회원을 찾지 못한 케이스도 여기 포함 — 가입 전 유저일 수 있음)
         if (userEmail != null && !userEmail.isEmpty()) {
-            log.error("X-USER-EMAIL로 회원을 찾을 수 없고 X-USER-ID도 없습니다: uri={}, email={}",
+            log.error("X-USER-EMAIL은 있으나 회원 조회 실패 + X-USER-ID 누락: uri={}, email={}",
                     request.getRequestURI(), userEmail);
-            throw new CustomException(ErrorCode.AUTHENTICATION_FAILED);
+        } else {
+            log.error("X-USER-ID / X-USER-EMAIL 헤더가 모두 누락되었습니다: {}", request.getRequestURI());
         }
-
-        log.error("X-USER-ID / X-USER-EMAIL 헤더가 모두 누락되었습니다: {}", request.getRequestURI());
         throw new CustomException(ErrorCode.USER_ID_HEADER_MISSING);
     }
 

--- a/src/main/java/com/project200/undabang/common/web/interceptor/XUserIdCheckInterceptor.java
+++ b/src/main/java/com/project200/undabang/common/web/interceptor/XUserIdCheckInterceptor.java
@@ -13,6 +13,7 @@ import org.springframework.lang.Nullable;
 import org.springframework.web.servlet.HandlerInterceptor;
 
 import java.util.Optional;
+import java.util.Set;
 import java.util.UUID;
 
 /**
@@ -21,13 +22,13 @@ import java.util.UUID;
  * 우선순위:
  * <ol>
  *   <li>X-USER-ID(sub) 가 유효한 UUID 이고 해당 회원이 DB 에 존재 → 그대로 컨텍스트에 설정 (대부분의 요청 경로)</li>
- *   <li>X-USER-ID 로 회원을 찾지 못했고 X-USER-EMAIL 로 회원을 찾으면 그 회원의 member_id 로 설정 (Cognito 이전 fallback)</li>
- *   <li>둘 다 실패했지만 X-USER-ID 가 유효한 UUID 인 경우 → '아직 가입되지 않은 사용자' (e.g. /auth/v1/sign-up) 로 간주하고
- *       X-USER-ID 를 그대로 컨텍스트에 설정하여 하위 핸들러가 처리하도록 pass-through 한다</li>
+ *   <li>X-USER-ID 는 있으나 DB 에 없고 X-USER-EMAIL 로 회원을 찾으면 그 회원의 member_id 로 설정 (Cognito 이전 fallback).
+ *       이 fallback 은 반드시 X-USER-ID 가 선행되어야 동작하므로, email 헤더만 단독으로 위조해 가장하는 경로는 차단된다.</li>
+ *   <li>{@link #UNREGISTERED_USER_ALLOWED_URIS} 에 등록된 URI (e.g. /auth/v1/sign-up) 에서는 DB/email 모두 찾지 못해도
+ *       X-USER-ID 로 컨텍스트만 세팅하고 pass-through 한다 (아직 가입되지 않은 사용자용).</li>
  * </ol>
- * X-USER-ID / X-USER-EMAIL 은 API Gateway Cognito Authorizer 가 검증된 JWT 클레임에서 주입/덮어쓰는 것으로
- * 신뢰되며, 외부에서 email 헤더만 위조해 타 계정을 가장하는 것은 Authorizer 계층에서 차단된다.
- * 요청 처리가 완료된 후에는 사용자 컨텍스트를 자동으로 초기화합니다.
+ * X-USER-ID / X-USER-EMAIL 은 API Gateway Cognito Authorizer 가 검증된 JWT 클레임에서 주입/덮어쓰는 것으로 신뢰된다.
+ * 요청 처리가 완료된 후에는 사용자 컨텍스트를 자동으로 초기화한다.
  */
 
 @Slf4j
@@ -39,6 +40,14 @@ public class XUserIdCheckInterceptor implements HandlerInterceptor {
 
     /** X-USER-EMAIL 헤더 상수 */
     private static final String USER_EMAIL_HEADER = "X-USER-EMAIL";
+
+    /**
+     * DB 에 회원이 아직 존재하지 않아도 통과시켜야 하는 URI allowlist.
+     * 회원 가입 플로우는 신규 사용자를 DB 에 저장하기 전 단계이므로 컨텍스트만 세팅하고 pass-through 한다.
+     */
+    private static final Set<String> UNREGISTERED_USER_ALLOWED_URIS = Set.of(
+            "/auth/v1/sign-up"
+    );
 
     /**
      * MemberRepository 는 @WebMvcTest 등 JPA가 없는 슬라이스 테스트 컨텍스트에서는 null 일 수 있으며,
@@ -79,7 +88,8 @@ public class XUserIdCheckInterceptor implements HandlerInterceptor {
         }
 
         // 우선순위 2: X-USER-EMAIL fallback (Cognito 이전으로 sub 가 바뀐 기존 회원 대응)
-        if (memberRepository != null && userEmail != null && !userEmail.isEmpty()) {
+        // X-USER-ID 가 선행 존재해야만 동작시켜, email 헤더 단독 위조로 타 계정을 가장하는 것을 차단한다.
+        if (parsedUserId != null && memberRepository != null && userEmail != null && !userEmail.isEmpty()) {
             Optional<Member> memberOpt = memberRepository.findByMemberEmailAndMemberDeletedAtNull(userEmail);
             if (memberOpt.isPresent()) {
                 setContext(memberOpt.get().getMemberId(), userEmail);
@@ -87,19 +97,23 @@ public class XUserIdCheckInterceptor implements HandlerInterceptor {
             }
         }
 
-        // 우선순위 3: X-USER-ID 는 유효하지만 DB 에 없고 email 로도 찾지 못한 경우
-        //            → '아직 가입되지 않은 사용자' (e.g. /auth/v1/sign-up) 플로우로 간주하고
-        //              X-USER-ID 로 컨텍스트만 세팅한 뒤 pass-through 한다.
-        if (parsedUserId != null) {
-            log.debug("신규 사용자 추정 pass-through: userId={}, email={}, uri={}",
-                    parsedUserId, maskEmail(userEmail), request.getRequestURI());
+        // 우선순위 3: 회원 가입 등 allowlist URI 에서만, X-USER-ID 로 컨텍스트 세팅 후 pass-through
+        String uri = request.getRequestURI();
+        if (parsedUserId != null && UNREGISTERED_USER_ALLOWED_URIS.contains(uri)) {
+            log.debug("신규 사용자 pass-through: userId={}, email={}, uri={}",
+                    parsedUserId, maskEmail(userEmail), uri);
             setContext(parsedUserId, userEmail);
             return true;
         }
 
-        // X-USER-ID 자체가 없는 경우
-        log.error("X-USER-ID 헤더가 누락되었습니다: {}", request.getRequestURI());
-        throw new CustomException(ErrorCode.USER_ID_HEADER_MISSING);
+        // 그 외: 회원을 특정할 수 없어 인증 실패로 처리
+        if (parsedUserId == null) {
+            log.error("X-USER-ID 헤더가 누락되었습니다: {}", uri);
+            throw new CustomException(ErrorCode.USER_ID_HEADER_MISSING);
+        }
+        log.error("X-USER-ID / X-USER-EMAIL 로 회원을 특정하지 못했습니다: userId={}, email={}, uri={}",
+                parsedUserId, maskEmail(userEmail), uri);
+        throw new CustomException(ErrorCode.AUTHENTICATION_FAILED);
     }
 
     private static void setContext(UUID userId, String userEmail) {

--- a/src/main/java/com/project200/undabang/common/web/interceptor/XUserIdCheckInterceptor.java
+++ b/src/main/java/com/project200/undabang/common/web/interceptor/XUserIdCheckInterceptor.java
@@ -20,11 +20,11 @@ import java.util.UUID;
  * <p>
  * 이 인터셉터는 모든 요청에서 헤더를 확인하여:
  * <ul>
- *   <li>X-USER-EMAIL 헤더가 존재하면 이메일로 DB 조회하여 member_id를 컨텍스트에 설정합니다 (우선)</li>
- *   <li>없거나 조회 실패 시 X-USER-ID(sub) 헤더가 유효한 UUID 형식인지 검증합니다</li>
- *   <li>유효한 경우 {@link UserContextHolder}에 사용자 ID를 설정합니다</li>
+ *   <li>X-USER-ID(sub)가 유효한 UUID 이고 해당 회원이 DB에 존재하면 그대로 사용합니다 (우선)</li>
+ *   <li>X-USER-ID 로 회원을 찾지 못한 경우에만 X-USER-EMAIL 로 DB 조회하여 member_id 를 설정합니다 (Cognito 이전 fallback)</li>
  * </ul>
- * Cognito 사용자 풀 이전 시 sub 값이 바뀌어도 이메일로 회원을 찾을 수 있게 하기 위함입니다.
+ * Cognito 사용자 풀 이전 시 sub 값이 바뀌어도 이메일로 회원을 찾을 수 있게 하기 위함이며,
+ * email 을 fallback 으로만 사용하여 외부에서 email 헤더 위조만으로 타 계정 가장이 불가능하도록 제한합니다.
  * 요청 처리가 완료된 후에는 사용자 컨텍스트를 자동으로 초기화합니다.
  */
 
@@ -40,19 +40,21 @@ public class XUserIdCheckInterceptor implements HandlerInterceptor {
 
     /**
      * MemberRepository 는 @WebMvcTest 등 JPA가 없는 슬라이스 테스트 컨텍스트에서는 null 일 수 있으며,
-     * 이 경우 email 기반 조회는 생략되고 기존 X-USER-ID(sub) fallback 만 수행됩니다.
+     * 이 경우 email 기반 조회 및 존재 검증은 생략되고 X-USER-ID(sub) 파싱만 수행됩니다.
      */
     @Nullable
     private final MemberRepository memberRepository;
 
     /**
-     * HTTP 요청이 처리되기 전에 X-USER-EMAIL / X-USER-ID 헤더를 검증하고 사용자 컨텍스트를 설정합니다.
+     * HTTP 요청이 처리되기 전에 X-USER-ID / X-USER-EMAIL 헤더를 검증하고 사용자 컨텍스트를 설정합니다.
      * <p>
      * 우선순위:
      * <ol>
-     *   <li>X-USER-EMAIL 로 DB 조회 성공 → member_id를 컨텍스트에 설정 (Cognito 이전 대응)</li>
-     *   <li>그 외 X-USER-ID(sub)를 UUID로 파싱해서 컨텍스트에 설정 (기존 방식)</li>
+     *   <li>X-USER-ID(sub) 를 UUID 로 파싱 → 회원 존재 시 컨텍스트에 설정 (기존 방식, 대부분의 요청 경로)</li>
+     *   <li>X-USER-ID 로 회원을 찾지 못했고 X-USER-EMAIL 이 존재 → email 로 DB 조회하여 설정 (Cognito 이전 fallback)</li>
      * </ol>
+     * email fallback 은 X-USER-ID 로 회원을 찾지 못한 경우에만 동작하므로, 요청당 DB 조회는 일반적으로
+     * 존재 검증 1회로 끝나며, 외부에서 email 만 위조해 가장하는 것을 차단한다.
      *
      * @param request 현재 HTTP 요청
      * @param response 현재 HTTP 응답
@@ -66,8 +68,27 @@ public class XUserIdCheckInterceptor implements HandlerInterceptor {
         String userEmail = request.getHeader(USER_EMAIL_HEADER);
         String userIdString = request.getHeader(USER_ID_HEADER);
 
-        // 우선순위 1: email로 DB 조회 (Cognito 이전 후 sub 값이 바뀌어도 동작)
-        // memberRepository 가 주입되지 않은 테스트 컨텍스트에서는 건너뛰고 X-USER-ID fallback 사용
+        // 우선순위 1: X-USER-ID(sub) — 회원 ID 와 일치하면 그대로 사용
+        if (userIdString != null && !userIdString.isEmpty()) {
+            try {
+                UUID userId = UUID.fromString(userIdString);
+                // memberRepository 가 없는 슬라이스 테스트 컨텍스트에서는 존재 검증을 생략한다.
+                if (memberRepository == null || memberRepository.existsById(userId)) {
+                    UserContextHolder.setUserId(userId);
+                    if (userEmail != null && !userEmail.isEmpty()) {
+                        UserContextHolder.setUserEmail(userEmail);
+                    }
+                    return true;
+                }
+                log.debug("X-USER-ID 로 회원을 찾지 못해 X-USER-EMAIL fallback 시도: userId={}, email={}",
+                        userId, maskEmail(userEmail));
+            } catch (IllegalArgumentException e) {
+                log.error("X-USER-ID header가 유효하지 않은 UUID 형식입니다: {}", userIdString, e);
+                throw new CustomException(ErrorCode.INVALID_USER_ID_FORMAT);
+            }
+        }
+
+        // 우선순위 2: X-USER-EMAIL fallback (Cognito 이전으로 sub 가 바뀐 회원 대응)
         if (memberRepository != null && userEmail != null && !userEmail.isEmpty()) {
             Optional<Member> memberOpt = memberRepository.findByMemberEmailAndMemberDeletedAtNull(userEmail);
             if (memberOpt.isPresent()) {
@@ -75,30 +96,12 @@ public class XUserIdCheckInterceptor implements HandlerInterceptor {
                 UserContextHolder.setUserEmail(userEmail);
                 return true;
             }
-            log.debug("X-USER-EMAIL로 회원을 찾을 수 없어 X-USER-ID로 fallback: {}", userEmail);
         }
 
-        // 우선순위 2: sub(X-USER-ID) 기반 (기존 방식 — 신규 가입 직후 혹은 email 매핑 헤더가 없는 경우)
-        if (userIdString != null && !userIdString.isEmpty()) {
-            try {
-                UUID userId = UUID.fromString(userIdString);
-                UserContextHolder.setUserId(userId);
-                if (userEmail != null && !userEmail.isEmpty()) {
-                    UserContextHolder.setUserEmail(userEmail);
-                }
-                return true;
-            } catch (IllegalArgumentException e) {
-                // UUID 형식이 잘못된 경우 로깅 또는 에러 처리
-                log.error("X-USER-ID header가 유효하지 않은 UUID 형식입니다: {}", userIdString, e);
-                throw new CustomException(ErrorCode.INVALID_USER_ID_FORMAT);
-            }
-        }
-
-        // X-USER-ID 가 없어 컨텍스트를 설정할 수 없음
-        // (X-USER-EMAIL 이 있었지만 회원을 찾지 못한 케이스도 여기 포함 — 가입 전 유저일 수 있음)
+        // 둘 다 실패
         if (userEmail != null && !userEmail.isEmpty()) {
-            log.error("X-USER-EMAIL은 있으나 회원 조회 실패 + X-USER-ID 누락: uri={}, email={}",
-                    request.getRequestURI(), userEmail);
+            log.error("X-USER-EMAIL 은 있으나 회원 조회 실패 + X-USER-ID 매핑 실패: uri={}, email={}",
+                    request.getRequestURI(), maskEmail(userEmail));
         } else {
             log.error("X-USER-ID / X-USER-EMAIL 헤더가 모두 누락되었습니다: {}", request.getRequestURI());
         }
@@ -117,5 +120,25 @@ public class XUserIdCheckInterceptor implements HandlerInterceptor {
     @Override
     public void afterCompletion(final HttpServletRequest request, final HttpServletResponse response, final Object handler, final Exception ex) throws Exception {
         UserContextHolder.reset();
+    }
+
+    /**
+     * 이메일의 로컬 파트를 마스킹한다 (예: dongwon@example.com → d*****n@example.com).
+     * 로그에 PII 가 원본 그대로 남지 않도록 하기 위함.
+     */
+    private static String maskEmail(String email) {
+        if (email == null || email.isEmpty()) {
+            return "";
+        }
+        int atIdx = email.indexOf('@');
+        if (atIdx <= 0) {
+            return "***";
+        }
+        String local = email.substring(0, atIdx);
+        String domain = email.substring(atIdx);
+        if (local.length() <= 2) {
+            return local.charAt(0) + "***" + domain;
+        }
+        return local.charAt(0) + "***" + local.charAt(local.length() - 1) + domain;
     }
 }

--- a/src/main/java/com/project200/undabang/common/web/interceptor/XUserIdCheckInterceptor.java
+++ b/src/main/java/com/project200/undabang/common/web/interceptor/XUserIdCheckInterceptor.java
@@ -3,34 +3,50 @@ package com.project200.undabang.common.web.interceptor;
 import com.project200.undabang.common.context.UserContextHolder;
 import com.project200.undabang.common.web.exception.CustomException;
 import com.project200.undabang.common.web.exception.ErrorCode;
+import com.project200.undabang.member.entity.Member;
+import com.project200.undabang.member.repository.MemberRepository;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.stereotype.Component;
 import org.springframework.web.servlet.HandlerInterceptor;
 
+import java.util.Optional;
 import java.util.UUID;
 
 /**
- * HTTP 요청의 X-USER-ID 헤더를 검증하고 사용자 컨텍스트를 설정하는 인터셉터
+ * HTTP 요청의 X-USER-ID / X-USER-EMAIL 헤더를 검증하고 사용자 컨텍스트를 설정하는 인터셉터
  * <p>
- * 이 인터셉터는 모든 요청에서 X-USER-ID 헤더를 확인하여:
+ * 이 인터셉터는 모든 요청에서 헤더를 확인하여:
  * <ul>
- *   <li>헤더가 존재하는지 검사합니다</li>
- *   <li>헤더 값이 유효한 UUID 형식인지 검증합니다</li>
+ *   <li>X-USER-EMAIL 헤더가 존재하면 이메일로 DB 조회하여 member_id를 컨텍스트에 설정합니다 (우선)</li>
+ *   <li>없거나 조회 실패 시 X-USER-ID(sub) 헤더가 유효한 UUID 형식인지 검증합니다</li>
  *   <li>유효한 경우 {@link UserContextHolder}에 사용자 ID를 설정합니다</li>
  * </ul>
+ * Cognito 사용자 풀 이전 시 sub 값이 바뀌어도 이메일로 회원을 찾을 수 있게 하기 위함입니다.
  * 요청 처리가 완료된 후에는 사용자 컨텍스트를 자동으로 초기화합니다.
  */
 
 @Slf4j
+@RequiredArgsConstructor
 public class XUserIdCheckInterceptor implements HandlerInterceptor {
 
     /** X-USER-ID 헤더 상수 */
     private static final String USER_ID_HEADER = "X-USER-ID";
 
+    /** X-USER-EMAIL 헤더 상수 */
+    private static final String USER_EMAIL_HEADER = "X-USER-EMAIL";
+
+    private final MemberRepository memberRepository;
+
     /**
-     * HTTP 요청이 처리되기 전에 X-USER-ID 헤더를 검증하고 사용자 컨텍스트를 설정합니다.
+     * HTTP 요청이 처리되기 전에 X-USER-EMAIL / X-USER-ID 헤더를 검증하고 사용자 컨텍스트를 설정합니다.
+     * <p>
+     * 우선순위:
+     * <ol>
+     *   <li>X-USER-EMAIL 로 DB 조회 성공 → member_id를 컨텍스트에 설정 (Cognito 이전 대응)</li>
+     *   <li>그 외 X-USER-ID(sub)를 UUID로 파싱해서 컨텍스트에 설정 (기존 방식)</li>
+     * </ol>
      *
      * @param request 현재 HTTP 요청
      * @param response 현재 HTTP 응답
@@ -41,21 +57,38 @@ public class XUserIdCheckInterceptor implements HandlerInterceptor {
      */
     @Override
     public boolean preHandle(final HttpServletRequest request, final HttpServletResponse response, final Object handler) throws Exception {
+        String userEmail = request.getHeader(USER_EMAIL_HEADER);
         String userIdString = request.getHeader(USER_ID_HEADER);
+
+        // 우선순위 1: email로 DB 조회 (Cognito 이전 후 sub 값이 바뀌어도 동작)
+        if (userEmail != null && !userEmail.isEmpty()) {
+            Optional<Member> memberOpt = memberRepository.findByMemberEmailAndMemberDeletedAtNull(userEmail);
+            if (memberOpt.isPresent()) {
+                UserContextHolder.setUserId(memberOpt.get().getMemberId());
+                UserContextHolder.setUserEmail(userEmail);
+                return true;
+            }
+            log.debug("X-USER-EMAIL로 회원을 찾을 수 없어 X-USER-ID로 fallback: {}", userEmail);
+        }
+
+        // 우선순위 2: sub(X-USER-ID) 기반 (기존 방식 — 신규 가입 직후 혹은 email 매핑 헤더가 없는 경우)
         if (userIdString != null && !userIdString.isEmpty()) {
             try {
                 UUID userId = UUID.fromString(userIdString);
                 UserContextHolder.setUserId(userId);
+                if (userEmail != null && !userEmail.isEmpty()) {
+                    UserContextHolder.setUserEmail(userEmail);
+                }
+                return true;
             } catch (IllegalArgumentException e) {
                 // UUID 형식이 잘못된 경우 로깅 또는 에러 처리
                 log.error("X-USER-ID header가 유효하지 않은 UUID 형식입니다: " + userIdString, e);
                 throw new CustomException(ErrorCode.INVALID_USER_ID_FORMAT);
             }
-        } else {
-            log.error("X-USER-ID 헤더가 누락되었습니다: " + request.getRequestURI());
-            throw new CustomException(ErrorCode.USER_ID_HEADER_MISSING);
         }
-        return true; // 계속해서 요청 처리 진행
+
+        log.error("X-USER-ID / X-USER-EMAIL 헤더가 모두 누락되었습니다: " + request.getRequestURI());
+        throw new CustomException(ErrorCode.USER_ID_HEADER_MISSING);
     }
 
     /**

--- a/src/main/java/com/project200/undabang/common/web/interceptor/XUserIdCheckInterceptor.java
+++ b/src/main/java/com/project200/undabang/common/web/interceptor/XUserIdCheckInterceptor.java
@@ -82,12 +82,19 @@ public class XUserIdCheckInterceptor implements HandlerInterceptor {
                 return true;
             } catch (IllegalArgumentException e) {
                 // UUID 형식이 잘못된 경우 로깅 또는 에러 처리
-                log.error("X-USER-ID header가 유효하지 않은 UUID 형식입니다: " + userIdString, e);
+                log.error("X-USER-ID header가 유효하지 않은 UUID 형식입니다: {}", userIdString, e);
                 throw new CustomException(ErrorCode.INVALID_USER_ID_FORMAT);
             }
         }
 
-        log.error("X-USER-ID / X-USER-EMAIL 헤더가 모두 누락되었습니다: " + request.getRequestURI());
+        // X-USER-EMAIL 이 있었지만 DB 에서 회원을 찾지 못했고 X-USER-ID 도 없는 경우 → 인증 실패
+        if (userEmail != null && !userEmail.isEmpty()) {
+            log.error("X-USER-EMAIL로 회원을 찾을 수 없고 X-USER-ID도 없습니다: uri={}, email={}",
+                    request.getRequestURI(), userEmail);
+            throw new CustomException(ErrorCode.AUTHENTICATION_FAILED);
+        }
+
+        log.error("X-USER-ID / X-USER-EMAIL 헤더가 모두 누락되었습니다: {}", request.getRequestURI());
         throw new CustomException(ErrorCode.USER_ID_HEADER_MISSING);
     }
 

--- a/src/main/java/com/project200/undabang/member/repository/MemberRepository.java
+++ b/src/main/java/com/project200/undabang/member/repository/MemberRepository.java
@@ -17,6 +17,8 @@ public interface MemberRepository extends JpaRepository<Member, UUID>, MemberRep
 
     Optional<Member> findByMemberIdAndMemberDeletedAtNull(UUID memberId);
 
+    Optional<Member> findByMemberEmailAndMemberDeletedAtNull(String memberEmail);
+
     @EntityGraph(attributePaths = {"memberPicture", "memberPicture.picture", "preferredExercises", "preferredExercises.exercise"})
     Optional<Member> findMemberProfileByMemberIdAndMemberDeletedAtNull(UUID memberId);
 }

--- a/src/test/java/com/project200/undabang/common/web/interceptor/XUserIdCheckInterceptorTest.java
+++ b/src/test/java/com/project200/undabang/common/web/interceptor/XUserIdCheckInterceptorTest.java
@@ -107,8 +107,8 @@ class XUserIdCheckInterceptorTest {
     class NewUserPassThrough {
 
         @Test
-        @DisplayName("X-USER-ID 가 유효 UUID 이고 DB/email 모두 찾지 못해도 신규 가입 플로우로 간주하고 통과")
-        void unknownUserId_andEmailNotFound_passesThroughForSignUp() {
+        @DisplayName("/auth/v1/sign-up 에서 X-USER-ID 가 유효 UUID 이고 DB/email 모두 찾지 못해도 통과")
+        void signUpUri_unknownUserIdAndEmail_passesThrough() {
             UUID incomingSub = UUID.randomUUID();
             request.addHeader("X-USER-ID", incomingSub.toString());
             request.addHeader("X-USER-EMAIL", "newuser@example.com");
@@ -125,10 +125,11 @@ class XUserIdCheckInterceptorTest {
         }
 
         @Test
-        @DisplayName("X-USER-EMAIL 없이 X-USER-ID 만 있는 신규 사용자도 통과")
-        void unknownUserId_withoutEmail_passesThrough() {
+        @DisplayName("/auth/v1/sign-up 에서 X-USER-EMAIL 없이 X-USER-ID 만 있어도 통과")
+        void signUpUri_userIdOnly_passesThrough() {
             UUID incomingSub = UUID.randomUUID();
             request.addHeader("X-USER-ID", incomingSub.toString());
+            request.setRequestURI("/auth/v1/sign-up");
             given(memberRepository.existsById(incomingSub)).willReturn(false);
 
             boolean result = interceptor.preHandle(request, response, new Object());
@@ -163,14 +164,52 @@ class XUserIdCheckInterceptorTest {
         }
 
         @Test
-        @DisplayName("X-USER-ID 는 비어있고 X-USER-EMAIL 만 있는 경우에도 USER_ID_HEADER_MISSING")
-        void onlyEmailHeader_throwsUserIdHeaderMissing() {
-            request.addHeader("X-USER-EMAIL", "user@example.com");
+        @DisplayName("X-USER-ID 없이 X-USER-EMAIL 만 있어도 email fallback 은 동작하지 않고 USER_ID_HEADER_MISSING")
+        void onlyEmailHeader_doesNotTriggerFallbackAndThrowsUserIdHeaderMissing() {
+            // email 단독 위조로 타 계정을 가장할 수 없도록, fallback 은 X-USER-ID 가 선행되어야 한다.
+            Member existing = Member.builder().memberId(UUID.randomUUID()).memberEmail("victim@example.com").build();
+            request.addHeader("X-USER-EMAIL", "victim@example.com");
+            // findByMemberEmail 이 호출되더라도 fallback 이 동작하지 않아야 함을 검증하기 위해 stub 를 넣는다.
+            given(memberRepository.findByMemberEmailAndMemberDeletedAtNull("victim@example.com"))
+                    .willReturn(Optional.of(existing));
 
             assertThatThrownBy(() -> interceptor.preHandle(request, response, new Object()))
                     .isInstanceOf(CustomException.class)
                     .extracting(ex -> ((CustomException) ex).getErrorCode())
                     .isEqualTo(ErrorCode.USER_ID_HEADER_MISSING);
+            assertThat(UserContextHolder.getUserId()).isNull();
+        }
+
+        @Test
+        @DisplayName("sign-up 이외 URI 에서 X-USER-ID 가 DB 에 없고 email 로도 찾지 못하면 AUTHENTICATION_FAILED")
+        void nonSignUpUri_unknownUserIdAndEmail_throwsAuthenticationFailed() {
+            UUID incomingSub = UUID.randomUUID();
+            request.addHeader("X-USER-ID", incomingSub.toString());
+            request.addHeader("X-USER-EMAIL", "ghost@example.com");
+            request.setRequestURI("/api/members/me");
+            given(memberRepository.existsById(incomingSub)).willReturn(false);
+            given(memberRepository.findByMemberEmailAndMemberDeletedAtNull("ghost@example.com"))
+                    .willReturn(Optional.empty());
+
+            assertThatThrownBy(() -> interceptor.preHandle(request, response, new Object()))
+                    .isInstanceOf(CustomException.class)
+                    .extracting(ex -> ((CustomException) ex).getErrorCode())
+                    .isEqualTo(ErrorCode.AUTHENTICATION_FAILED);
+            assertThat(UserContextHolder.getUserId()).isNull();
+        }
+
+        @Test
+        @DisplayName("sign-up 이외 URI 에서 X-USER-ID 가 DB 에 없고 email 도 없으면 AUTHENTICATION_FAILED")
+        void nonSignUpUri_unknownUserIdWithoutEmail_throwsAuthenticationFailed() {
+            UUID incomingSub = UUID.randomUUID();
+            request.addHeader("X-USER-ID", incomingSub.toString());
+            request.setRequestURI("/api/members/me");
+            given(memberRepository.existsById(incomingSub)).willReturn(false);
+
+            assertThatThrownBy(() -> interceptor.preHandle(request, response, new Object()))
+                    .isInstanceOf(CustomException.class)
+                    .extracting(ex -> ((CustomException) ex).getErrorCode())
+                    .isEqualTo(ErrorCode.AUTHENTICATION_FAILED);
         }
     }
 

--- a/src/test/java/com/project200/undabang/common/web/interceptor/XUserIdCheckInterceptorTest.java
+++ b/src/test/java/com/project200/undabang/common/web/interceptor/XUserIdCheckInterceptorTest.java
@@ -1,0 +1,214 @@
+package com.project200.undabang.common.web.interceptor;
+
+import com.project200.undabang.common.context.UserContextHolder;
+import com.project200.undabang.common.web.exception.CustomException;
+import com.project200.undabang.common.web.exception.ErrorCode;
+import com.project200.undabang.member.entity.Member;
+import com.project200.undabang.member.repository.MemberRepository;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+
+@DisplayName("XUserIdCheckInterceptor 단위 테스트")
+class XUserIdCheckInterceptorTest {
+
+    private MemberRepository memberRepository;
+    private XUserIdCheckInterceptor interceptor;
+    private MockHttpServletRequest request;
+    private MockHttpServletResponse response;
+
+    @BeforeEach
+    void setUp() {
+        memberRepository = mock(MemberRepository.class);
+        interceptor = new XUserIdCheckInterceptor(memberRepository);
+        request = new MockHttpServletRequest();
+        response = new MockHttpServletResponse();
+        UserContextHolder.reset();
+    }
+
+    @AfterEach
+    void tearDown() {
+        UserContextHolder.reset();
+    }
+
+    @Nested
+    @DisplayName("X-USER-ID 기반 정상 경로")
+    class UserIdHappyPath {
+
+        @Test
+        @DisplayName("X-USER-ID 가 DB 에 존재하면 해당 ID 로 컨텍스트 세팅하고 통과")
+        void existingUserId_setsContext() {
+            UUID userId = UUID.randomUUID();
+            request.addHeader("X-USER-ID", userId.toString());
+            request.addHeader("X-USER-EMAIL", "user@example.com");
+            given(memberRepository.existsById(userId)).willReturn(true);
+
+            boolean result = interceptor.preHandle(request, response, new Object());
+
+            assertThat(result).isTrue();
+            assertThat(UserContextHolder.getUserId()).isEqualTo(userId);
+            assertThat(UserContextHolder.getUserEmail()).isEqualTo("user@example.com");
+        }
+
+        @Test
+        @DisplayName("X-USER-ID 만 있고 email 이 없어도 정상 통과")
+        void existingUserId_withoutEmail_setsContext() {
+            UUID userId = UUID.randomUUID();
+            request.addHeader("X-USER-ID", userId.toString());
+            given(memberRepository.existsById(userId)).willReturn(true);
+
+            boolean result = interceptor.preHandle(request, response, new Object());
+
+            assertThat(result).isTrue();
+            assertThat(UserContextHolder.getUserId()).isEqualTo(userId);
+            assertThat(UserContextHolder.getUserEmail()).isNull();
+        }
+    }
+
+    @Nested
+    @DisplayName("X-USER-EMAIL fallback (Cognito 이전)")
+    class EmailFallback {
+
+        @Test
+        @DisplayName("X-USER-ID 가 DB 에 없지만 email 로 회원을 찾으면 그 회원 ID 로 세팅")
+        void unknownUserId_butEmailMatches_usesMemberIdFromEmail() {
+            UUID incomingSub = UUID.randomUUID();
+            UUID dbMemberId = UUID.randomUUID();
+            Member existing = Member.builder().memberId(dbMemberId).memberEmail("user@example.com").build();
+
+            request.addHeader("X-USER-ID", incomingSub.toString());
+            request.addHeader("X-USER-EMAIL", "user@example.com");
+            given(memberRepository.existsById(incomingSub)).willReturn(false);
+            given(memberRepository.findByMemberEmailAndMemberDeletedAtNull("user@example.com"))
+                    .willReturn(Optional.of(existing));
+
+            boolean result = interceptor.preHandle(request, response, new Object());
+
+            assertThat(result).isTrue();
+            assertThat(UserContextHolder.getUserId()).isEqualTo(dbMemberId);
+            assertThat(UserContextHolder.getUserEmail()).isEqualTo("user@example.com");
+        }
+    }
+
+    @Nested
+    @DisplayName("신규 사용자 pass-through")
+    class NewUserPassThrough {
+
+        @Test
+        @DisplayName("X-USER-ID 가 유효 UUID 이고 DB/email 모두 찾지 못해도 신규 가입 플로우로 간주하고 통과")
+        void unknownUserId_andEmailNotFound_passesThroughForSignUp() {
+            UUID incomingSub = UUID.randomUUID();
+            request.addHeader("X-USER-ID", incomingSub.toString());
+            request.addHeader("X-USER-EMAIL", "newuser@example.com");
+            request.setRequestURI("/auth/v1/sign-up");
+            given(memberRepository.existsById(incomingSub)).willReturn(false);
+            given(memberRepository.findByMemberEmailAndMemberDeletedAtNull("newuser@example.com"))
+                    .willReturn(Optional.empty());
+
+            boolean result = interceptor.preHandle(request, response, new Object());
+
+            assertThat(result).isTrue();
+            assertThat(UserContextHolder.getUserId()).isEqualTo(incomingSub);
+            assertThat(UserContextHolder.getUserEmail()).isEqualTo("newuser@example.com");
+        }
+
+        @Test
+        @DisplayName("X-USER-EMAIL 없이 X-USER-ID 만 있는 신규 사용자도 통과")
+        void unknownUserId_withoutEmail_passesThrough() {
+            UUID incomingSub = UUID.randomUUID();
+            request.addHeader("X-USER-ID", incomingSub.toString());
+            given(memberRepository.existsById(incomingSub)).willReturn(false);
+
+            boolean result = interceptor.preHandle(request, response, new Object());
+
+            assertThat(result).isTrue();
+            assertThat(UserContextHolder.getUserId()).isEqualTo(incomingSub);
+        }
+    }
+
+    @Nested
+    @DisplayName("에러 케이스")
+    class Errors {
+
+        @Test
+        @DisplayName("X-USER-ID 가 유효하지 않은 UUID 형식이면 INVALID_USER_ID_FORMAT 예외")
+        void invalidUuidFormat_throwsInvalidUserIdFormat() {
+            request.addHeader("X-USER-ID", "not-a-uuid");
+
+            assertThatThrownBy(() -> interceptor.preHandle(request, response, new Object()))
+                    .isInstanceOf(CustomException.class)
+                    .extracting(ex -> ((CustomException) ex).getErrorCode())
+                    .isEqualTo(ErrorCode.INVALID_USER_ID_FORMAT);
+        }
+
+        @Test
+        @DisplayName("X-USER-ID 헤더가 아예 누락되면 USER_ID_HEADER_MISSING 예외")
+        void missingAllHeaders_throwsUserIdHeaderMissing() {
+            assertThatThrownBy(() -> interceptor.preHandle(request, response, new Object()))
+                    .isInstanceOf(CustomException.class)
+                    .extracting(ex -> ((CustomException) ex).getErrorCode())
+                    .isEqualTo(ErrorCode.USER_ID_HEADER_MISSING);
+        }
+
+        @Test
+        @DisplayName("X-USER-ID 는 비어있고 X-USER-EMAIL 만 있는 경우에도 USER_ID_HEADER_MISSING")
+        void onlyEmailHeader_throwsUserIdHeaderMissing() {
+            request.addHeader("X-USER-EMAIL", "user@example.com");
+
+            assertThatThrownBy(() -> interceptor.preHandle(request, response, new Object()))
+                    .isInstanceOf(CustomException.class)
+                    .extracting(ex -> ((CustomException) ex).getErrorCode())
+                    .isEqualTo(ErrorCode.USER_ID_HEADER_MISSING);
+        }
+    }
+
+    @Nested
+    @DisplayName("MemberRepository 미주입 슬라이스 테스트 컨텍스트")
+    class NoRepository {
+
+        @Test
+        @DisplayName("memberRepository 가 null 이면 존재 검증 없이 X-USER-ID 로만 컨텍스트 세팅")
+        void nullRepository_setsContextFromUserIdOnly() {
+            XUserIdCheckInterceptor noRepoInterceptor = new XUserIdCheckInterceptor(null);
+            UUID userId = UUID.randomUUID();
+            request.addHeader("X-USER-ID", userId.toString());
+            request.addHeader("X-USER-EMAIL", "user@example.com");
+
+            boolean result = noRepoInterceptor.preHandle(request, response, new Object());
+
+            assertThat(result).isTrue();
+            assertThat(UserContextHolder.getUserId()).isEqualTo(userId);
+            assertThat(UserContextHolder.getUserEmail()).isEqualTo("user@example.com");
+        }
+    }
+
+    @Nested
+    @DisplayName("afterCompletion")
+    class AfterCompletion {
+
+        @Test
+        @DisplayName("afterCompletion 은 UserContextHolder 를 초기화한다")
+        void afterCompletion_resetsUserContext() throws Exception {
+            UUID userId = UUID.randomUUID();
+            UserContextHolder.setUserId(userId);
+            UserContextHolder.setUserEmail("user@example.com");
+
+            interceptor.afterCompletion(request, response, new Object(), null);
+
+            assertThat(UserContextHolder.getUserId()).isNull();
+            assertThat(UserContextHolder.getUserEmail()).isNull();
+        }
+    }
+}

--- a/src/test/resources/application-dev-docs.yml
+++ b/src/test/resources/application-dev-docs.yml
@@ -1,5 +1,5 @@
 restdocs:
   uris:
     scheme: https
-    host: api.undabang.store
+    host: api.undabang.site
     port: 443

--- a/src/test/resources/application-prod-docs.yml
+++ b/src/test/resources/application-prod-docs.yml
@@ -1,5 +1,5 @@
 restdocs:
   uris:
     scheme: https
-    host: api.undabang.store
+    host: api.undabang.site
     port: 443

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -73,7 +73,7 @@ cors:
 restdocs:
   uris:
     scheme: https
-    host: api.undabang.store
+    host: api.undabang.site
     port: 443
 
 batch:


### PR DESCRIPTION
1. 새 AWS 계정 이관에 따른 ECR 및 도메인 설정 업데이트 (undabang.store → undabang.site)
2. Cognito 사용자 풀 이전 대비 email 기반 회원 조회 지원
3. @WebMvcTest 컨텍스트에서 MemberRepository 미주입 시 컨텍스트 로딩 실패 수정