### PR TITLE
feat(auth): 로그인 응답에 memberId 반환

### DIFF
--- a/src/main/java/com/project200/undabang/auth/controller/AuthController.java
+++ b/src/main/java/com/project200/undabang/auth/controller/AuthController.java
@@ -1,6 +1,7 @@
 package com.project200.undabang.auth.controller;
 
 import com.project200.undabang.auth.dto.request.LoginRequestDto;
+import com.project200.undabang.auth.dto.response.LoginResponseDto;
 import com.project200.undabang.auth.service.AuthService;
 import com.project200.undabang.common.web.exception.CustomException;
 import com.project200.undabang.common.web.exception.ErrorCode;
@@ -26,7 +27,7 @@ public class AuthController {
 
     @ResponseStatus(HttpStatus.OK)
     @PostMapping("/login")
-    public CommonResponse<Void> loginMember(@RequestHeader(value = "User-Agent", required = false) String userAgent,
+    public CommonResponse<LoginResponseDto> loginMember(@RequestHeader(value = "User-Agent", required = false) String userAgent,
                                             @RequestHeader(value = "X-Fcm-Token", required = false) String fcmToken,
                                             @Valid @RequestBody(required = false) LoginRequestDto requestDto) {
 
@@ -40,7 +41,7 @@ public class AuthController {
             fcmTokenCommandService.saveFcmToken(member, fcmToken, userAgent, requestDto);
         }
 
-        return CommonResponse.success(new SuccessDetails("LOGIN_SUCCESS", "로그인 성공"));
+        return CommonResponse.success(new SuccessDetails("LOGIN_SUCCESS", "로그인 성공"), LoginResponseDto.of(member));
     }
 
     @ResponseStatus(HttpStatus.OK)

--- a/src/main/java/com/project200/undabang/auth/dto/response/LoginResponseDto.java
+++ b/src/main/java/com/project200/undabang/auth/dto/response/LoginResponseDto.java
@@ -1,0 +1,22 @@
+package com.project200.undabang.auth.dto.response;
+
+import com.project200.undabang.member.entity.Member;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.UUID;
+
+@Getter@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class LoginResponseDto {
+    private UUID memberId;
+
+    public static LoginResponseDto of(Member member) {
+        return LoginResponseDto.builder()
+                .memberId(member.getMemberId())
+                .build();
+    }
+}

--- a/src/test/java/com/project200/undabang/auth/controller/AuthControllerTest.java
+++ b/src/test/java/com/project200/undabang/auth/controller/AuthControllerTest.java
@@ -64,6 +64,7 @@ class AuthControllerTest extends AbstractRestDocSupport {
                             .headers(getCommonApiHeaders(memberId))
                             .content(objectMapper.writeValueAsString(requestDto)))
                     .andExpect(MockMvcResultMatchers.status().isOk())
+                    .andExpect(MockMvcResultMatchers.jsonPath("$.data.memberId").value(memberId.toString()))
                     .andDo(document.document(
                             requestHeaders(
                                     RestDocsUtils.HEADER_ACCESS_TOKEN,
@@ -79,7 +80,9 @@ class AuthControllerTest extends AbstractRestDocSupport {
                                             .description("접속 모드를 의미합니다. APP, PWA, BROWSER 중 하나를 선택해야 합니다.")
                             ),
                             responseFields(
-                                    RestDocsUtils.commonResponseFieldsOnly()
+                                    RestDocsUtils.commonResponseFields(
+                                            fieldWithPath("data.memberId").type(JsonFieldType.STRING).description("로그인한 회원의 식별자(UUID)입니다.")
+                                    )
                             )
                     ));
 
@@ -101,7 +104,8 @@ class AuthControllerTest extends AbstractRestDocSupport {
                             .accept(MediaType.APPLICATION_JSON)
                             .headers(getCommonApiHeaders(memberId))
                             .content(objectMapper.writeValueAsString(requestDto)))
-                    .andExpect(MockMvcResultMatchers.status().isOk());
+                    .andExpect(MockMvcResultMatchers.status().isOk())
+                    .andExpect(MockMvcResultMatchers.jsonPath("$.data.memberId").value(memberId.toString()));
 
             BDDMockito.then(authService).should().login();
             // 토큰이 없으므로 saveFcmToken은 호출되지 않아야 함
@@ -120,12 +124,15 @@ class AuthControllerTest extends AbstractRestDocSupport {
                             .accept(MediaType.APPLICATION_JSON)
                             .headers(getCommonApiHeaders(memberId))) // Content 없이 요청
                     .andExpect(MockMvcResultMatchers.status().isOk())
+                    .andExpect(MockMvcResultMatchers.jsonPath("$.data.memberId").value(memberId.toString()))
                     .andDo(document.document(
                             requestHeaders(
                                     RestDocsUtils.HEADER_ACCESS_TOKEN
                             ),
                             responseFields(
-                                    RestDocsUtils.commonResponseFieldsOnly()
+                                    RestDocsUtils.commonResponseFields(
+                                            fieldWithPath("data.memberId").type(JsonFieldType.STRING).description("로그인한 회원의 식별자(UUID)입니다.")
+                                    )
                             )
                     ));
 


### PR DESCRIPTION
## 개요

POST /api/v1/login 응답 data에 로그인한 회원의 memberId(UUID)를 담습니다.

closes #571

## 변경 내용

- `LoginResponseDto` 신규 — `SignUpResponseDto`와 같은 Lombok 빌더 + `of(Member)` 팩토리 관례, 필드는 `memberId` 하나
- `AuthController.loginMember` 반환 타입을 `CommonResponse<LoginResponseDto>`로 변경 — `LOGIN_SUCCESS` 코드/메시지는 그대로 두고 data만 `null → {memberId}` 로 변경. FCM 분기·logout 경로는 불변
- `AuthControllerTest` — 성공 케이스에 `$.data.memberId` jsonPath 검증 추가, RestDocs 문서화 케이스는 `commonResponseFields(data.memberId)`로 교체. 테스트 메서드명이 그대로라 `로그인-API.adoc`의 스니펫 include는 변경 불필요

## 확인 필요

- [ ] 로컬에서 테스트 미실행 — CI에서 `AuthControllerTest` 통과 확인 필요
- [ ] 스테이징 배포 후 현행 스토어 버전 Android APK로 로그인 호환 확인 (구버전 파서가 data 객체를 견디는지 — 이 확인 전 프로덕션 배포 금지)
- [ ] 실패 시 응답 스키마는 기존과 동일(data: null)이라 별도 우회(v2/헤더)는 이번 PR 범위에서 제외
