### PR TITLE
fix(auth): 해석 캐시를 incomingSub→memberId 매핑으로 전환 (PR #567 Copilot 리뷰 반영)

### DIFF
--- a/src/main/java/com/project200/undabang/common/web/interceptor/XUserIdCheckInterceptor.java
+++ b/src/main/java/com/project200/undabang/common/web/interceptor/XUserIdCheckInterceptor.java
@@ -32,10 +32,11 @@ import java.util.UUID;
  * X-USER-ID / X-USER-EMAIL 은 API Gateway Cognito Authorizer 가 검증된 JWT 클레임에서 주입/덮어쓰는 것으로 신뢰된다.
  * 요청 처리가 완료된 후에는 사용자 컨텍스트를 자동으로 초기화한다.
  * <p>
- * 존재 검증은 positive 캐시({@link Caffeine}, TTL 1 분)를 통해 요청당 DB 조회 부담을 완화한다.
- * 존재하지 않는 결과(false) 는 캐시하지 않아 가입/복구 직후 즉시 반영된다.
- * soft-delete 시 TTL 만료 전까지 stale positive 가 남을 수 있으므로, 탈퇴 플로우는
- * {@link #evictMemberExistence(UUID)} 를 호출해 즉시 무효화해야 한다.
+ * <b>해석 캐시</b>: 요청 헤더의 X-USER-ID(incomingSub) → 최종 사용할 member_id 매핑을 Caffeine 에 positive 캐시(TTL 1 분).
+ * 직접 일치 케이스는 identity 매핑(incomingSub==memberId)이 저장되고, Cognito 이전 fallback 케이스에서는
+ * incomingSub → 실제 member_id 매핑이 저장되어 다음 요청부터는 email 재조회 없이 통과한다.
+ * 해석 실패(false) 는 캐시하지 않아 가입 직후 즉시 반영된다. soft-delete / 복구 플로우는
+ * {@link #evictResolvedMemberId(UUID)} 를 호출해 TTL 만료를 기다리지 않고 stale 매핑을 제거해야 한다.
  */
 @Slf4j
 public class XUserIdCheckInterceptor implements HandlerInterceptor {
@@ -61,12 +62,12 @@ public class XUserIdCheckInterceptor implements HandlerInterceptor {
     @Nullable
     private final MemberRepository memberRepository;
 
-    /** sub UUID 단위 positive 존재 캐시 (soft-delete 되지 않은 회원만 true 로 저장) */
-    private final Cache<UUID, Boolean> memberExistenceCache;
+    /** incomingSub(JWT sub) → 실제 member_id 해석 결과를 positive 캐시. miss/실패는 저장하지 않는다. */
+    private final Cache<UUID, UUID> resolvedMemberIdCache;
 
     public XUserIdCheckInterceptor(@Nullable MemberRepository memberRepository) {
         this.memberRepository = memberRepository;
-        this.memberExistenceCache = Caffeine.newBuilder()
+        this.resolvedMemberIdCache = Caffeine.newBuilder()
                 .expireAfterWrite(Duration.ofMinutes(1))
                 .maximumSize(10_000)
                 .build();
@@ -86,37 +87,18 @@ public class XUserIdCheckInterceptor implements HandlerInterceptor {
         String userEmail = request.getHeader(USER_EMAIL_HEADER);
         String userIdString = request.getHeader(USER_ID_HEADER);
 
-        UUID parsedUserId = null;
-        if (userIdString != null && !userIdString.isEmpty()) {
-            try {
-                parsedUserId = UUID.fromString(userIdString);
-            } catch (IllegalArgumentException e) {
-                log.error("X-USER-ID header가 유효하지 않은 UUID 형식입니다: {}", userIdString, e);
-                throw new CustomException(ErrorCode.INVALID_USER_ID_FORMAT);
-            }
-        }
+        UUID parsedUserId = parseUserIdOrThrow(userIdString);
 
-        // 우선순위 1: X-USER-ID(sub) 가 회원 ID 와 일치하면 그대로 사용 (대부분의 요청)
-        // memberRepository 가 없는 슬라이스 테스트 컨텍스트에서는 존재 검증을 생략한다.
-        if (parsedUserId != null && memberExists(parsedUserId)) {
-            setContext(parsedUserId, userEmail);
-            return true;
-        }
-
-        // 우선순위 2: X-USER-EMAIL fallback (Cognito 이전으로 sub 가 바뀐 기존 회원 대응)
-        // X-USER-ID 가 선행 존재해야만 동작시켜, email 헤더 단독 위조로 타 계정을 가장하는 것을 차단한다.
-        if (parsedUserId != null && memberRepository != null && userEmail != null && !userEmail.isEmpty()) {
-            Optional<Member> memberOpt = memberRepository.findByMemberEmailAndMemberDeletedAtNull(userEmail);
-            if (memberOpt.isPresent()) {
-                UUID memberId = memberOpt.get().getMemberId();
-                memberExistenceCache.put(memberId, Boolean.TRUE);
-                setContext(memberId, userEmail);
+        if (parsedUserId != null) {
+            UUID resolvedMemberId = resolveMemberId(parsedUserId, userEmail);
+            if (resolvedMemberId != null) {
+                setContext(resolvedMemberId, userEmail);
                 return true;
             }
         }
 
-        // 우선순위 3: 회원 가입 등 allowlist URI 에서만, X-USER-ID 로 컨텍스트 세팅 후 pass-through
         String uri = request.getRequestURI();
+        // allowlist URI 에서만, X-USER-ID 로 컨텍스트 세팅 후 pass-through (회원 가입 등 신규 사용자)
         if (parsedUserId != null && UNREGISTERED_USER_ALLOWED_URIS.contains(uri)) {
             log.debug("신규 사용자 pass-through: userId={}, email={}, uri={}",
                     parsedUserId, maskEmail(userEmail), uri);
@@ -134,31 +116,63 @@ public class XUserIdCheckInterceptor implements HandlerInterceptor {
         throw new CustomException(ErrorCode.AUTHENTICATION_FAILED);
     }
 
-    /**
-     * soft-delete 되지 않은 회원인지 확인한다. Positive 캐시로 반복 조회 부담을 줄이되, false 는 캐시하지 않아
-     * 가입 직후 다음 요청에서 즉시 반영되도록 한다. 슬라이스 테스트 컨텍스트(memberRepository=null) 에서는 true 로 간주.
-     */
-    private boolean memberExists(UUID userId) {
-        if (memberRepository == null) {
-            return true;
+    private UUID parseUserIdOrThrow(String userIdString) {
+        if (userIdString == null || userIdString.isEmpty()) {
+            return null;
         }
-        Boolean cached = memberExistenceCache.getIfPresent(userId);
-        if (cached != null) {
-            return cached;
+        try {
+            return UUID.fromString(userIdString);
+        } catch (IllegalArgumentException e) {
+            log.error("X-USER-ID header가 유효하지 않은 UUID 형식입니다: {}", userIdString, e);
+            throw new CustomException(ErrorCode.INVALID_USER_ID_FORMAT);
         }
-        boolean exists = memberRepository.existsByMemberIdAndMemberDeletedAtNull(userId);
-        if (exists) {
-            memberExistenceCache.put(userId, Boolean.TRUE);
-        }
-        return exists;
     }
 
     /**
-     * 회원 탈퇴/복구 등으로 존재 상태가 바뀐 순간 stale positive 캐시를 즉시 무효화한다.
-     * 해당 커맨드 서비스에서 이 메서드를 직접 호출해 TTL 만료를 기다리지 않고 인증을 차단/허용하도록 한다.
+     * incomingSub(JWT sub) 를 실제 사용할 member_id 로 해석한다. 반환값이 null 이면 사용자를 특정할 수 없는 상태.
+     * <ol>
+     *   <li>해석 캐시 적중 시 DB 조회 없이 바로 반환 (직접 일치 / fallback 양쪽 모두 커버)</li>
+     *   <li>sub 가 soft-delete 되지 않은 member_id 와 일치하면 identity 매핑 캐시 후 반환</li>
+     *   <li>sub 가 DB 에 없고 X-USER-EMAIL 이 있으면 email 로 조회 (Cognito 이전 fallback).
+     *       성공 시 incomingSub → 실제 member_id 매핑을 캐시 후 반환</li>
+     * </ol>
+     * 슬라이스 테스트 컨텍스트(memberRepository=null) 에서는 DB 조회 없이 incomingSub 를 identity 매핑으로 반환.
      */
-    public void evictMemberExistence(UUID userId) {
-        memberExistenceCache.invalidate(userId);
+    @Nullable
+    private UUID resolveMemberId(UUID incomingSub, @Nullable String userEmail) {
+        if (memberRepository == null) {
+            return incomingSub;
+        }
+
+        UUID cached = resolvedMemberIdCache.getIfPresent(incomingSub);
+        if (cached != null) {
+            return cached;
+        }
+
+        if (memberRepository.existsByMemberIdAndMemberDeletedAtNull(incomingSub)) {
+            resolvedMemberIdCache.put(incomingSub, incomingSub);
+            return incomingSub;
+        }
+
+        if (userEmail != null && !userEmail.isEmpty()) {
+            Optional<Member> memberOpt = memberRepository.findByMemberEmailAndMemberDeletedAtNull(userEmail);
+            if (memberOpt.isPresent()) {
+                UUID actualMemberId = memberOpt.get().getMemberId();
+                resolvedMemberIdCache.put(incomingSub, actualMemberId);
+                return actualMemberId;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * 회원 탈퇴/복구 등으로 해석 결과가 바뀐 순간 stale 매핑을 즉시 무효화한다.
+     * 해당 커맨드 서비스에서 이 메서드를 직접 호출해 TTL(1분) 만료를 기다리지 않도록 한다.
+     * 현재 코드베이스에는 회원 탈퇴 플로우가 없으므로 호출 지점이 없지만, 추후 구현 시 함께 연결하기 위한 훅.
+     */
+    public void evictResolvedMemberId(UUID incomingSub) {
+        resolvedMemberIdCache.invalidate(incomingSub);
     }
 
     private static void setContext(UUID userId, String userEmail) {

--- a/src/test/java/com/project200/undabang/common/web/interceptor/XUserIdCheckInterceptorTest.java
+++ b/src/test/java/com/project200/undabang/common/web/interceptor/XUserIdCheckInterceptorTest.java
@@ -215,15 +215,16 @@ class XUserIdCheckInterceptorTest {
         }
 
         @Test
-        @DisplayName("soft-delete 된 회원(member_deleted_at NOT NULL)은 존재 검증에서 false 처리되어 통과하지 못한다")
-        void softDeletedMember_isNotConsideredExisting() {
+        @DisplayName("soft-delete 된 회원은 existsByMemberIdAndMemberDeletedAtNull=false, email 조회도 탈퇴 필터로 empty → AUTHENTICATION_FAILED")
+        void softDeletedMember_blockedByDeletedAtNullFilters() {
+            // soft-delete 된 사용자가 탈퇴 후에도 캐시되지 않은 상태에서 요청했을 때,
+            // existsByMemberIdAndMemberDeletedAtNull 와 findByMemberEmailAndMemberDeletedAtNull 두 쿼리 모두
+            // memberDeletedAtNull 조건 덕에 탈퇴자를 제외해 인증이 차단되는지 확인한다.
             UUID deletedUserId = UUID.randomUUID();
             request.addHeader("X-USER-ID", deletedUserId.toString());
             request.addHeader("X-USER-EMAIL", "deleted@example.com");
             request.setRequestURI("/api/members/me");
-            // soft-delete 된 회원은 existsByMemberIdAndMemberDeletedAtNull 이 false 를 반환한다.
             given(memberRepository.existsByMemberIdAndMemberDeletedAtNull(deletedUserId)).willReturn(false);
-            // email 조회 역시 memberDeletedAtNull 조건이라 탈퇴 회원을 찾지 못한다.
             given(memberRepository.findByMemberEmailAndMemberDeletedAtNull("deleted@example.com"))
                     .willReturn(Optional.empty());
 
@@ -232,16 +233,19 @@ class XUserIdCheckInterceptorTest {
                     .extracting(ex -> ((CustomException) ex).getErrorCode())
                     .isEqualTo(ErrorCode.AUTHENTICATION_FAILED);
             assertThat(UserContextHolder.getUserId()).isNull();
+            // 두 쿼리 모두 soft-delete 필터를 거쳐 탈퇴자를 제외했는지 확인
+            verify(memberRepository).existsByMemberIdAndMemberDeletedAtNull(deletedUserId);
+            verify(memberRepository).findByMemberEmailAndMemberDeletedAtNull("deleted@example.com");
         }
     }
 
     @Nested
-    @DisplayName("존재 검증 positive 캐시")
-    class ExistenceCache {
+    @DisplayName("해석 결과 positive 캐시")
+    class ResolvedMemberIdCache {
 
         @Test
-        @DisplayName("연속된 요청에서 동일 userId 에 대한 DB 조회는 한 번만 발생한다 (positive 캐시)")
-        void existsCheck_cachedAfterFirstHit() {
+        @DisplayName("직접 일치 케이스: 연속된 요청에서 동일 userId 에 대한 DB 조회는 한 번만 발생한다")
+        void directMatch_cachedAfterFirstHit() {
             UUID userId = UUID.randomUUID();
             given(memberRepository.existsByMemberIdAndMemberDeletedAtNull(userId)).willReturn(true);
 
@@ -257,8 +261,34 @@ class XUserIdCheckInterceptorTest {
         }
 
         @Test
-        @DisplayName("존재하지 않는 userId 는 캐시되지 않아, 이후 가입되면 즉시 반영된다")
-        void existsCheck_falseNotCached_signUpReflectedImmediately() {
+        @DisplayName("Cognito 이전 fallback 케이스: incomingSub→resolvedMemberId 매핑이 캐시되어 다음 요청에서 email 재조회 생략")
+        void emailFallback_cachesIncomingSubToResolvedMemberId() {
+            UUID incomingSub = UUID.randomUUID();
+            UUID dbMemberId = UUID.randomUUID();
+            Member existing = Member.builder().memberId(dbMemberId).memberEmail("user@example.com").build();
+
+            given(memberRepository.existsByMemberIdAndMemberDeletedAtNull(incomingSub)).willReturn(false);
+            given(memberRepository.findByMemberEmailAndMemberDeletedAtNull("user@example.com"))
+                    .willReturn(Optional.of(existing));
+
+            for (int i = 0; i < 3; i++) {
+                MockHttpServletRequest req = new MockHttpServletRequest();
+                req.addHeader("X-USER-ID", incomingSub.toString());
+                req.addHeader("X-USER-EMAIL", "user@example.com");
+                boolean result = interceptor.preHandle(req, response, new Object());
+                assertThat(result).isTrue();
+                assertThat(UserContextHolder.getUserId()).isEqualTo(dbMemberId);
+                UserContextHolder.reset();
+            }
+
+            // 첫 요청에서 existsBy 1회 + findByEmail 1회, 이후 2회는 캐시로 둘 다 생략
+            verify(memberRepository, times(1)).existsByMemberIdAndMemberDeletedAtNull(incomingSub);
+            verify(memberRepository, times(1)).findByMemberEmailAndMemberDeletedAtNull("user@example.com");
+        }
+
+        @Test
+        @DisplayName("해석 실패는 캐시되지 않아, 이후 가입되면 즉시 반영된다")
+        void resolutionFailure_notCached_signUpReflectedImmediately() {
             UUID userId = UUID.randomUUID();
             request.addHeader("X-USER-ID", userId.toString());
             request.setRequestURI("/auth/v1/sign-up");
@@ -269,7 +299,7 @@ class XUserIdCheckInterceptorTest {
             assertThat(first).isTrue();
             UserContextHolder.reset();
 
-            // 2번째: 가입 직후 - true 반환이 즉시 반영되어야 함 (캐시에 false 가 남아있지 않음)
+            // 2번째: 가입 직후 - true 반환이 즉시 반영되어야 함
             MockHttpServletRequest req2 = new MockHttpServletRequest();
             req2.addHeader("X-USER-ID", userId.toString());
             req2.setRequestURI("/api/members/me");
@@ -281,12 +311,12 @@ class XUserIdCheckInterceptorTest {
         }
 
         @Test
-        @DisplayName("evictMemberExistence 호출 후에는 다음 요청에서 DB 재조회가 발생한다 (탈퇴 즉시 반영)")
-        void evictMemberExistence_forcesFreshLookup() {
+        @DisplayName("evictResolvedMemberId 호출 후에는 다음 요청에서 DB 재조회가 발생한다 (탈퇴 즉시 반영)")
+        void evictResolvedMemberId_forcesFreshLookup() {
             UUID userId = UUID.randomUUID();
             given(memberRepository.existsByMemberIdAndMemberDeletedAtNull(userId)).willReturn(true, false);
 
-            // 1번째: 정상 통과, 캐시에 true 저장
+            // 1번째: 정상 통과, 캐시에 identity 매핑 저장
             MockHttpServletRequest req1 = new MockHttpServletRequest();
             req1.addHeader("X-USER-ID", userId.toString());
             assertThat(interceptor.preHandle(req1, response, new Object())).isTrue();
@@ -300,7 +330,7 @@ class XUserIdCheckInterceptorTest {
             verify(memberRepository, times(1)).existsByMemberIdAndMemberDeletedAtNull(userId);
 
             // 탈퇴 이벤트 발생: 캐시 무효화
-            interceptor.evictMemberExistence(userId);
+            interceptor.evictResolvedMemberId(userId);
 
             // 3번째: DB 재조회 → 탈퇴 상태 반영되어 차단
             MockHttpServletRequest req3 = new MockHttpServletRequest();


### PR DESCRIPTION
PR #567 에 달린 Copilot 리뷰 3건 반영.

## 반영

### 1. Fallback 캐시가 실제로는 이점이 없던 문제 (가장 중요)
기존 \`Cache<UUID, Boolean>\` 은 DB 의 \`memberId\` 기준이라, Cognito 이전 fallback 에서 \`dbMemberId\` 를 캐시해도 **다음 요청도 여전히 \`incomingSub\`(바뀌기 전 sub) 로 들어와** 캐시가 miss 납니다. 결과적으로 이전 사용자 매 요청마다 \`existsBy + findByEmail\` 2쿼리가 발생하고 있었습니다.

**수정**: \`Cache<UUID, UUID>\` 로 전환해 \`incomingSub → 실제 member_id\` 매핑을 저장.
- 직접 일치: identity 매핑 (incomingSub == memberId)
- Fallback: incomingSub → DB memberId 매핑 → 다음 요청부터 email 조회 생략

### 2. 중복 테스트 정리
\`softDeletedMember_isNotConsideredExisting\` 과 \`nonSignUpUri_unknownUserIdAndEmail\` 이 mock 구성상 같은 코드 경로를 탔던 것 반영. 전자에 \`verify\` 를 추가해 '두 쿼리 모두 deletedAtNull 필터 경유' 라는 고유 검증 포인트를 둠 (soft-delete 필터 동작 자체가 검증 대상).

### 3. Stale window + 호출 지점 부재 (의도적 tradeoff)
\`evictMemberExistence\` → \`evictResolvedMemberId\` 로 이름 변경하고, Javadoc 에 현재 호출 지점 없음을 명시. 탈퇴 플로우가 이 코드베이스에 아직 없어 **호출자는 미래 추가 시 함께 연결** 해야 한다는 의도적 YAGNI 훅. TTL 1분 상한은 Cognito JWT 유효기간(보통 1시간) 보다 훨씬 짧아 실질 보안 영향은 제한적.

Copilot suggestion 은 캐시 자체를 무력화(매 요청 DB 재조회)하는 내용이라 그대로 적용하지 않았습니다. 지적의 본질(탈퇴 즉시 반영 요구) 은 eviction 훅과 짧은 TTL 조합으로 대응 가능.

## 테스트
- 단위 테스트 15 케이스 전부 통과 (fallback 캐시 적중, identity 매핑 캐시, soft-delete 이중 필터, evict 후 즉시 반영 등)

## 연관 PR
- #567 (develop → main) - 이 PR 머지 후 자동 반영