### PR TITLE
fix: Metaspace OOM 방지 #569

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,14 @@
+# Copilot PR Review Instructions
+
+리뷰 코멘트, 요약, 제안은 **한국어**로 작성해 주세요. 코드 식별자·API 이름·에러 메시지 등 고유명사는 원문 그대로 유지.
+
+## 프로젝트 컨텍스트
+- Spring Boot 3.4 / Java 21 / JPA · Hibernate 6 / QueryDSL / Hibernate Spatial (JTS + geolatte)
+- MySQL, AWS (S3 / Cognito / CodeDeploy / ECR), Firebase Admin SDK
+- 배포: ECR 이미지 + CodeDeploy, dev/prod 각 EC2 단일 인스턴스 (t3.micro 공용)
+- solo dev 저장소 — PR 본문·커밋 메시지는 한국어 개조식
+
+## 리뷰 시 고려
+- 메모리 / 성능 지적은 **실제 RSS 관측값** 기반인지, 이론 최악치인지 구분해 주세요
+- 옵션 제안 시 `docker-compose.yml` memory limit 과 Dockerfile CMD 의 JVM 옵션 관계를 함께 검토
+- 한 줄 제안보다 trade-off 가 있으면 옵션 2~3개를 비교해 제시

--- a/deploy-dev/Dockerfile
+++ b/deploy-dev/Dockerfile
@@ -4,4 +4,4 @@ ENV TZ=Asia/Seoul
 
 COPY undabang-*-SNAPSHOT.jar server.jar
 
-CMD ["java", "-Xms200m", "-Xmx200m", "-XX:MaxMetaspaceSize=128m", "-jar", "-Dspring.profiles.active=dev", "server.jar"]
+CMD ["java", "-Xms200m", "-Xmx200m", "-XX:MaxMetaspaceSize=256m", "-jar", "-Dspring.profiles.active=dev", "server.jar"]

--- a/deploy-prod/Dockerfile
+++ b/deploy-prod/Dockerfile
@@ -4,4 +4,4 @@ ENV TZ=Asia/Seoul
 
 COPY undabang-*-SNAPSHOT.jar server.jar
 
-CMD ["java", "-Xms250m", "-Xmx250m", "-XX:MaxMetaspaceSize=150m", "-jar", "-Dspring.profiles.active=prod", "server.jar"]
+CMD ["java", "-Xms250m", "-Xmx250m", "-XX:MaxMetaspaceSize=256m", "-jar", "-Dspring.profiles.active=prod", "server.jar"]

--- a/deploy-prod/docker-compose.yml
+++ b/deploy-prod/docker-compose.yml
@@ -14,9 +14,7 @@ services:
       timeout: 5s
       retries: 5
     # 운영 서버는 스왑메모리 영역에 최대한 가지 않도록 설정
-
-    environment:
-      - JAVA_TOOL_OPTIONS=-Xms400m -Xmx500m -XX:MaxMetaspaceSize=128m
+    # JVM 메모리 옵션은 Dockerfile CMD 에 일원화 (중복 정의 제거)
 
     deploy:
       resources:

--- a/src/main/java/com/project200/undabang/member/dto/request/CreateExerciseLocationRequest.java
+++ b/src/main/java/com/project200/undabang/member/dto/request/CreateExerciseLocationRequest.java
@@ -18,6 +18,14 @@ import java.time.LocalDateTime;
 @NoArgsConstructor
 @AllArgsConstructor
 public class CreateExerciseLocationRequest {
+    /**
+     * SRID 4326 (WGS84) 전용 GeometryFactory. 매 호출마다 생성하면 Hibernate Spatial 이
+     * 좌표계를 반복 파싱하면서 geolatte CRS 객체 + ANTLR 파서 state 가 Metaspace 에 누적됨.
+     * JTS GeometryFactory 는 thread-safe 이므로 정적 공유 안전.
+     */
+    private static final GeometryFactory GEOMETRY_FACTORY =
+            new GeometryFactory(new PrecisionModel(), 4326);
+
     @NotNull
     @Size(min = 1, max = 100, message = "운동 장소명은 최대 100글자 입력 가능합니다.")
     private String name;
@@ -36,9 +44,7 @@ public class CreateExerciseLocationRequest {
      * 주어진 회원 정보를 기반으로 ExerciseLocation 엔티티를 생성합니다.
      */
     public ExerciseLocation toEntity(Member member) {
-        GeometryFactory geometryFactory = new GeometryFactory(new PrecisionModel(), 4326);
-
-        Point point = geometryFactory.createPoint(new Coordinate(this.longitude, this.latitude));
+        Point point = GEOMETRY_FACTORY.createPoint(new Coordinate(this.longitude, this.latitude));
 
         return ExerciseLocation.builder()
                 .member(member)


### PR DESCRIPTION
## 📝작업 내용

### MaxMetaspaceSize 상향 (dev 128m -> 256m, prod 150m -> 256m)
- Spring Boot 3.4 + JPA + Hibernate-Spatial + QueryDSL + AWS SDK + Firebase 조합으로 스타트업만으로 Non-class Metaspace 98 MB 소비. 기존 128m 는 여유 15 MB 에 불과, OOM 직전에서 기동되는 상태
- dev 컨테이너 재시작 직후 snapshot: `113/128 MB` (88%)
- prod 도 동일 리스크라 선제 상향

### `CreateExerciseLocationRequest` GeometryFactory 정적화
- 기존: `toEntity()` 매 호출마다 `new GeometryFactory(new PrecisionModel(), 4326)`
- Hibernate Spatial 이 Point -> geolatte 변환 시 CRS(SRID 4326) 재파싱 유발
- heap histogram 증거: `PrimeMeridian` `Ellipsoid` 각 5,981 중복, `CrsId` 52,649
- JTS `GeometryFactory` 는 thread-safe 라 static final 공유 안전

### 스크린샷 (선택)

## #️⃣연관된 이슈
#569