### PR TITLE
Releases: 인증 인터셉터 soft-delete 차단 및 존재 검증 캐시

### DIFF
--- a/src/main/java/com/project200/undabang/common/web/interceptor/XUserIdCheckInterceptor.java
+++ b/src/main/java/com/project200/undabang/common/web/interceptor/XUserIdCheckInterceptor.java
@@ -32,8 +32,10 @@ import java.util.UUID;
  * X-USER-ID / X-USER-EMAIL 은 API Gateway Cognito Authorizer 가 검증된 JWT 클레임에서 주입/덮어쓰는 것으로 신뢰된다.
  * 요청 처리가 완료된 후에는 사용자 컨텍스트를 자동으로 초기화한다.
  * <p>
- * 존재 검증은 positive 캐시({@link Caffeine}, TTL 5 분)를 통해 요청당 DB 조회 부담을 완화한다.
+ * 존재 검증은 positive 캐시({@link Caffeine}, TTL 1 분)를 통해 요청당 DB 조회 부담을 완화한다.
  * 존재하지 않는 결과(false) 는 캐시하지 않아 가입/복구 직후 즉시 반영된다.
+ * soft-delete 시 TTL 만료 전까지 stale positive 가 남을 수 있으므로, 탈퇴 플로우는
+ * {@link #evictMemberExistence(UUID)} 를 호출해 즉시 무효화해야 한다.
  */
 @Slf4j
 public class XUserIdCheckInterceptor implements HandlerInterceptor {
@@ -65,7 +67,7 @@ public class XUserIdCheckInterceptor implements HandlerInterceptor {
     public XUserIdCheckInterceptor(@Nullable MemberRepository memberRepository) {
         this.memberRepository = memberRepository;
         this.memberExistenceCache = Caffeine.newBuilder()
-                .expireAfterWrite(Duration.ofMinutes(5))
+                .expireAfterWrite(Duration.ofMinutes(1))
                 .maximumSize(10_000)
                 .build();
     }
@@ -149,6 +151,14 @@ public class XUserIdCheckInterceptor implements HandlerInterceptor {
             memberExistenceCache.put(userId, Boolean.TRUE);
         }
         return exists;
+    }
+
+    /**
+     * 회원 탈퇴/복구 등으로 존재 상태가 바뀐 순간 stale positive 캐시를 즉시 무효화한다.
+     * 해당 커맨드 서비스에서 이 메서드를 직접 호출해 TTL 만료를 기다리지 않고 인증을 차단/허용하도록 한다.
+     */
+    public void evictMemberExistence(UUID userId) {
+        memberExistenceCache.invalidate(userId);
     }
 
     private static void setContext(UUID userId, String userEmail) {

--- a/src/main/java/com/project200/undabang/common/web/interceptor/XUserIdCheckInterceptor.java
+++ b/src/main/java/com/project200/undabang/common/web/interceptor/XUserIdCheckInterceptor.java
@@ -32,10 +32,11 @@ import java.util.UUID;
  * X-USER-ID / X-USER-EMAIL 은 API Gateway Cognito Authorizer 가 검증된 JWT 클레임에서 주입/덮어쓰는 것으로 신뢰된다.
  * 요청 처리가 완료된 후에는 사용자 컨텍스트를 자동으로 초기화한다.
  * <p>
- * 존재 검증은 positive 캐시({@link Caffeine}, TTL 1 분)를 통해 요청당 DB 조회 부담을 완화한다.
- * 존재하지 않는 결과(false) 는 캐시하지 않아 가입/복구 직후 즉시 반영된다.
- * soft-delete 시 TTL 만료 전까지 stale positive 가 남을 수 있으므로, 탈퇴 플로우는
- * {@link #evictMemberExistence(UUID)} 를 호출해 즉시 무효화해야 한다.
+ * <b>해석 캐시</b>: 요청 헤더의 X-USER-ID(incomingSub) → 최종 사용할 member_id 매핑을 Caffeine 에 positive 캐시(TTL 1 분).
+ * 직접 일치 케이스는 identity 매핑(incomingSub==memberId)이 저장되고, Cognito 이전 fallback 케이스에서는
+ * incomingSub → 실제 member_id 매핑이 저장되어 다음 요청부터는 email 재조회 없이 통과한다.
+ * 해석 실패(false) 는 캐시하지 않아 가입 직후 즉시 반영된다. soft-delete / 복구 플로우는
+ * {@link #evictResolvedMemberId(UUID)} 를 호출해 TTL 만료를 기다리지 않고 stale 매핑을 제거해야 한다.
  */
 @Slf4j
 public class XUserIdCheckInterceptor implements HandlerInterceptor {
@@ -61,12 +62,12 @@ public class XUserIdCheckInterceptor implements HandlerInterceptor {
     @Nullable
     private final MemberRepository memberRepository;
 
-    /** sub UUID 단위 positive 존재 캐시 (soft-delete 되지 않은 회원만 true 로 저장) */
-    private final Cache<UUID, Boolean> memberExistenceCache;
+    /** incomingSub(JWT sub) → 실제 member_id 해석 결과를 positive 캐시. miss/실패는 저장하지 않는다. */
+    private final Cache<UUID, UUID> resolvedMemberIdCache;
 
     public XUserIdCheckInterceptor(@Nullable MemberRepository memberRepository) {
         this.memberRepository = memberRepository;
-        this.memberExistenceCache = Caffeine.newBuilder()
+        this.resolvedMemberIdCache = Caffeine.newBuilder()
                 .expireAfterWrite(Duration.ofMinutes(1))
                 .maximumSize(10_000)
                 .build();
@@ -86,37 +87,18 @@ public class XUserIdCheckInterceptor implements HandlerInterceptor {
         String userEmail = request.getHeader(USER_EMAIL_HEADER);
         String userIdString = request.getHeader(USER_ID_HEADER);
 
-        UUID parsedUserId = null;
-        if (userIdString != null && !userIdString.isEmpty()) {
-            try {
-                parsedUserId = UUID.fromString(userIdString);
-            } catch (IllegalArgumentException e) {
-                log.error("X-USER-ID header가 유효하지 않은 UUID 형식입니다: {}", userIdString, e);
-                throw new CustomException(ErrorCode.INVALID_USER_ID_FORMAT);
-            }
-        }
+        UUID parsedUserId = parseUserIdOrThrow(userIdString);
 
-        // 우선순위 1: X-USER-ID(sub) 가 회원 ID 와 일치하면 그대로 사용 (대부분의 요청)
-        // memberRepository 가 없는 슬라이스 테스트 컨텍스트에서는 존재 검증을 생략한다.
-        if (parsedUserId != null && memberExists(parsedUserId)) {
-            setContext(parsedUserId, userEmail);
-            return true;
-        }
-
-        // 우선순위 2: X-USER-EMAIL fallback (Cognito 이전으로 sub 가 바뀐 기존 회원 대응)
-        // X-USER-ID 가 선행 존재해야만 동작시켜, email 헤더 단독 위조로 타 계정을 가장하는 것을 차단한다.
-        if (parsedUserId != null && memberRepository != null && userEmail != null && !userEmail.isEmpty()) {
-            Optional<Member> memberOpt = memberRepository.findByMemberEmailAndMemberDeletedAtNull(userEmail);
-            if (memberOpt.isPresent()) {
-                UUID memberId = memberOpt.get().getMemberId();
-                memberExistenceCache.put(memberId, Boolean.TRUE);
-                setContext(memberId, userEmail);
+        if (parsedUserId != null) {
+            UUID resolvedMemberId = resolveMemberId(parsedUserId, userEmail);
+            if (resolvedMemberId != null) {
+                setContext(resolvedMemberId, userEmail);
                 return true;
             }
         }
 
-        // 우선순위 3: 회원 가입 등 allowlist URI 에서만, X-USER-ID 로 컨텍스트 세팅 후 pass-through
         String uri = request.getRequestURI();
+        // allowlist URI 에서만, X-USER-ID 로 컨텍스트 세팅 후 pass-through (회원 가입 등 신규 사용자)
         if (parsedUserId != null && UNREGISTERED_USER_ALLOWED_URIS.contains(uri)) {
             log.debug("신규 사용자 pass-through: userId={}, email={}, uri={}",
                     parsedUserId, maskEmail(userEmail), uri);
@@ -134,31 +116,63 @@ public class XUserIdCheckInterceptor implements HandlerInterceptor {
         throw new CustomException(ErrorCode.AUTHENTICATION_FAILED);
     }
 
-    /**
-     * soft-delete 되지 않은 회원인지 확인한다. Positive 캐시로 반복 조회 부담을 줄이되, false 는 캐시하지 않아
-     * 가입 직후 다음 요청에서 즉시 반영되도록 한다. 슬라이스 테스트 컨텍스트(memberRepository=null) 에서는 true 로 간주.
-     */
-    private boolean memberExists(UUID userId) {
-        if (memberRepository == null) {
-            return true;
+    private UUID parseUserIdOrThrow(String userIdString) {
+        if (userIdString == null || userIdString.isEmpty()) {
+            return null;
         }
-        Boolean cached = memberExistenceCache.getIfPresent(userId);
-        if (cached != null) {
-            return cached;
+        try {
+            return UUID.fromString(userIdString);
+        } catch (IllegalArgumentException e) {
+            log.error("X-USER-ID header가 유효하지 않은 UUID 형식입니다: {}", userIdString, e);
+            throw new CustomException(ErrorCode.INVALID_USER_ID_FORMAT);
         }
-        boolean exists = memberRepository.existsByMemberIdAndMemberDeletedAtNull(userId);
-        if (exists) {
-            memberExistenceCache.put(userId, Boolean.TRUE);
-        }
-        return exists;
     }
 
     /**
-     * 회원 탈퇴/복구 등으로 존재 상태가 바뀐 순간 stale positive 캐시를 즉시 무효화한다.
-     * 해당 커맨드 서비스에서 이 메서드를 직접 호출해 TTL 만료를 기다리지 않고 인증을 차단/허용하도록 한다.
+     * incomingSub(JWT sub) 를 실제 사용할 member_id 로 해석한다. 반환값이 null 이면 사용자를 특정할 수 없는 상태.
+     * <ol>
+     *   <li>해석 캐시 적중 시 DB 조회 없이 바로 반환 (직접 일치 / fallback 양쪽 모두 커버)</li>
+     *   <li>sub 가 soft-delete 되지 않은 member_id 와 일치하면 identity 매핑 캐시 후 반환</li>
+     *   <li>sub 가 DB 에 없고 X-USER-EMAIL 이 있으면 email 로 조회 (Cognito 이전 fallback).
+     *       성공 시 incomingSub → 실제 member_id 매핑을 캐시 후 반환</li>
+     * </ol>
+     * 슬라이스 테스트 컨텍스트(memberRepository=null) 에서는 DB 조회 없이 incomingSub 를 identity 매핑으로 반환.
      */
-    public void evictMemberExistence(UUID userId) {
-        memberExistenceCache.invalidate(userId);
+    @Nullable
+    private UUID resolveMemberId(UUID incomingSub, @Nullable String userEmail) {
+        if (memberRepository == null) {
+            return incomingSub;
+        }
+
+        UUID cached = resolvedMemberIdCache.getIfPresent(incomingSub);
+        if (cached != null) {
+            return cached;
+        }
+
+        if (memberRepository.existsByMemberIdAndMemberDeletedAtNull(incomingSub)) {
+            resolvedMemberIdCache.put(incomingSub, incomingSub);
+            return incomingSub;
+        }
+
+        if (userEmail != null && !userEmail.isEmpty()) {
+            Optional<Member> memberOpt = memberRepository.findByMemberEmailAndMemberDeletedAtNull(userEmail);
+            if (memberOpt.isPresent()) {
+                UUID actualMemberId = memberOpt.get().getMemberId();
+                resolvedMemberIdCache.put(incomingSub, actualMemberId);
+                return actualMemberId;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * 회원 탈퇴/복구 등으로 해석 결과가 바뀐 순간 stale 매핑을 즉시 무효화한다.
+     * 해당 커맨드 서비스에서 이 메서드를 직접 호출해 TTL(1분) 만료를 기다리지 않도록 한다.
+     * 현재 코드베이스에는 회원 탈퇴 플로우가 없으므로 호출 지점이 없지만, 추후 구현 시 함께 연결하기 위한 훅.
+     */
+    public void evictResolvedMemberId(UUID incomingSub) {
+        resolvedMemberIdCache.invalidate(incomingSub);
     }
 
     private static void setContext(UUID userId, String userEmail) {

--- a/src/main/java/com/project200/undabang/common/web/interceptor/XUserIdCheckInterceptor.java
+++ b/src/main/java/com/project200/undabang/common/web/interceptor/XUserIdCheckInterceptor.java
@@ -1,5 +1,7 @@
 package com.project200.undabang.common.web.interceptor;
 
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
 import com.project200.undabang.common.context.UserContextHolder;
 import com.project200.undabang.common.web.exception.CustomException;
 import com.project200.undabang.common.web.exception.ErrorCode;
@@ -7,11 +9,11 @@ import com.project200.undabang.member.entity.Member;
 import com.project200.undabang.member.repository.MemberRepository;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
-import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.lang.Nullable;
 import org.springframework.web.servlet.HandlerInterceptor;
 
+import java.time.Duration;
 import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
@@ -21,7 +23,7 @@ import java.util.UUID;
  * <p>
  * 우선순위:
  * <ol>
- *   <li>X-USER-ID(sub) 가 유효한 UUID 이고 해당 회원이 DB 에 존재 → 그대로 컨텍스트에 설정 (대부분의 요청 경로)</li>
+ *   <li>X-USER-ID(sub) 가 유효한 UUID 이고 해당 회원이 DB 에 존재(soft-delete 되지 않음) → 그대로 컨텍스트에 설정 (대부분의 요청 경로)</li>
  *   <li>X-USER-ID 는 있으나 DB 에 없고 X-USER-EMAIL 로 회원을 찾으면 그 회원의 member_id 로 설정 (Cognito 이전 fallback).
  *       이 fallback 은 반드시 X-USER-ID 가 선행되어야 동작하므로, email 헤더만 단독으로 위조해 가장하는 경로는 차단된다.</li>
  *   <li>{@link #UNREGISTERED_USER_ALLOWED_URIS} 에 등록된 URI (e.g. /auth/v1/sign-up) 에서는 DB/email 모두 찾지 못해도
@@ -29,10 +31,11 @@ import java.util.UUID;
  * </ol>
  * X-USER-ID / X-USER-EMAIL 은 API Gateway Cognito Authorizer 가 검증된 JWT 클레임에서 주입/덮어쓰는 것으로 신뢰된다.
  * 요청 처리가 완료된 후에는 사용자 컨텍스트를 자동으로 초기화한다.
+ * <p>
+ * 존재 검증은 positive 캐시({@link Caffeine}, TTL 5 분)를 통해 요청당 DB 조회 부담을 완화한다.
+ * 존재하지 않는 결과(false) 는 캐시하지 않아 가입/복구 직후 즉시 반영된다.
  */
-
 @Slf4j
-@RequiredArgsConstructor
 public class XUserIdCheckInterceptor implements HandlerInterceptor {
 
     /** X-USER-ID 헤더 상수 */
@@ -55,6 +58,17 @@ public class XUserIdCheckInterceptor implements HandlerInterceptor {
      */
     @Nullable
     private final MemberRepository memberRepository;
+
+    /** sub UUID 단위 positive 존재 캐시 (soft-delete 되지 않은 회원만 true 로 저장) */
+    private final Cache<UUID, Boolean> memberExistenceCache;
+
+    public XUserIdCheckInterceptor(@Nullable MemberRepository memberRepository) {
+        this.memberRepository = memberRepository;
+        this.memberExistenceCache = Caffeine.newBuilder()
+                .expireAfterWrite(Duration.ofMinutes(5))
+                .maximumSize(10_000)
+                .build();
+    }
 
     /**
      * HTTP 요청이 처리되기 전에 X-USER-ID / X-USER-EMAIL 헤더를 검증하고 사용자 컨텍스트를 설정합니다.
@@ -82,7 +96,7 @@ public class XUserIdCheckInterceptor implements HandlerInterceptor {
 
         // 우선순위 1: X-USER-ID(sub) 가 회원 ID 와 일치하면 그대로 사용 (대부분의 요청)
         // memberRepository 가 없는 슬라이스 테스트 컨텍스트에서는 존재 검증을 생략한다.
-        if (parsedUserId != null && (memberRepository == null || memberRepository.existsById(parsedUserId))) {
+        if (parsedUserId != null && memberExists(parsedUserId)) {
             setContext(parsedUserId, userEmail);
             return true;
         }
@@ -92,7 +106,9 @@ public class XUserIdCheckInterceptor implements HandlerInterceptor {
         if (parsedUserId != null && memberRepository != null && userEmail != null && !userEmail.isEmpty()) {
             Optional<Member> memberOpt = memberRepository.findByMemberEmailAndMemberDeletedAtNull(userEmail);
             if (memberOpt.isPresent()) {
-                setContext(memberOpt.get().getMemberId(), userEmail);
+                UUID memberId = memberOpt.get().getMemberId();
+                memberExistenceCache.put(memberId, Boolean.TRUE);
+                setContext(memberId, userEmail);
                 return true;
             }
         }
@@ -114,6 +130,25 @@ public class XUserIdCheckInterceptor implements HandlerInterceptor {
         log.error("X-USER-ID / X-USER-EMAIL 로 회원을 특정하지 못했습니다: userId={}, email={}, uri={}",
                 parsedUserId, maskEmail(userEmail), uri);
         throw new CustomException(ErrorCode.AUTHENTICATION_FAILED);
+    }
+
+    /**
+     * soft-delete 되지 않은 회원인지 확인한다. Positive 캐시로 반복 조회 부담을 줄이되, false 는 캐시하지 않아
+     * 가입 직후 다음 요청에서 즉시 반영되도록 한다. 슬라이스 테스트 컨텍스트(memberRepository=null) 에서는 true 로 간주.
+     */
+    private boolean memberExists(UUID userId) {
+        if (memberRepository == null) {
+            return true;
+        }
+        Boolean cached = memberExistenceCache.getIfPresent(userId);
+        if (cached != null) {
+            return cached;
+        }
+        boolean exists = memberRepository.existsByMemberIdAndMemberDeletedAtNull(userId);
+        if (exists) {
+            memberExistenceCache.put(userId, Boolean.TRUE);
+        }
+        return exists;
     }
 
     private static void setContext(UUID userId, String userEmail) {

--- a/src/main/java/com/project200/undabang/member/repository/MemberRepository.java
+++ b/src/main/java/com/project200/undabang/member/repository/MemberRepository.java
@@ -15,6 +15,8 @@ public interface MemberRepository extends JpaRepository<Member, UUID>, MemberRep
 
     boolean existsByMemberId(UUID memberId);
 
+    boolean existsByMemberIdAndMemberDeletedAtNull(UUID memberId);
+
     Optional<Member> findByMemberIdAndMemberDeletedAtNull(UUID memberId);
 
     Optional<Member> findByMemberEmailAndMemberDeletedAtNull(String memberEmail);

--- a/src/test/java/com/project200/undabang/common/web/interceptor/XUserIdCheckInterceptorTest.java
+++ b/src/test/java/com/project200/undabang/common/web/interceptor/XUserIdCheckInterceptorTest.java
@@ -279,6 +279,39 @@ class XUserIdCheckInterceptorTest {
 
             verify(memberRepository, times(2)).existsByMemberIdAndMemberDeletedAtNull(userId);
         }
+
+        @Test
+        @DisplayName("evictMemberExistence 호출 후에는 다음 요청에서 DB 재조회가 발생한다 (탈퇴 즉시 반영)")
+        void evictMemberExistence_forcesFreshLookup() {
+            UUID userId = UUID.randomUUID();
+            given(memberRepository.existsByMemberIdAndMemberDeletedAtNull(userId)).willReturn(true, false);
+
+            // 1번째: 정상 통과, 캐시에 true 저장
+            MockHttpServletRequest req1 = new MockHttpServletRequest();
+            req1.addHeader("X-USER-ID", userId.toString());
+            assertThat(interceptor.preHandle(req1, response, new Object())).isTrue();
+            UserContextHolder.reset();
+
+            // 2번째: 캐시 hit - DB 재조회 없음
+            MockHttpServletRequest req2 = new MockHttpServletRequest();
+            req2.addHeader("X-USER-ID", userId.toString());
+            assertThat(interceptor.preHandle(req2, response, new Object())).isTrue();
+            UserContextHolder.reset();
+            verify(memberRepository, times(1)).existsByMemberIdAndMemberDeletedAtNull(userId);
+
+            // 탈퇴 이벤트 발생: 캐시 무효화
+            interceptor.evictMemberExistence(userId);
+
+            // 3번째: DB 재조회 → 탈퇴 상태 반영되어 차단
+            MockHttpServletRequest req3 = new MockHttpServletRequest();
+            req3.addHeader("X-USER-ID", userId.toString());
+            req3.setRequestURI("/api/members/me");
+            assertThatThrownBy(() -> interceptor.preHandle(req3, response, new Object()))
+                    .isInstanceOf(CustomException.class)
+                    .extracting(ex -> ((CustomException) ex).getErrorCode())
+                    .isEqualTo(ErrorCode.AUTHENTICATION_FAILED);
+            verify(memberRepository, times(2)).existsByMemberIdAndMemberDeletedAtNull(userId);
+        }
     }
 
     @Nested

--- a/src/test/java/com/project200/undabang/common/web/interceptor/XUserIdCheckInterceptorTest.java
+++ b/src/test/java/com/project200/undabang/common/web/interceptor/XUserIdCheckInterceptorTest.java
@@ -20,6 +20,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 
 @DisplayName("XUserIdCheckInterceptor 단위 테스트")
 class XUserIdCheckInterceptorTest {
@@ -53,7 +55,7 @@ class XUserIdCheckInterceptorTest {
             UUID userId = UUID.randomUUID();
             request.addHeader("X-USER-ID", userId.toString());
             request.addHeader("X-USER-EMAIL", "user@example.com");
-            given(memberRepository.existsById(userId)).willReturn(true);
+            given(memberRepository.existsByMemberIdAndMemberDeletedAtNull(userId)).willReturn(true);
 
             boolean result = interceptor.preHandle(request, response, new Object());
 
@@ -67,7 +69,7 @@ class XUserIdCheckInterceptorTest {
         void existingUserId_withoutEmail_setsContext() {
             UUID userId = UUID.randomUUID();
             request.addHeader("X-USER-ID", userId.toString());
-            given(memberRepository.existsById(userId)).willReturn(true);
+            given(memberRepository.existsByMemberIdAndMemberDeletedAtNull(userId)).willReturn(true);
 
             boolean result = interceptor.preHandle(request, response, new Object());
 
@@ -90,7 +92,7 @@ class XUserIdCheckInterceptorTest {
 
             request.addHeader("X-USER-ID", incomingSub.toString());
             request.addHeader("X-USER-EMAIL", "user@example.com");
-            given(memberRepository.existsById(incomingSub)).willReturn(false);
+            given(memberRepository.existsByMemberIdAndMemberDeletedAtNull(incomingSub)).willReturn(false);
             given(memberRepository.findByMemberEmailAndMemberDeletedAtNull("user@example.com"))
                     .willReturn(Optional.of(existing));
 
@@ -113,7 +115,7 @@ class XUserIdCheckInterceptorTest {
             request.addHeader("X-USER-ID", incomingSub.toString());
             request.addHeader("X-USER-EMAIL", "newuser@example.com");
             request.setRequestURI("/auth/v1/sign-up");
-            given(memberRepository.existsById(incomingSub)).willReturn(false);
+            given(memberRepository.existsByMemberIdAndMemberDeletedAtNull(incomingSub)).willReturn(false);
             given(memberRepository.findByMemberEmailAndMemberDeletedAtNull("newuser@example.com"))
                     .willReturn(Optional.empty());
 
@@ -130,7 +132,7 @@ class XUserIdCheckInterceptorTest {
             UUID incomingSub = UUID.randomUUID();
             request.addHeader("X-USER-ID", incomingSub.toString());
             request.setRequestURI("/auth/v1/sign-up");
-            given(memberRepository.existsById(incomingSub)).willReturn(false);
+            given(memberRepository.existsByMemberIdAndMemberDeletedAtNull(incomingSub)).willReturn(false);
 
             boolean result = interceptor.preHandle(request, response, new Object());
 
@@ -187,7 +189,7 @@ class XUserIdCheckInterceptorTest {
             request.addHeader("X-USER-ID", incomingSub.toString());
             request.addHeader("X-USER-EMAIL", "ghost@example.com");
             request.setRequestURI("/api/members/me");
-            given(memberRepository.existsById(incomingSub)).willReturn(false);
+            given(memberRepository.existsByMemberIdAndMemberDeletedAtNull(incomingSub)).willReturn(false);
             given(memberRepository.findByMemberEmailAndMemberDeletedAtNull("ghost@example.com"))
                     .willReturn(Optional.empty());
 
@@ -204,12 +206,78 @@ class XUserIdCheckInterceptorTest {
             UUID incomingSub = UUID.randomUUID();
             request.addHeader("X-USER-ID", incomingSub.toString());
             request.setRequestURI("/api/members/me");
-            given(memberRepository.existsById(incomingSub)).willReturn(false);
+            given(memberRepository.existsByMemberIdAndMemberDeletedAtNull(incomingSub)).willReturn(false);
 
             assertThatThrownBy(() -> interceptor.preHandle(request, response, new Object()))
                     .isInstanceOf(CustomException.class)
                     .extracting(ex -> ((CustomException) ex).getErrorCode())
                     .isEqualTo(ErrorCode.AUTHENTICATION_FAILED);
+        }
+
+        @Test
+        @DisplayName("soft-delete 된 회원(member_deleted_at NOT NULL)은 존재 검증에서 false 처리되어 통과하지 못한다")
+        void softDeletedMember_isNotConsideredExisting() {
+            UUID deletedUserId = UUID.randomUUID();
+            request.addHeader("X-USER-ID", deletedUserId.toString());
+            request.addHeader("X-USER-EMAIL", "deleted@example.com");
+            request.setRequestURI("/api/members/me");
+            // soft-delete 된 회원은 existsByMemberIdAndMemberDeletedAtNull 이 false 를 반환한다.
+            given(memberRepository.existsByMemberIdAndMemberDeletedAtNull(deletedUserId)).willReturn(false);
+            // email 조회 역시 memberDeletedAtNull 조건이라 탈퇴 회원을 찾지 못한다.
+            given(memberRepository.findByMemberEmailAndMemberDeletedAtNull("deleted@example.com"))
+                    .willReturn(Optional.empty());
+
+            assertThatThrownBy(() -> interceptor.preHandle(request, response, new Object()))
+                    .isInstanceOf(CustomException.class)
+                    .extracting(ex -> ((CustomException) ex).getErrorCode())
+                    .isEqualTo(ErrorCode.AUTHENTICATION_FAILED);
+            assertThat(UserContextHolder.getUserId()).isNull();
+        }
+    }
+
+    @Nested
+    @DisplayName("존재 검증 positive 캐시")
+    class ExistenceCache {
+
+        @Test
+        @DisplayName("연속된 요청에서 동일 userId 에 대한 DB 조회는 한 번만 발생한다 (positive 캐시)")
+        void existsCheck_cachedAfterFirstHit() {
+            UUID userId = UUID.randomUUID();
+            given(memberRepository.existsByMemberIdAndMemberDeletedAtNull(userId)).willReturn(true);
+
+            for (int i = 0; i < 5; i++) {
+                MockHttpServletRequest req = new MockHttpServletRequest();
+                req.addHeader("X-USER-ID", userId.toString());
+                boolean result = interceptor.preHandle(req, response, new Object());
+                assertThat(result).isTrue();
+                UserContextHolder.reset();
+            }
+
+            verify(memberRepository, times(1)).existsByMemberIdAndMemberDeletedAtNull(userId);
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 userId 는 캐시되지 않아, 이후 가입되면 즉시 반영된다")
+        void existsCheck_falseNotCached_signUpReflectedImmediately() {
+            UUID userId = UUID.randomUUID();
+            request.addHeader("X-USER-ID", userId.toString());
+            request.setRequestURI("/auth/v1/sign-up");
+            given(memberRepository.existsByMemberIdAndMemberDeletedAtNull(userId)).willReturn(false, true);
+
+            // 1번째: 가입 전 - pass-through
+            boolean first = interceptor.preHandle(request, response, new Object());
+            assertThat(first).isTrue();
+            UserContextHolder.reset();
+
+            // 2번째: 가입 직후 - true 반환이 즉시 반영되어야 함 (캐시에 false 가 남아있지 않음)
+            MockHttpServletRequest req2 = new MockHttpServletRequest();
+            req2.addHeader("X-USER-ID", userId.toString());
+            req2.setRequestURI("/api/members/me");
+            boolean second = interceptor.preHandle(req2, response, new Object());
+            assertThat(second).isTrue();
+            assertThat(UserContextHolder.getUserId()).isEqualTo(userId);
+
+            verify(memberRepository, times(2)).existsByMemberIdAndMemberDeletedAtNull(userId);
         }
     }
 

--- a/src/test/java/com/project200/undabang/common/web/interceptor/XUserIdCheckInterceptorTest.java
+++ b/src/test/java/com/project200/undabang/common/web/interceptor/XUserIdCheckInterceptorTest.java
@@ -215,15 +215,16 @@ class XUserIdCheckInterceptorTest {
         }
 
         @Test
-        @DisplayName("soft-delete 된 회원(member_deleted_at NOT NULL)은 존재 검증에서 false 처리되어 통과하지 못한다")
-        void softDeletedMember_isNotConsideredExisting() {
+        @DisplayName("soft-delete 된 회원은 existsByMemberIdAndMemberDeletedAtNull=false, email 조회도 탈퇴 필터로 empty → AUTHENTICATION_FAILED")
+        void softDeletedMember_blockedByDeletedAtNullFilters() {
+            // soft-delete 된 사용자가 탈퇴 후에도 캐시되지 않은 상태에서 요청했을 때,
+            // existsByMemberIdAndMemberDeletedAtNull 와 findByMemberEmailAndMemberDeletedAtNull 두 쿼리 모두
+            // memberDeletedAtNull 조건 덕에 탈퇴자를 제외해 인증이 차단되는지 확인한다.
             UUID deletedUserId = UUID.randomUUID();
             request.addHeader("X-USER-ID", deletedUserId.toString());
             request.addHeader("X-USER-EMAIL", "deleted@example.com");
             request.setRequestURI("/api/members/me");
-            // soft-delete 된 회원은 existsByMemberIdAndMemberDeletedAtNull 이 false 를 반환한다.
             given(memberRepository.existsByMemberIdAndMemberDeletedAtNull(deletedUserId)).willReturn(false);
-            // email 조회 역시 memberDeletedAtNull 조건이라 탈퇴 회원을 찾지 못한다.
             given(memberRepository.findByMemberEmailAndMemberDeletedAtNull("deleted@example.com"))
                     .willReturn(Optional.empty());
 
@@ -232,16 +233,19 @@ class XUserIdCheckInterceptorTest {
                     .extracting(ex -> ((CustomException) ex).getErrorCode())
                     .isEqualTo(ErrorCode.AUTHENTICATION_FAILED);
             assertThat(UserContextHolder.getUserId()).isNull();
+            // 두 쿼리 모두 soft-delete 필터를 거쳐 탈퇴자를 제외했는지 확인
+            verify(memberRepository).existsByMemberIdAndMemberDeletedAtNull(deletedUserId);
+            verify(memberRepository).findByMemberEmailAndMemberDeletedAtNull("deleted@example.com");
         }
     }
 
     @Nested
-    @DisplayName("존재 검증 positive 캐시")
-    class ExistenceCache {
+    @DisplayName("해석 결과 positive 캐시")
+    class ResolvedMemberIdCache {
 
         @Test
-        @DisplayName("연속된 요청에서 동일 userId 에 대한 DB 조회는 한 번만 발생한다 (positive 캐시)")
-        void existsCheck_cachedAfterFirstHit() {
+        @DisplayName("직접 일치 케이스: 연속된 요청에서 동일 userId 에 대한 DB 조회는 한 번만 발생한다")
+        void directMatch_cachedAfterFirstHit() {
             UUID userId = UUID.randomUUID();
             given(memberRepository.existsByMemberIdAndMemberDeletedAtNull(userId)).willReturn(true);
 
@@ -257,8 +261,34 @@ class XUserIdCheckInterceptorTest {
         }
 
         @Test
-        @DisplayName("존재하지 않는 userId 는 캐시되지 않아, 이후 가입되면 즉시 반영된다")
-        void existsCheck_falseNotCached_signUpReflectedImmediately() {
+        @DisplayName("Cognito 이전 fallback 케이스: incomingSub→resolvedMemberId 매핑이 캐시되어 다음 요청에서 email 재조회 생략")
+        void emailFallback_cachesIncomingSubToResolvedMemberId() {
+            UUID incomingSub = UUID.randomUUID();
+            UUID dbMemberId = UUID.randomUUID();
+            Member existing = Member.builder().memberId(dbMemberId).memberEmail("user@example.com").build();
+
+            given(memberRepository.existsByMemberIdAndMemberDeletedAtNull(incomingSub)).willReturn(false);
+            given(memberRepository.findByMemberEmailAndMemberDeletedAtNull("user@example.com"))
+                    .willReturn(Optional.of(existing));
+
+            for (int i = 0; i < 3; i++) {
+                MockHttpServletRequest req = new MockHttpServletRequest();
+                req.addHeader("X-USER-ID", incomingSub.toString());
+                req.addHeader("X-USER-EMAIL", "user@example.com");
+                boolean result = interceptor.preHandle(req, response, new Object());
+                assertThat(result).isTrue();
+                assertThat(UserContextHolder.getUserId()).isEqualTo(dbMemberId);
+                UserContextHolder.reset();
+            }
+
+            // 첫 요청에서 existsBy 1회 + findByEmail 1회, 이후 2회는 캐시로 둘 다 생략
+            verify(memberRepository, times(1)).existsByMemberIdAndMemberDeletedAtNull(incomingSub);
+            verify(memberRepository, times(1)).findByMemberEmailAndMemberDeletedAtNull("user@example.com");
+        }
+
+        @Test
+        @DisplayName("해석 실패는 캐시되지 않아, 이후 가입되면 즉시 반영된다")
+        void resolutionFailure_notCached_signUpReflectedImmediately() {
             UUID userId = UUID.randomUUID();
             request.addHeader("X-USER-ID", userId.toString());
             request.setRequestURI("/auth/v1/sign-up");
@@ -269,7 +299,7 @@ class XUserIdCheckInterceptorTest {
             assertThat(first).isTrue();
             UserContextHolder.reset();
 
-            // 2번째: 가입 직후 - true 반환이 즉시 반영되어야 함 (캐시에 false 가 남아있지 않음)
+            // 2번째: 가입 직후 - true 반환이 즉시 반영되어야 함
             MockHttpServletRequest req2 = new MockHttpServletRequest();
             req2.addHeader("X-USER-ID", userId.toString());
             req2.setRequestURI("/api/members/me");
@@ -281,12 +311,12 @@ class XUserIdCheckInterceptorTest {
         }
 
         @Test
-        @DisplayName("evictMemberExistence 호출 후에는 다음 요청에서 DB 재조회가 발생한다 (탈퇴 즉시 반영)")
-        void evictMemberExistence_forcesFreshLookup() {
+        @DisplayName("evictResolvedMemberId 호출 후에는 다음 요청에서 DB 재조회가 발생한다 (탈퇴 즉시 반영)")
+        void evictResolvedMemberId_forcesFreshLookup() {
             UUID userId = UUID.randomUUID();
             given(memberRepository.existsByMemberIdAndMemberDeletedAtNull(userId)).willReturn(true, false);
 
-            // 1번째: 정상 통과, 캐시에 true 저장
+            // 1번째: 정상 통과, 캐시에 identity 매핑 저장
             MockHttpServletRequest req1 = new MockHttpServletRequest();
             req1.addHeader("X-USER-ID", userId.toString());
             assertThat(interceptor.preHandle(req1, response, new Object())).isTrue();
@@ -300,7 +330,7 @@ class XUserIdCheckInterceptorTest {
             verify(memberRepository, times(1)).existsByMemberIdAndMemberDeletedAtNull(userId);
 
             // 탈퇴 이벤트 발생: 캐시 무효화
-            interceptor.evictMemberExistence(userId);
+            interceptor.evictResolvedMemberId(userId);
 
             // 3번째: DB 재조회 → 탈퇴 상태 반영되어 차단
             MockHttpServletRequest req3 = new MockHttpServletRequest();


### PR DESCRIPTION
PR #564 / #565 머지 후 누락/지적된 잔여 개선 사항을 main 에 반영합니다.

1. soft-delete 인증 우회 차단: MemberRepository.existsByMemberIdAndMemberDeletedAtNull 도입, 인터셉터에서 \`member_deleted_at != NULL\` 회원은 '존재하지 않음' 으로 처리
2. 요청당 DB 조회 부담 완화: Caffeine positive 캐시(TTL 1분, max 10k) 도입, 미존재 결과는 캐시하지 않음
3. 캐시 stale window 관리: TTL 상한 60초 + evictMemberExistence(UUID) 훅 노출 → 추후 탈퇴/복구 커맨드 서비스가 즉시 무효화 가능

dev 서버 CI 통과 및 로컬 E2E 스모크 5 케이스 (sign-up, email 단독 위조 차단, AUTHENTICATION_FAILED 분기, email fallback, soft-delete 차단) 확인 완료.

## 🔗 관련 PR
- #566 (develop 머지, 잔여 개선)
- #565 (develop 머지, sign-up 버그 픽스 + Copilot 1차 리뷰 반영)
- #564 (main 머지된 최초 AWS 이전 릴리즈, 누락분 이 PR 로 이어감)